### PR TITLE
Add CI script for running e2e conformance tests

### DIFF
--- a/hack/checkin_account.py
+++ b/hack/checkin_account.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import httplib
+import urllib
+import os
+
+BOSKOS_HOST=os.environ.get("BOSKOS_HOST", "boskos")
+BOSKOS_RESOURCE_NAME=os.environ['BOSKOS_RESOURCE_NAME']
+
+USER = "cluster-api-provider-gcp"
+
+if __name__ == "__main__":
+    conn = httplib.HTTPConnection(BOSKOS_HOST)
+    conn.request("POST", "/release?%s" % urllib.urlencode({
+        'name': BOSKOS_RESOURCE_NAME,
+        'dest': 'dirty',
+        'owner': USER,
+    }))
+
+    resp = conn.getresponse()
+    if resp.status != 200:
+        sys.exit("Got invalid response %d" % resp.status)
+    conn.close()

--- a/hack/checkout_account.py
+++ b/hack/checkout_account.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Checks out a gcp account from E2E"""
+
+import urllib
+import httplib
+import os
+import sys
+import json
+
+BOSKOS_HOST=os.environ.get("BOSKOS_HOST", "boskos")
+
+RESOURCE_TYPE = "gcp-account"
+USER = "cluster-api-provider-gcp"
+
+def post_request(host, input_state = "clean"):
+    conn = httplib.HTTPConnection(host)
+    conn.request("POST", "/acquire?%s" % urllib.urlencode({
+        'type': RESOURCE_TYPE,
+        'owner': USER,
+        'state': input_state,
+        'dest': 'busy',
+    })
+
+    )
+    resp = conn.getresponse()
+    status = resp.status
+    reason = resp.reason
+    body = resp.read()
+    conn.close()
+    return status, reason, body
+
+if __name__ == "__main__":
+    status, reason, result = post_request(BOSKOS_HOST)
+    #  we're working around an issue with the data in boskos.
+    #  We'll remove the code that tries both free and clean once all the data is good.
+    #  Afterwards we should just check for free
+    if status == 404:
+        status, reason, result = post_request(BOSKOS_HOST, "free")
+
+    if status != 200:
+        sys.exit("Got invalid response %d: %s" % (status, reason))
+
+    body = json.loads(result)
+    print 'export BOSKOS_RESOURCE_NAME="%s";' % body['name']
+    print 'export GCP_PROJECT="%s";' % body['name']

--- a/hack/ci/README.md
+++ b/hack/ci/README.md
@@ -1,0 +1,4 @@
+This directory contains glue used to test the cluster-api-provider-gcp repo in CI.
+
+We don't recommend reusing anything from these scripts, and intend to replace
+them at some point.

--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# hack script for running a cluster-api-provider-gcp e2e
+
+set -o errexit -o nounset -o pipefail -o xtrace
+
+GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS:-""}
+GCP_PROJECT=${GCP_PROJECT:-""}
+GCP_REGION=${GCP_REGION:-"us-east4"}
+CLUSTER_NAME=${CLUSTER_NAME:-"test1"}
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+# our exit handler (trap)
+cleanup() {
+  # always attempt to dump logs
+  kind "export" logs --name="clusterapi" "${ARTIFACTS}/logs" || true
+  # KIND_IS_UP is true once we: kind create
+  if [[ "${KIND_IS_UP:-}" = true ]]; then
+    kubectl \
+      --kubeconfig=$(kind get kubeconfig-path --name="clusterapi") \
+      delete cluster test1 || true
+    kubectl \
+      --kubeconfig=$(kind get kubeconfig-path --name="clusterapi") \
+      wait --for=delete cluster/test1 || true
+    make kind-reset || true
+  fi
+  # clean up e2e.test symlink
+  (cd "$(go env GOPATH)/src/k8s.io/kubernetes" && rm -f _output/bin/e2e.test) || true
+  # remove our tempdir
+  # NOTE: this needs to be last, or it will prevent kind delete
+  if [[ -n "${TMP_DIR:-}" ]]; then
+    rm -rf "${TMP_DIR}"
+  fi
+}
+
+init_image() {
+  image=$(gcloud compute images list --project $GCP_PROJECT \
+    --no-standard-images --filter="family:capi-ubuntu-1804-k8s" --format="table[no-heading](name)")
+  if [[ -z "$image" ]]; then
+      if ! command -v packer &> /dev/null; then
+        hostos=$(go env GOHOSTOS)
+        hostarch=$(go env GOHOSTARCH)
+        version="1.4.3"
+        url="https://releases.hashicorp.com/packer/${version}/packer_${version}_${hostos}_${hostarch}.zip"
+        echo "Downloading packer from $url"
+        wget -O packer.zip $url  && \
+          unzip packer.zip && \
+          rm packer.zip && \
+          mv packer "$(go env GOPATH)/bin"
+      fi
+      (cd "$(go env GOPATH)/src/sigs.k8s.io/image-builder/images/capi" && \
+      GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS \
+      make build-gce-default)
+  fi
+}
+
+# build kubernetes / node image, e2e binaries
+build() {
+  # possibly enable bazel build caching before building kubernetes
+  if [[ "${BAZEL_REMOTE_CACHE_ENABLED:-false}" == "true" ]]; then
+    create_bazel_cache_rcs.sh || true
+  fi
+
+  pushd "$(go env GOPATH)/src/k8s.io/kubernetes"
+
+  # make sure we have e2e requirements
+  bazel build //cmd/kubectl //test/e2e:e2e.test //vendor/github.com/onsi/ginkgo/ginkgo
+
+  # ensure the e2e script will find our binaries ...
+  mkdir -p "${PWD}/_output/bin/"
+  cp "${PWD}/bazel-bin/test/e2e/e2e.test" "${PWD}/_output/bin/e2e.test"
+  PATH="$(dirname "$(find "${PWD}/bazel-bin/" -name kubectl -type f)"):${PATH}"
+  export PATH
+
+  # attempt to release some memory after building
+  sync || true
+  echo 1 > /proc/sys/vm/drop_caches || true
+
+  popd
+}
+
+# generate manifests needed for creating the GCP cluster to run the tests
+generate_manifests() {
+GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS \
+	GCP_REGION=$GCP_REGION \
+	GCP_PROJECT=$GCP_PROJECT \
+	CLUSTER_NAME=$CLUSTER_NAME \
+	make generate-examples
+}
+
+# up a cluster with kind
+create_cluster() {
+  # actually create the cluster
+  KIND_IS_UP=true
+  make create-cluster
+
+  # Wait till all machines are running
+  while true; do
+    read running total <<< $(kubectl get machines --kubeconfig=$(kind get kubeconfig-path --name="clusterapi") \
+     -o json | jq -r '.items[].status.phase' | awk '/running/ {count++} END{print count " " NR}') ;
+    if [[ $total == "5" && $running == "5" ]]; then
+      return
+    fi
+    timestamp=$(date +"[%H:%M:%S]")
+    echo "$timestamp Total machines : $total / Running : $running .. waiting for 10 seconds"
+    sleep 10
+  done
+}
+
+# run e2es with kubetest
+run_tests() {
+  # export the KUBECONFIG
+  KUBECONFIG="${PWD}/kubeconfig"
+  export KUBECONFIG
+
+  # ginkgo regexes
+  SKIP="${SKIP:-}"
+  FOCUS="${FOCUS:-"\\[Conformance\\]"}"
+  # if we set PARALLEL=true, skip serial tests set --ginkgo-parallel
+  if [[ "${PARALLEL:-false}" == "true" ]]; then
+    export GINKGO_PARALLEL=y
+    if [[ -z "${SKIP}" ]]; then
+      SKIP="\\[Serial\\]"
+    else
+      SKIP="\\[Serial\\]|${SKIP}"
+    fi
+  fi
+
+  # get the number of worker nodes
+  # TODO(bentheelder): this is kinda gross
+  NUM_NODES="$(kubectl get nodes --kubeconfig=$KUBECONFIG \
+    -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.taints}{"\n"}{end}' \
+    | grep -cv "node-role.kubernetes.io/master" )"
+
+  # wait for all the nodes to be ready
+  kubectl wait --for=condition=Ready node --kubeconfig=$KUBECONFIG --all
+
+  # setting this env prevents ginkg e2e from trying to run provider setup
+  export KUBERNETES_CONFORMANCE_TEST="y"
+  # run the tests
+  (cd "$(go env GOPATH)/src/k8s.io/kubernetes" && ./hack/ginkgo-e2e.sh \
+    '--provider=skeleton' "--num-nodes=${NUM_NODES}" \
+    "--ginkgo.focus=${FOCUS}" "--ginkgo.skip=${SKIP}" \
+    "--report-dir=${ARTIFACTS}" '--disable-log-dump=true')
+
+  unset KUBECONFIG
+  unset KUBERNETES_CONFORMANCE_TEST
+}
+
+# setup kind, build kubernetes, create a cluster, run the e2es
+main() {
+  if [[ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
+    cat <<EOF
+$GOOGLE_APPLICATION_CREDENTIALS is not set.
+Please set this to the path of the service account used to run this script.
+EOF
+    return 2
+  else
+    gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+  fi
+  if [[ -z "$GCP_PROJECT" ]]; then
+    GCP_PROJECT=$(cat ${GOOGLE_APPLICATION_CREDENTIALS} | jq -r .project_id)
+    cat <<EOF
+GCP_PROJECT is not set. Using project_id $GCP_PROJECT
+EOF
+  fi
+  if [[ -z "$GCP_REGION" ]]; then
+    cat <<EOF
+GCP_REGION is not set.
+Please specify which the GCP region to use.
+EOF
+    return 2
+  fi
+
+  # create temp dir and setup cleanup
+  TMP_DIR=$(mktemp -d)
+  trap cleanup EXIT
+  # ensure artifacts exists when not in CI
+  ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
+  export ARTIFACTS
+  mkdir -p "${ARTIFACTS}"
+
+  source "${REPO_ROOT}/hack/ensure-go.sh"
+  source "${REPO_ROOT}/hack/ensure-kind.sh"
+
+  # now build and run the cluster and tests
+  init_image
+  build
+  generate_manifests
+  create_cluster
+  run_tests
+}
+
+main

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GOPATH_BIN="$(go env GOPATH)/bin/"
+MINIMUM_KIND_VERSION=v0.5.1
+
+# Ensure the kind tool exists and is a viable version, or installs it
+verify_kind_version() {
+
+  # If kind is not available on the path, get it
+  if ! [ -x "$(command -v kind)" ]; then
+    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+      echo 'kind not found, installing'
+      if ! [ -d "${GOPATH_BIN}" ]; then
+        mkdir -p "${GOPATH_BIN}"
+      fi
+      curl -sLo "${GOPATH_BIN}/kind" https://github.com/kubernetes-sigs/kind/releases/download/${MINIMUM_KIND_VERSION}/kind-linux-amd64
+      chmod +x "${GOPATH_BIN}/kind"
+    else
+      echo "Missing required binary in path: kind"
+      return 2
+    fi
+  fi
+
+  local kind_version
+  kind_version=$(kind version)
+  if [[ "${MINIMUM_KIND_VERSION}" != $(echo -e "${MINIMUM_KIND_VERSION}\n${kind_version}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
+    cat <<EOF
+Detected kind version: ${kind_version}.
+Requires ${MINIMUM_KIND_VERSION} or greater.
+Please install ${MINIMUM_KIND_VERSION} or later.
+EOF
+    return 2
+  fi
+}
+
+verify_kind_version

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+################################################################################
+# usage: e2e.sh
+#  This program runs the e2e tests.
+################################################################################
+
+set -o nounset
+set -o pipefail
+
+# our exit handler (trap)
+cleanup() {
+  # If Boskos is being used then release the GCP project back to Boskos.
+  [ -z "${BOSKOS_HOST:-}" ] || hack/checkin_account.py
+}
+
+trap cleanup EXIT
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}" || exit 1
+
+# If BOSKOS_HOST is set then acquire an AWS account from Boskos.
+if [ -n "${BOSKOS_HOST:-}" ]; then
+  # Check out the account from Boskos and store the produced environment
+  # variables in a temporary file.
+  account_env_var_file="$(mktemp)"
+  python hack/checkout_account.py 1>"${account_env_var_file}"
+  checkout_account_status="${?}"
+
+  # If the checkout process was a success then load the account's
+  # environment variables into this process.
+  # shellcheck disable=SC1090
+  [ "${checkout_account_status}" = "0" ] && . "${account_env_var_file}"
+
+  # Always remove the account environment variable file. It contains
+  # sensitive information.
+  rm -f "${account_env_var_file}"
+
+  if [ ! "${checkout_account_status}" = "0" ]; then
+    echo "error getting account from boskos" 1>&2
+    exit "${checkout_account_status}"
+  fi
+fi
+
+(cd "${REPO_ROOT}" && hack/ci/e2e-conformance.sh)


### PR DESCRIPTION
Change-Id: I4a32f8bf7f54a86fbd88617e634b2fd8ed6a76a9

```
GCP_PROJECT=my_gcp_project GOOGLE_APPLICATION_CREDENTIALS=$HOME/my-service-account.json hack/ci/e2e-conformance.sh
```

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
We need a CI job that uses CAPG to start a cluster and run some e2e tests. The scripts in this PR can help with that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
