### PR TITLE
Reflect current state of slow startup

### DIFF
--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -37,7 +37,7 @@ spec:
         cloud-provider: gce
   clusterConfiguration:
     apiServer:
-      timeoutForControlPlane: 10m
+      timeoutForControlPlane: 20m
       extraArgs:
         cloud-provider: gce
     controllerManager:


### PR DESCRIPTION
Until we track down the slow start up issue, we should bump to 20 minutes.

Change-Id: I764eb281fc61bf26aa591f593e9a1a9df1072f1c

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
