### PR TITLE
machineactuator: Get cluster from metadata if not set

### DIFF
--- a/pkg/cloud/google/BUILD.bazel
+++ b/pkg/cloud/google/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/cloud/google/clients/errors:go_default_library",
         "//pkg/cloud/google/config:go_default_library",
         "//pkg/cloud/google/machinesetup:go_default_library",
+        "//vendor/cloud.google.com/go/compute/metadata:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/golang.org/x/oauth2/google:go_default_library",


### PR DESCRIPTION
This lets us avoid requiring the cluster in the machineactuator,
particularly as we seem to only need it for the project.

```release-note
NONE
```