### PR TITLE
Strip `v` from `kubelet` and `controlplane` version

### DIFF
--- a/pkg/cloud/google/machineactuator.go
+++ b/pkg/cloud/google/machineactuator.go
@@ -254,9 +254,12 @@ func (gce *GCEClient) Create(_ context.Context, cluster *clusterv1.Cluster, mach
 	}
 
 	configParams := &machinesetup.ConfigParams{
-		OS:       machineConfig.OS,
-		Roles:    machineConfig.Roles,
-		Versions: machine.Spec.Versions,
+		OS:    machineConfig.OS,
+		Roles: machineConfig.Roles,
+		Versions: clusterv1.MachineVersionInfo{
+			Kubelet:      stripVersion(machine.Spec.Versions.Kubelet),
+			ControlPlane: stripVersion(machine.Spec.Versions.ControlPlane),
+		},
 	}
 	machineSetupConfigs, err := gce.machineSetupConfigGetter.GetMachineSetupConfig()
 	if err != nil {
@@ -646,12 +649,10 @@ func (gce *GCEClient) machineproviderconfig(providerSpec clusterv1.ProviderSpec)
 */
 
 func (gce *GCEClient) updateMasterInplace(cluster *clusterv1.Cluster, oldMachine *clusterv1.Machine, newMachine *clusterv1.Machine) error {
-	oldMachine.Spec.Versions.ControlPlane = stripVersion(oldMachine.Spec.Versions.ControlPlane)
-	newMachine.Spec.Versions.ControlPlane = stripVersion(newMachine.Spec.Versions.ControlPlane)
 	if oldMachine.Spec.Versions.ControlPlane != newMachine.Spec.Versions.ControlPlane {
 		cmd := fmt.Sprintf(
 			"curl -fsSL https://dl.k8s.io/release/v%s/bin/linux/amd64/kubeadm | sudo tee /usr/bin/kubeadm > /dev/null; "+
-				"sudo chmod a+rx /usr/bin/kubeadm", newMachine.Spec.Versions.ControlPlane)
+				"sudo chmod a+rx /usr/bin/kubeadm", stripVersion(newMachine.Spec.Versions.ControlPlane))
 		_, err := gce.remoteSshCommand(cluster, newMachine, cmd)
 		if err != nil {
 			klog.Infof("remotesshcomand error: %v", err)
@@ -660,7 +661,7 @@ func (gce *GCEClient) updateMasterInplace(cluster *clusterv1.Cluster, oldMachine
 
 		// TODO: We might want to upgrade kubeadm if the target control plane version is newer.
 		// Upgrade control plan.
-		cmd = fmt.Sprintf("sudo kubeadm upgrade apply %s -y", "v"+newMachine.Spec.Versions.ControlPlane)
+		cmd = fmt.Sprintf("sudo kubeadm upgrade apply %s -y", "v"+stripVersion(newMachine.Spec.Versions.ControlPlane))
 		_, err = gce.remoteSshCommand(cluster, newMachine, cmd)
 		if err != nil {
 			klog.Infof("remotesshcomand error: %v", err)
@@ -669,14 +670,12 @@ func (gce *GCEClient) updateMasterInplace(cluster *clusterv1.Cluster, oldMachine
 	}
 
 	// Upgrade kubelet.
-	oldMachine.Spec.Versions.Kubelet = stripVersion(oldMachine.Spec.Versions.Kubelet)
-	newMachine.Spec.Versions.Kubelet = stripVersion(newMachine.Spec.Versions.Kubelet)
 	if oldMachine.Spec.Versions.Kubelet != newMachine.Spec.Versions.Kubelet {
 		cmd := fmt.Sprintf("sudo kubectl drain %s --kubeconfig /etc/kubernetes/admin.conf --ignore-daemonsets", newMachine.Name)
 		// The errors are intentionally ignored as master has static pods.
 		gce.remoteSshCommand(cluster, newMachine, cmd)
 		// Upgrade kubelet to desired version.
-		cmd = fmt.Sprintf("sudo apt-get install kubelet=%s", newMachine.Spec.Versions.Kubelet+"-00")
+		cmd = fmt.Sprintf("sudo apt-get install kubelet=%s", stripVersion(newMachine.Spec.Versions.Kubelet)+"-00")
 		_, err := gce.remoteSshCommand(cluster, newMachine, cmd)
 		if err != nil {
 			klog.Infof("remotesshcomand error: %v", err)
@@ -693,14 +692,11 @@ func (gce *GCEClient) updateMasterInplace(cluster *clusterv1.Cluster, oldMachine
 	return nil
 }
 
-func stripVersion(version string) (newVersion string) {
-	cutSet := "vV"
-	newVersion = strings.Trim(version, cutSet)
-	return
+func stripVersion(version string) string {
+	return strings.Trim(version, "vV")
 }
 
 func (gce *GCEClient) validateMachine(machine *clusterv1.Machine, config *gceconfigv1.GCEMachineProviderSpec) *apierrors.MachineError {
-	machine.Spec.Versions.Kubelet = stripVersion(machine.Spec.Versions.Kubelet)
 	if machine.Spec.Versions.Kubelet == "" {
 		return apierrors.InvalidMachineConfiguration("spec.versions.kubelet can't be empty")
 	}
@@ -854,7 +850,6 @@ func clientWithAltTokenSource(gceConfigPath string) (*http.Client, error) {
 
 func (gce *GCEClient) getMetadata(cluster *clusterv1.Cluster, machine *clusterv1.Machine, clusterConfig *gceconfigv1.GCEClusterProviderSpec, configParams *machinesetup.ConfigParams) (*compute.Metadata, error) {
 	var metadataMap map[string]string
-	machine.Spec.Versions.Kubelet = stripVersion(machine.Spec.Versions.Kubelet)
 	if machine.Spec.Versions.Kubelet == "" {
 		return nil, errors.New("invalid master configuration: missing Machine.Spec.Versions.Kubelet")
 	}
@@ -866,7 +861,6 @@ func (gce *GCEClient) getMetadata(cluster *clusterv1.Cluster, machine *clusterv1
 	if err != nil {
 		return nil, err
 	}
-	machine.Spec.Versions.ControlPlane = stripVersion(machine.Spec.Versions.ControlPlane)
 	if isMaster(configParams.Roles) {
 		if machine.Spec.Versions.ControlPlane == "" {
 			return nil, gce.handleMachineError(machine, apierrors.InvalidMachineConfiguration(


### PR DESCRIPTION
In some cases `kubelet` and `controlplane` versions are copied from `Kubernetes` version. `Kubernetes` version contains an extra `v` from `kubelet & controlplane` version. That's why I striped `v` from `kubelet` and `controlplane` version.