### PR TITLE
🐛 Fix GCPCluster watcher on GCPMachines / delete instance groups

### DIFF
--- a/cloud/services/compute/instancegroup.go
+++ b/cloud/services/compute/instancegroup.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compute
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"google.golang.org/api/compute/v1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1alpha2"
+	"sigs.k8s.io/cluster-api-provider-gcp/cloud/gcperrors"
+	"sigs.k8s.io/cluster-api-provider-gcp/cloud/wait"
+)
+
+func (s *Service) ReconcileInstanceGroups() error {
+	// Get each available zone.
+	zones, err := s.getZones()
+	if err != nil {
+		return err
+	}
+
+	// Reconcile API Server instance groups and record them.
+	for _, zone := range zones {
+		name := fmt.Sprintf("%s-%s-%s", s.scope.Name(), infrav1.APIServerRoleTagValue, zone)
+		group, err := s.instancegroups.Get(s.scope.Project(), zone, name).Do()
+		switch {
+		case gcperrors.IsNotFound(err):
+			continue
+		case err != nil:
+			return errors.Wrapf(err, "failed to describe instance group %q", name)
+		default:
+			if s.scope.Network().APIServerInstanceGroups == nil {
+				s.scope.Network().APIServerInstanceGroups = make(map[string]string)
+			}
+			s.scope.Network().APIServerInstanceGroups[zone] = group.Name
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) DeleteInstanceGroups() error {
+	for zone, group := range s.scope.Network().APIServerInstanceGroups {
+		op, err := s.instancegroups.Delete(s.scope.Project(), zone, group).Do()
+		if err != nil {
+			return errors.Wrapf(err, "failed to create backend service")
+		}
+		if err := wait.ForComputeOperation(s.scope.Compute, s.scope.Project(), op); err != nil {
+			return errors.Wrapf(err, "failed to create backend service")
+		}
+	}
+	return nil
+}
+
+func (s *Service) GetOrCreateInstanceGroup(zone, name string) (*compute.InstanceGroup, error) {
+	group, err := s.instancegroups.Get(s.scope.Project(), zone, name).Do()
+	if gcperrors.IsNotFound(err) {
+		spec := &compute.InstanceGroup{
+			Name:    name,
+			Network: s.scope.NetworkID(),
+			NamedPorts: []*compute.NamedPort{
+				{
+					Name: "apiserver",
+					Port: 6443,
+				},
+			},
+		}
+		op, err := s.instancegroups.Insert(s.scope.Project(), zone, spec).Do()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create instance group")
+		}
+		if err := wait.ForComputeOperation(s.scope.Compute, s.scope.Project(), op); err != nil {
+			return nil, errors.Wrapf(err, "failed to create instance group")
+		}
+		group, err = s.instancegroups.Get(s.scope.Project(), zone, name).Do()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to describe instance group")
+		}
+	} else if err != nil {
+		return nil, errors.Wrapf(err, "failed to describe instance group")
+	}
+
+	return group, nil
+}
+
+func (s *Service) GetInstanceGroupMembers(zone, name string) ([]*compute.InstanceWithNamedPorts, error) {
+	members, err := s.instancegroups.
+		ListInstances(s.scope.Project(), zone, name, &compute.InstanceGroupsListInstancesRequest{}).
+		Do()
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not list instances in group %q", name)
+	}
+	return members.Items, nil
+}
+
+func (s *Service) EnsureInstanceGroupMember(zone, name string, i *compute.Instance) error {
+	members, err := s.GetInstanceGroupMembers(zone, name)
+	if err != nil {
+		return err
+	}
+
+	// If the instance is already registered, return early.
+	for _, registered := range members {
+		if registered.Instance == i.SelfLink {
+			return nil
+		}
+	}
+
+	// Register the instance with the group
+	req := &compute.InstanceGroupsAddInstancesRequest{
+		Instances: []*compute.InstanceReference{
+			{
+				Instance: i.SelfLink,
+			},
+		},
+	}
+	op, err := s.instancegroups.AddInstances(s.scope.Project(), zone, name, req).Do()
+	if err != nil {
+		return errors.Wrapf(err, "failed to add instance to group")
+	}
+	if err := wait.ForComputeOperation(s.scope.Compute, s.scope.Project(), op); err != nil {
+		return errors.Wrapf(err, "failed to add instance to group")
+	}
+
+	return nil
+}

--- a/cloud/services/compute/loadbalancers.go
+++ b/cloud/services/compute/loadbalancers.go
@@ -42,27 +42,6 @@ const (
 
 // ReconcileLoadbalancers reconciles the api server load balancer.
 func (s *Service) ReconcileLoadbalancers() error {
-	// Fetch API Server Instance Groups.
-	// TODO(vincepri): Move to network reconciliation.
-	zones, err := s.getZones()
-	if err != nil {
-		return err
-	}
-	for _, zone := range zones {
-		name := fmt.Sprintf("%s-%s-%s", s.scope.Name(), infrav1.APIServerRoleTagValue, zone)
-		group, err := s.instancegroups.Get(s.scope.Project(), zone, name).Do()
-		switch {
-		case gcperrors.IsNotFound(err):
-			continue
-		case err != nil:
-			return errors.Wrapf(err, "failed to describe instance group %q", name)
-		default:
-			if s.scope.Network().APIServerInstanceGroups == nil {
-				s.scope.Network().APIServerInstanceGroups = make(map[string]string)
-			}
-			s.scope.Network().APIServerInstanceGroups[zone] = group.SelfLink
-		}
-	}
 
 	// Reconcile Health Check.
 	healthCheckSpec := s.getAPIServerHealthCheckSpec()

--- a/controllers/gcpcluster_controller.go
+++ b/controllers/gcpcluster_controller.go
@@ -48,7 +48,7 @@ func (r *GCPClusterReconciler) SetupWithManager(mgr ctrl.Manager, options contro
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
 		For(&infrav1.GCPCluster{}).
-		Owns(&infrav1.GCPMachine{}).
+		For(&infrav1.GCPMachine{}).
 		Complete(r)
 }
 
@@ -129,6 +129,10 @@ func (r *GCPClusterReconciler) reconcile(clusterScope *scope.ClusterScope) (reco
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile firewalls for GCPCluster %s/%s", gcpCluster.Namespace, gcpCluster.Name)
 	}
 
+	if err := computeSvc.ReconcileInstanceGroups(); err != nil {
+		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile instance groups for GCPCluster %s/%s", gcpCluster.Namespace, gcpCluster.Name)
+	}
+
 	if err := computeSvc.ReconcileLoadbalancers(); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile load balancers for GCPCluster %s/%s", gcpCluster.Namespace, gcpCluster.Name)
 	}
@@ -159,6 +163,10 @@ func (r *GCPClusterReconciler) reconcileDelete(clusterScope *scope.ClusterScope)
 
 	if err := computeSvc.DeleteLoadbalancers(); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "error deleting load balancer for GCPCluster %s/%s", gcpCluster.Namespace, gcpCluster.Name)
+	}
+
+	if err := computeSvc.DeleteInstanceGroups(); err != nil {
+		return reconcile.Result{}, errors.Wrapf(err, "error deleting instance groups for GCPCluster %s/%s", gcpCluster.Namespace, gcpCluster.Name)
 	}
 
 	if err := computeSvc.DeleteFirewalls(); err != nil {


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR fixes a bug where the GCPCluster would watch only GCPMachines that it owned, which the OwnerReference is never set for. Instead, we watch all GCPMachines in this case and reconcile the Cluster object as well.

It also adds support for deleting instance groups and it refactors the code in multiple methods under the cloud package.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #165 
Fixes #163 
