### PR TITLE
Build/Use k8s 1.16.0 image in packer

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -30,6 +30,7 @@ cleanup() {
   echo "cleaning up - checking in boskos account $BOSKOS_RESOURCE_NAME on host $BOSKOS_HOST"
   # If Boskos is being used then release the GCP project back to Boskos.
   hack/checkin_account.py > $ARTIFACTS/boskos.log 2>&1
+  [[ -z ${HEART_BEAT_PID:-} ]] || kill -9 "${HEART_BEAT_PID}"
 }
 
 trap cleanup EXIT
@@ -61,5 +62,6 @@ if [ ! "${checkout_account_status}" = "0" ]; then
 fi
 
 nohup python -u hack/heartbeat_account.py > $ARTIFACTS/boskos.log 2>&1 &
+HEART_BEAT_PID=$(echo $!)
 
 (cd "${REPO_ROOT}" && hack/ci/e2e-conformance.sh)


### PR DESCRIPTION
We currently default to 1.15.4 in sigs.k8s.io/image-builder. Ideally we need to ensure sigs.k8s.io/image-builder is tested with 1.16.0 which it does not seem to yet. So brute forcing to see if it will work.

Why do we need this? we are using k/k latest master e2e conformance tests in the CI jobs and CRD(s) were promoted in 1.16, so a bunch of Conformance tests fail

Change-Id: Ib8fe24c28863216eeea485cce1a670e41de7c15a

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
