### PR TITLE
Provide bootstrap CA cert and config for nodes.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -90,11 +90,11 @@ func initStaticDeps(mgr manager.Manager) {
 
 	bootstrapKubeconfig, err := ioutil.ReadFile(*bootstrapKubeconfig)
 	if err != nil {
-		glog.Exitf("Couldn't open bootstrap kubeconfig file %v", err)
+		glog.Warningf("Couldn't open bootstrap kubeconfig file %v", err)
 	}
 	bootstrapCACert, err := ioutil.ReadFile(*bootstrapCACert)
 	if err != nil {
-		glog.Exitf("Couldn't open bootstrap CA cert file %v", err)
+		glog.Warningf("Couldn't open bootstrap CA cert file %v", err)
 	}
 
 	google.MachineActuator, err = google.NewMachineActuator(google.MachineActuatorParams{

--- a/pkg/cloud/google/machineactuator.go
+++ b/pkg/cloud/google/machineactuator.go
@@ -89,6 +89,8 @@ type GCEClientMachineSetupConfigGetter interface {
 }
 
 type GCEClient struct {
+	bootstrapKubeconfig      []byte
+	bootstrapCACert          []byte
 	certificateAuthority     *cert.CertificateAuthority
 	computeService           GCEClientComputeService
 	kubeadm                  GCEClientKubeadm
@@ -101,6 +103,8 @@ type GCEClient struct {
 }
 
 type MachineActuatorParams struct {
+	BootstrapKubeconfig      []byte
+	BootstrapCACert          []byte
 	CertificateAuthority     *cert.CertificateAuthority
 	ComputeService           GCEClientComputeService
 	Kubeadm                  GCEClientKubeadm
@@ -132,6 +136,8 @@ func NewMachineActuator(params MachineActuatorParams) (*GCEClient, error) {
 	}
 
 	return &GCEClient{
+		bootstrapKubeconfig:   params.BootstrapKubeconfig,
+		bootstrapCACert:       params.BootstrapCACert,
 		certificateAuthority:  params.CertificateAuthority,
 		computeService:        computeService,
 		kubeadm:               getOrNewKubeadm(params),
@@ -877,7 +883,7 @@ func (gce *GCEClient) getMetadata(cluster *clusterv1.Cluster, machine *clusterv1
 		if err != nil {
 			return nil, err
 		}
-		metadataMap, err = nodeMetadata(kubeadmToken, cluster, machine, clusterConfig.Project, &machineSetupMetadata)
+		metadataMap, err = nodeMetadata(gce.bootstrapKubeconfig, gce.bootstrapCACert, kubeadmToken, cluster, machine, clusterConfig.Project, &machineSetupMetadata)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
I'd like also to add a sample file for the bootstrap kubeconfig -- what's the best place to put it?

It's essentially this:

```yaml
apiVersion: v1
kind: Config
clusters:
- name: local
  cluster:
    server: http://localhost:8080
contexts:
- context:
    cluster: local
  name: localhost-8080
current-context: localhost-8080
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
For GKE integration, we need to be able to bootstrap a node by having its CA cert and kubeconfig. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #51 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Provide bootstrap CA cert and config for nodes.
```
