### PR TITLE
feat: support externalIPs for machines

### DIFF
--- a/config/crds/gceproviderconfig_v1alpha1_gcemachineproviderspec.yaml
+++ b/config/crds/gceproviderconfig_v1alpha1_gcemachineproviderspec.yaml
@@ -37,6 +37,8 @@ spec:
             - initializeParams
             type: object
           type: array
+        externalIP:
+          type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client

--- a/pkg/apis/gceproviderconfig/v1alpha1/gcemachineproviderconfig_types.go
+++ b/pkg/apis/gceproviderconfig/v1alpha1/gcemachineproviderconfig_types.go
@@ -35,8 +35,9 @@ type GCEMachineProviderSpec struct {
 	MachineType string `json:"machineType"`
 
 	// The name of the OS to be installed on the machine.
-	OS    string `json:"os,omitempty"`
-	Disks []Disk `json:"disks,omitempty"`
+	OS         string `json:"os,omitempty"`
+	Disks      []Disk `json:"disks,omitempty"`
+	ExternalIP string `json:"externalIP,omitempty"`
 }
 
 // The MachineRole indicates the purpose of the Machine, and will determine

--- a/pkg/cloud/google/machineactuator.go
+++ b/pkg/cloud/google/machineactuator.go
@@ -296,8 +296,9 @@ func (gce *GCEClient) Create(_ context.Context, cluster *clusterv1.Cluster, mach
 					Network: "global/networks/default",
 					AccessConfigs: []*compute.AccessConfig{
 						{
-							Type: "ONE_TO_ONE_NAT",
-							Name: "External NAT",
+							Type:  "ONE_TO_ONE_NAT",
+							Name:  "External NAT",
+							NatIP: machineConfig.ExternalIP,
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR would add the ability for pre-generated external IPs to be specified in the machine manifest for masters (or really any instance type). One of the things I'm interested in is generating some static-ish machine manifests for each master that provides this externalIP field. An example that's similar to what I've been using:

```yaml
apiVersion: "cluster.k8s.io/v1alpha1"
kind: Machine
metadata:
  generateName: gce-master-
  labels:
    cluster.k8s.io/cluster-name: test1-7s5v2
    set: master
spec:
  providerSpec:
    value:
      apiVersion: "gceproviderconfig/v1alpha1"
      kind: "GCEMachineProviderSpec"
      roles:
      - Master
      zone: "us-central1-f"
      machineType: "n1-standard-1"
      os: "ubuntu-1604-lts"
      disks:
      - initializeParams:
          diskSizeGb: 30
          diskType: "pd-standard"
      externalIP: "111.222.333.444"
  versions:
    kubelet: 1.12.0
    controlPlane: 1.12.0
``` 
Similar to #123, I'm hoping to have this ability so that I can wrap the GCP provider for use with talos, where we will pre-generate certs for the master IPs that then get pushed into the nodes as userdata. Also want to note that adding these external IPs would be totally optional and creating a machine manifest without it still works just fine.

**Which issue(s) this PR fixes**:
Fixes #124
