### PR TITLE
Don't always log an error message

### DIFF
--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machine/controller.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machine/controller.go
@@ -133,7 +133,9 @@ func (c *MachineControllerImpl) Reconcile(machine *clusterv1.Machine) error {
 	// Machine resource created. Machine does not yet exist.
 	glog.Infof("Reconciling machine object %v triggers idempotent create.", m.ObjectMeta.Name)
 	err = c.create(m)
-	glog.Warningf("Unable to create machine %v: %v", name, err)
+	if err != nil {
+		glog.Warningf("unable to create machine %v: %v", name, err)
+	}
 	return err
 }
 


### PR DESCRIPTION
We were always logging an error message, even if there was no error.


```release-note
NONE
```