### PR TITLE
🐛 fix: remove leading v from kube version

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -26,7 +26,7 @@ command -v "${ENVSUBST}" >/dev/null 2>&1 || echo -v "Cannot find ${ENVSUBST} in 
 
 # Cluster.
 export CLUSTER_NAME="${CLUSTER_NAME:-test1}"
-export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.15.3}"
+export KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.15.3}"
 
 # Machine settings.
 export CONTROL_PLANE_MACHINE_TYPE="${CONTROL_PLANE_MACHINE_TYPE:-n1-standard-2}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes #156 by removing the v from KUBERNETES_VERSION and
allowing it to pass the semver check during machine creation.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #156
