### PR TITLE
Avoid hard coding the cluster name in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ MANIFEST_ROOT ?= config
 CRD_ROOT ?= $(MANIFEST_ROOT)/crd/bases
 WEBHOOK_ROOT ?= $(MANIFEST_ROOT)/webhook
 RBAC_ROOT ?= $(MANIFEST_ROOT)/rbac
+CLUSTER_NAME ?= test1
 
 ## --------------------------------------
 ## Help
@@ -277,7 +278,7 @@ create-cluster: $(CLUSTERCTL) ## Create a development Kubernetes cluster on GCP 
 		alpha phases get-kubeconfig -v=3 \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		--namespace=default \
-		--cluster-name=test1
+		--cluster-name=$(CLUSTER_NAME)
 	# Apply addons on the target cluster, waiting for the control-plane to become available.
 	$(CLUSTERCTL) \
 		alpha phases apply-addons -v=3 \
@@ -294,7 +295,7 @@ delete-cluster: $(CLUSTERCTL) ## Deletes the development Kubernetes Cluster "tes
 	delete cluster -v 4 \
 	--bootstrap-type kind \
 	--bootstrap-flags="name=clusterapi" \
-	--cluster test1 \
+	--cluster $(CLUSTER_NAME) \
 	--kubeconfig ./kubeconfig \
 	-p ./examples/_out/provider-components.yaml \
 


### PR DESCRIPTION
Do the same as what we do in examples/generate.sh, pick up CLUSTER_NAME
environment variable.

Change-Id: I1b9d46a648f31d07cf7af254df9d4112b393c2d5

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
