### PR TITLE
Fix the name of kustomized files.

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,8 +18,8 @@ namePrefix: gcp-provider-
 # YAML string, with resources separated by document
 # markers ("---").
 resources:
-- ../crds/gceproviderconfig_v1alpha1_gceclusterproviderconfig.yaml
-- ../crds/gceproviderconfig_v1alpha1_gcemachineproviderconfig.yaml
+- ../crds/gceproviderconfig_v1alpha1_gceclusterproviderspec.yaml
+- ../crds/gceproviderconfig_v1alpha1_gcemachineproviderspec.yaml
 - ../rbac/rbac_role.yaml
 - ../rbac/rbac_role_binding.yaml
 - ../manager/manager.yaml


### PR DESCRIPTION
**What this PR does / why we need it**: Currently the instructions to run kustomize produce an error because the files it tries to load no longer exist (they were renamed in https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/58). 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @justinsb 