### PR TITLE
Update to golang 1.12.5

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,7 +17,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_depen
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.11.5",
+    go_version = "1.12.5",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")


### PR DESCRIPTION
Latest golang, also syncing up with cluster-api & cluster-api-provider-aws


```release-note
NONE
```