### PR TITLE
Be explicit that minikube <= 0.28.0 is required for now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 ### Prerequisites
 
 1. Install `kubectl` (see [here](http://kubernetes.io/docs/user-guide/prereqs/)).
-1. Install [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/).
+1. Install [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/), version <= 0.28.0 (see: [cluster-api/issues/475](https://github.com/kubernetes-sigs/cluster-api/issues/475)).
 1. Install a [driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md) for minikube. For Linux, we recommend kvm2. For MacOS, we recommend VirtualBox.
 1. Build the `clusterctl` tool
 
@@ -135,5 +135,3 @@ behalf, make sure to run these commands for each namespace that you created:
    gcloud compute firewall-rules delete $CLUSTER_NAME-allow-cluster-internal
    gcloud compute firewall-rules delete $CLUSTER_NAME-allow-api-public
    ```
-
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Current version of the minikube (0.28.2) won't work with clusterctl. There is an opened issue upstream (https://github.com/kubernetes-sigs/cluster-api/issues/475).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #38 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
```
NO
```
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
