### PR TITLE
Update README.md - Change cluster create command to use bootstrap option instead of minikube.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
    ```bash
    export GOOGLE_APPLICATION_CREDENTIALS=cmd/clusterctl/examples/google/out/machine-controller-serviceaccount.json
 
-   ./bin/clusterctl create cluster --provider google -c cmd/clusterctl/examples/google/out/cluster.yaml -m cmd/clusterctl/examples/google/out/machines.yaml -p cmd/clusterctl/examples/google/out/provider-components.yaml -a cmd/clusterctl/examples/google/out/addons.yaml --minikube="kubernetes-version=v1.12.0"
+   ./bin/clusterctl create cluster --provider google -c cmd/clusterctl/examples/google/out/cluster.yaml -m cmd/clusterctl/examples/google/out/machines.yaml -p cmd/clusterctl/examples/google/out/provider-components.yaml -a cmd/clusterctl/examples/google/out/addons.yaml ----bootstrap-type=minikube --bootstrap-flags="kubernetes-version=v1.12.0"
    ```
 
 To choose a specific minikube driver, please use the `--vm-driver` command line parameter. For example to use the kvm2 driver with clusterctl you woud add `--vm-driver kvm2`.
 
-Adding `--minikube="kubernetes-version=v1.12.0"` enforces bootstrap cluster to be in a version supporting sub-resources in CRDs, used by this code. Kubernetes before version v1.12 doesn't support them out-of-the-box.
+Adding `----bootstrap-type=minikube --bootstrap-flags="kubernetes-version=v1.12.0"` enforces bootstrap cluster to be in a version supporting sub-resources in CRDs, used by this code. Kubernetes before version v1.12 doesn't support them out-of-the-box.
 
 Additional advanced flags can be found via help.
 


### PR DESCRIPTION
Change cluster create syntax to use bootstrap instead of minikube option.

**What this PR does / why we need it**:
The kubernetes version required by ClusterAPI was previously passed using the --minikube option to the cluster create command. But, the --minikube option was removed some time ago from the cluster create command, in favor of using --bootstrap options to pass the kubernetes version.

Using the old syntax now fails with no explanation to the user as to how to solve the issue.

This PR updates the README so that users will conform to the correct command syntax.