### PR TITLE
Update getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
 ### Cluster Creation
 
-1. Create the `cluster.yaml`, `machines.yaml`, `provider-components.yaml`, and `addons.yaml` files:
+1. Create the `cluster.yaml`, `machines.yaml`, `provider-components.yaml`, and `addons.yaml` files, and create GCP serviceaccounts:
 
    ```bash
    cd cmd/clusterctl/examples/google
@@ -47,9 +47,15 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
    echo "---" >> cmd/clusterctl/examples/google/out/provider-components.yaml
    kustomize build vendor/sigs.k8s.io/cluster-api/config/default/ >> cmd/clusterctl/examples/google/out/provider-components.yaml
    ```
+
 1. Create a cluster:
 
+   Set the generated serviceaccount as a local environment variable so that the `clusterctl` process uses the same google
+   credentials as do the processes running in minikube and in the final cluster.
+
    ```bash
+   export GOOGLE_APPLICATION_CREDENTIALS=cmd/clusterctl/examples/google/out/machine-controller-serviceaccount.json
+
    ./bin/clusterctl create cluster --provider google -c cmd/clusterctl/examples/google/out/cluster.yaml -m cmd/clusterctl/examples/google/out/machines.yaml -p cmd/clusterctl/examples/google/out/provider-components.yaml -a cmd/clusterctl/examples/google/out/addons.yaml
    ```
 

--- a/cmd/clusterctl/examples/google/addons.yaml.template
+++ b/cmd/clusterctl/examples/google/addons.yaml.template
@@ -16,7 +16,7 @@ metadata:
   name: glbc
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:controller:glbc
@@ -34,7 +34,7 @@ rules:
   resources: ["ingresses/status"]
   verbs: ["update"]
 ---
-apiVersion: rbac.authorization.k8s.io/
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:controller:glbc

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -35,6 +35,7 @@ rules:
   - ""
   resources:
   - nodes
+  - events
   verbs:
   - get
   - list


### PR DESCRIPTION
Fixes a few issues with the getting started process

1. `clusterctl` runs locally and needs authorization to call to GCP.  README.md adds instructions for using the machine-controller serviceaccount
2. machine-controller creates an event in the default namespace when the machine is created.  The rbac template is changed to add full access to the event kind.
3.  `addons.yaml` is missing a version specification, and kubectl fails to apply (with an very unclear error).  `/v1` is added to the template.
