### PR TITLE
sed cluster_name in machines.yaml

### DIFF
--- a/cmd/clusterctl/examples/google/generate-yaml.sh
+++ b/cmd/clusterctl/examples/google/generate-yaml.sh
@@ -160,6 +160,7 @@ MACHINE_CONTROLLER_SSH_PRIVATE=$(cat $MACHINE_CONTROLLER_SSH_PRIVATE_FILE | base
 cp machine_setup_configs.yaml ${OUTPUT_DIR}/machine_setup_configs.yaml
 
 cat $MACHINE_TEMPLATE_FILE \
+  | sed -e "s/\$CLUSTER_NAME/$CLUSTER_NAME/" \
   | sed -e "s/\$ZONE/$ZONE/" \
   > $MACHINE_GENERATED_FILE
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug with the generate-yaml.sh script that was causing the `CLUSTER_NAME` variable to not get updated in the generated machine.yaml file and thus deployment of a cluster to fail using the README instructions. This simply adds the same sed command that happens for other templates.

Here's an example of the error I was seeing:
```
F0228 17:12:20.060510   31053 create_cluster.go:60] unable to create control plane machine: error creating a machine object in namespace default: Machine.cluster.k8s.io "gce-master-8g5z6" is invalid: metadata.labels: Invalid value: "$CLUSTER_NAME": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

Release note:
```release-note
NONE
```
