### PR TITLE
Move cloud-config generation server-side

### DIFF
--- a/cmd/clusterctl/examples/google/machine_setup_configs.yaml
+++ b/cmd/clusterctl/examples/google/machine_setup_configs.yaml
@@ -18,6 +18,16 @@ items:
           curl  --retry 5 --silent --fail --header "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/$@"
       }
 
+      function copy_file () {
+          if ! curl_metadata attributes/$1; then
+              return
+          fi
+          echo "Copying metadata $1 -> $2..."
+          mkdir -p $(dirname $2)
+          curl_metadata attributes/$1 > $2
+          chmod $3 $2
+      }
+
       curl -sf https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
       touch /etc/apt/sources.list.d/kubernetes.list
       sh -c 'echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
@@ -79,13 +89,7 @@ items:
       PUBLICIP=`curl_metadata "network-interfaces/0/access-configs/0/external-ip"`
 
       # Set up the GCE cloud config, which gets picked up by kubeadm init since cloudProvider is set to GCE.
-      cat > /etc/kubernetes/cloud-config <<EOF
-      [global]
-      project-id = ${PROJECT}
-      network-name = ${NETWORK}
-      subnetwork-name = ${SUBNETWORK}
-      node-tags = ${NODE_TAG}
-      EOF
+      copy_file cloud-config /etc/kubernetes/cloud-config 0644
 
       # Set up kubeadm config file to pass parameters to kubeadm init.
       cat > /etc/kubernetes/kubeadm_config.yaml <<EOF
@@ -155,6 +159,20 @@ items:
       set -e
       set -x
       (
+      function curl_metadata() {
+          curl  --retry 5 --silent --fail --header "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/$@"
+      }
+
+      function copy_file () {
+          if ! curl_metadata attributes/$1; then
+              return
+          fi
+          echo "Copying metadata $1 -> $2..."
+          mkdir -p $(dirname $2)
+          curl_metadata attributes/$1 > $2
+          chmod $3 $2
+      }
+
       apt-get update
       apt-get install -y apt-transport-https prips
       apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys F76221572C52609D
@@ -177,20 +195,14 @@ items:
 
       install_configure_docker
 
+      copy_file cloud-config /etc/kubernetes/cloud-config 0644
+
       curl -fs https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
       cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
       deb http://apt.kubernetes.io/ kubernetes-xenial main
       EOF
       apt-get update
 
-      mkdir -p /etc/kubernetes/
-      cat > /etc/kubernetes/cloud-config <<EOF
-      [global]
-      project-id = ${PROJECT}
-      network-name = ${NETWORK}
-      subnetwork-name = ${SUBNETWORK}
-      node-tags = ${NODE_TAG}
-      EOF
       # Our Debian packages have versions like "1.8.0-00" or "1.8.0-01". Do a prefix
       # search based on our SemVer to find the right (newest) package version.
       function getversion() {

--- a/pkg/cloud/google/machineactuator.go
+++ b/pkg/cloud/google/machineactuator.go
@@ -882,6 +882,27 @@ func (gce *GCEClient) getMetadata(cluster *clusterv1.Cluster, machine *clusterv1
 			return nil, err
 		}
 	}
+
+	{
+		var b strings.Builder
+
+		project := clusterConfig.Project
+
+		clusterName := cluster.Name
+		nodeTag := clusterName + "-worker"
+
+		network := "default"
+		subnetwork := "kubernetes"
+
+		fmt.Fprintf(&b, "[global]\n")
+		fmt.Fprintf(&b, "project-id = %s\n", project)
+		fmt.Fprintf(&b, "network-name = %s\n", network)
+		fmt.Fprintf(&b, "subnetwork-name = %s\n", subnetwork)
+		fmt.Fprintf(&b, "node-tags = %s\n", nodeTag)
+
+		metadataMap["cloud-config"] = b.String()
+	}
+
 	var metadataItems []*compute.MetadataItems
 	for k, v := range metadataMap {
 		v := v // rebind scope to avoid loop aliasing below

--- a/pkg/cloud/google/metadata.go
+++ b/pkg/cloud/google/metadata.go
@@ -113,12 +113,6 @@ CONTROL_PLANE_VERSION={{ .Machine.Spec.Versions.ControlPlane }}
 CLUSTER_DNS_DOMAIN={{ .Cluster.Spec.ClusterNetwork.ServiceDomain }}
 POD_CIDR={{ .PodCIDR }}
 SERVICE_CIDR={{ .ServiceCIDR }}
-# Environment variables for GCE cloud config
-PROJECT={{ .Project }}
-NETWORK=default
-SUBNETWORK=kubernetes
-CLUSTER_NAME={{ .Cluster.Name }}
-NODE_TAG="$CLUSTER_NAME-worker"
 `
 
 const nodeEnvironmentVars = `
@@ -133,10 +127,4 @@ MACHINE+={{ .Machine.ObjectMeta.Name }}
 CLUSTER_DNS_DOMAIN={{ .Cluster.Spec.ClusterNetwork.ServiceDomain }}
 POD_CIDR={{ .PodCIDR }}
 SERVICE_CIDR={{ .ServiceCIDR }}
-# Environment variables for GCE cloud config
-PROJECT={{ .Project }}
-NETWORK=default
-SUBNETWORK=kubernetes
-CLUSTER_NAME={{ .Cluster.Name }}
-NODE_TAG="$CLUSTER_NAME-worker"
 `


### PR DESCRIPTION
There's no reason to generate it client-side, and this sets us up
nicely for more server-side generation.


```release-note
NONE
```