### PR TITLE
feat: support additional metadata for instances

### DIFF
--- a/cmd/clusterctl/examples/google/machine_setup_configs.yaml
+++ b/cmd/clusterctl/examples/google/machine_setup_configs.yaml
@@ -8,7 +8,8 @@ items:
       controlPlane: 1.12.0
   image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
   metadata:
-    startupScript: |
+  - name: "startup-script"
+    value: |
       set -e
       set -x
       (
@@ -155,7 +156,8 @@ items:
       kubelet: 1.12.0
   image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
   metadata:
-    startupScript: |
+  - name: "startup-script"
+    value: |
       set -e
       set -x
       (

--- a/pkg/cloud/google/machineactuator_test.go
+++ b/pkg/cloud/google/machineactuator_test.go
@@ -54,7 +54,7 @@ const (
 type GCEClientMachineSetupConfigMock struct {
 	mockGetYaml     func() (string, error)
 	mockGetImage    func(params *machinesetup.ConfigParams) (string, error)
-	mockGetMetadata func(params *machinesetup.ConfigParams) (machinesetup.Metadata, error)
+	mockGetMetadata func(params *machinesetup.ConfigParams) ([]machinesetup.MetadataItem, error)
 }
 
 func (m *GCEClientMachineSetupConfigMock) GetYaml() (string, error) {
@@ -71,9 +71,9 @@ func (m *GCEClientMachineSetupConfigMock) GetImage(params *machinesetup.ConfigPa
 	return m.mockGetImage(params)
 }
 
-func (m *GCEClientMachineSetupConfigMock) GetMetadata(params *machinesetup.ConfigParams) (machinesetup.Metadata, error) {
+func (m *GCEClientMachineSetupConfigMock) GetMetadata(params *machinesetup.ConfigParams) ([]machinesetup.MetadataItem, error) {
 	if m.mockGetYaml == nil {
-		return machinesetup.Metadata{}, nil
+		return []machinesetup.MetadataItem{}, nil
 	}
 	return m.mockGetMetadata(params)
 }
@@ -286,8 +286,8 @@ func newMachineSetupConfigMock() *GCEClientMachineSetupConfigMock {
 		mockGetYaml: func() (string, error) {
 			return "", nil
 		},
-		mockGetMetadata: func(params *machinesetup.ConfigParams) (machinesetup.Metadata, error) {
-			metadata := machinesetup.Metadata{}
+		mockGetMetadata: func(params *machinesetup.ConfigParams) ([]machinesetup.MetadataItem, error) {
+			metadata := []machinesetup.MetadataItem{}
 			return metadata, nil
 		},
 		mockGetImage: func(params *machinesetup.ConfigParams) (string, error) {

--- a/pkg/cloud/google/machinesetup/config_types.go
+++ b/pkg/cloud/google/machinesetup/config_types.go
@@ -32,7 +32,7 @@ import (
 type MachineSetupConfig interface {
 	GetYaml() (string, error)
 	GetImage(params *ConfigParams) (string, error)
-	GetMetadata(params *ConfigParams) (Metadata, error)
+	GetMetadata(params *ConfigParams) ([]MetadataItem, error)
 }
 
 // Config Watch holds the path to the machine setup configs yaml file.
@@ -59,12 +59,13 @@ type config struct {
 	// The fully specified image path. e.g.
 	//   projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
 	//   projects/ubuntu-os-cloud/global/images/ubuntu-1604-xenial-v20180405
-	Image    string   `json:"image"`
-	Metadata Metadata `json:"metadata"`
+	Image    string         `json:"image"`
+	Metadata []MetadataItem `json:"metadata"`
 }
 
-type Metadata struct {
-	StartupScript string `json:"startupScript"`
+type MetadataItem struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 type ConfigParams struct {
@@ -119,10 +120,10 @@ func (vc *ValidConfigs) GetImage(params *ConfigParams) (string, error) {
 	return machineSetupConfig.Image, nil
 }
 
-func (vc *ValidConfigs) GetMetadata(params *ConfigParams) (Metadata, error) {
+func (vc *ValidConfigs) GetMetadata(params *ConfigParams) ([]MetadataItem, error) {
 	machineSetupConfig, err := vc.matchMachineSetupConfig(params)
 	if err != nil {
-		return Metadata{}, err
+		return []MetadataItem{}, err
 	}
 	return machineSetupConfig.Metadata, nil
 }

--- a/pkg/cloud/google/machinesetup/config_types_test.go
+++ b/pkg/cloud/google/machinesetup/config_types_test.go
@@ -48,7 +48,8 @@ func TestParseMachineSetupYaml(t *testing.T) {
       controlPlane: 1.9.4
   image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1710
   metadata:
-    startupScript: |
+  - name: "startup-script"
+    value: |
       #!/bin/bash
 - machineParams:
   - os: ubuntu-1710
@@ -63,7 +64,8 @@ func TestParseMachineSetupYaml(t *testing.T) {
       kubelet: 1.9.4
   image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1710
   metadata:
-    startupScript: |
+  - name: "startup-script"
+    value: |
       #!/bin/bash
       echo this is the node config.`),
 			expectedErr: false,
@@ -117,8 +119,11 @@ func TestGetYaml(t *testing.T) {
 								},
 							},
 							Image: "projects/ubuntu-os-cloud/global/images/family/ubuntu-1710",
-							Metadata: Metadata{
-								StartupScript: "Master startup script",
+							Metadata: []MetadataItem{
+								MetadataItem{
+									Name:  "startup-script",
+									Value: "Master startup script",
+								},
 							},
 						},
 						{
@@ -132,15 +137,19 @@ func TestGetYaml(t *testing.T) {
 								},
 							},
 							Image: "projects/ubuntu-os-cloud/global/images/family/ubuntu-1710",
-							Metadata: Metadata{
-								StartupScript: "Node startup script",
+							Metadata: []MetadataItem{
+								MetadataItem{
+									Name:  "startup-script",
+									Value: "Node startup script",
+								},
 							},
 						},
 					},
 				},
 			},
-			expectedStrings: []string{"startupScript: Master startup script", "startupScript: Node startup script"},
-			expectedErr:     false,
+			expectedStrings: []string{"- name: startup-script\n    value: Master startup script",
+				"- name: startup-script\n    value: Node startup script"},
+			expectedErr: false,
 		},
 	}
 
@@ -189,8 +198,11 @@ func TestMatchMachineSetupConfig(t *testing.T) {
 			},
 		},
 		Image: "projects/ubuntu-os-cloud/global/images/family/ubuntu-1710",
-		Metadata: Metadata{
-			StartupScript: "Master startup script",
+		Metadata: []MetadataItem{
+			MetadataItem{
+				Name:  "startup-script",
+				Value: "Master startup script",
+			},
 		},
 	}
 	nodeMachineSetupConfig := config{
@@ -211,8 +223,11 @@ func TestMatchMachineSetupConfig(t *testing.T) {
 			},
 		},
 		Image: "projects/ubuntu-os-cloud/global/images/family/ubuntu-1710",
-		Metadata: Metadata{
-			StartupScript: "Node startup script",
+		Metadata: []MetadataItem{
+			MetadataItem{
+				Name:  "startup-script",
+				Value: "Node startup script",
+			},
 		},
 	}
 	multiRoleSetupConfig := config{
@@ -227,8 +242,11 @@ func TestMatchMachineSetupConfig(t *testing.T) {
 			},
 		},
 		Image: "projects/ubuntu-os-cloud/global/images/family/ubuntu-1710",
-		Metadata: Metadata{
-			StartupScript: "Multi-role startup script",
+		Metadata: []MetadataItem{
+			MetadataItem{
+				Name:  "startup-script",
+				Value: "Multi-role startup script",
+			},
 		},
 	}
 	duplicateMasterMachineSetupConfig := config{
@@ -251,8 +269,11 @@ func TestMatchMachineSetupConfig(t *testing.T) {
 			},
 		},
 		Image: "projects/ubuntu-os-cloud/global/images/family/ubuntu-1710",
-		Metadata: Metadata{
-			StartupScript: "Duplicate master startup script",
+		Metadata: []MetadataItem{
+			MetadataItem{
+				Name:  "startup-script",
+				Value: "Duplicate master startup script",
+			},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Interested to see what folks think about this approach. This PR would add the ability to supply additional metadata to instances that get created by the provider. As it currently stands, there's only the "startup-script" metadata field that can be edited. I'd like to be able to squirrel other data away in metadata during instance creation time. This PR allows metadata to be specified as a list with name/value fields, like:

```bash
  metadata:
  - name: "startup-script"
    value: |
      #!/bin/bash
      echo "this is metadata"
  - name: "additional-data"
    value: |
      this: "just a test"
```
It allows us to keep the "startup-script" in it's current form, while also allowing for additions.

**Which issue(s) this PR fixes**:
Fixes #122 
