### PR TITLE
Dockerfile: move manager from /root/ to /

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN chmod a+rx /usr/bin/kubeadm
 
 # Copy the controller-manager into a thin image
 FROM ubuntu:latest
-WORKDIR /root/
+WORKDIR /
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-gcp/manager .
 COPY --from=kubeadm /usr/bin/kubeadm /usr/bin/kubeadm
-ENTRYPOINT ["./manager"]
+ENTRYPOINT ["/manager"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,7 +55,7 @@ spec:
       - name: manager
         image: SET_BY_PATCH
         command:
-        - "/root/manager"
+        - "/manager"
         args:
         - "-logtostderr=true"
         - "-stderrthreshold=INFO"


### PR DESCRIPTION
Equivalent of https://github.com/kubernetes-sigs/cluster-api/pull/609


```release-note
NONE
```