### PR TITLE
Remove ---- from clusterctl command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ Note: Until incompatible changes introduced in kustomize v2.0.0 are addressed by
    ```bash
    export GOOGLE_APPLICATION_CREDENTIALS=cmd/clusterctl/examples/google/out/machine-controller-serviceaccount.json
 
-   ./bin/clusterctl create cluster --provider google -c cmd/clusterctl/examples/google/out/cluster.yaml -m cmd/clusterctl/examples/google/out/machines.yaml -p cmd/clusterctl/examples/google/out/provider-components.yaml -a cmd/clusterctl/examples/google/out/addons.yaml ----bootstrap-type=minikube --bootstrap-flags="kubernetes-version=v1.12.0"
+   ./bin/clusterctl create cluster --provider google -c cmd/clusterctl/examples/google/out/cluster.yaml -m cmd/clusterctl/examples/google/out/machines.yaml -p cmd/clusterctl/examples/google/out/provider-components.yaml -a cmd/clusterctl/examples/google/out/addons.yaml --bootstrap-type=minikube --bootstrap-flags="kubernetes-version=v1.12.0"
    ```
 
 To choose a specific minikube driver, please use the `--vm-driver` command line parameter. For example to use the kvm2 driver with clusterctl you woud add `--vm-driver kvm2`.
 
-Adding `----bootstrap-type=minikube --bootstrap-flags="kubernetes-version=v1.12.0"` enforces bootstrap cluster to be in a version supporting sub-resources in CRDs, used by this code. Kubernetes before version v1.12 doesn't support them out-of-the-box.
+Adding `--bootstrap-type=minikube --bootstrap-flags="kubernetes-version=v1.12.0"` enforces bootstrap cluster to be in a version supporting sub-resources in CRDs, used by this code. Kubernetes before version v1.12 doesn't support them out-of-the-box.
 
 Additional advanced flags can be found via help.
 


### PR DESCRIPTION


**What this PR does / why we need it**:
The command in the instructions is incorrect: `clusterctl` takes `--bootstrap-type`, not `----bootstrap-type`.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
