### PR TITLE
🐛 Don't try to validate disk size updates

### DIFF
--- a/controllers/gcpmachine_controller.go
+++ b/controllers/gcpmachine_controller.go
@@ -331,12 +331,6 @@ func (r *GCPMachineReconciler) validateUpdate(spec *infrav1.GCPMachineSpec, i *g
 		errs = append(errs, errors.Errorf("instance type cannot be mutated from %q to %q", i.MachineType, spec.InstanceType))
 	}
 
-	// Root Device Size
-	if len(i.Disks) > 0 && spec.RootDeviceSize > 0 && spec.RootDeviceSize != i.Disks[0].InitializeParams.DiskSizeGb {
-		errs = append(errs, errors.Errorf("Root volume size cannot be mutated from %v to %v",
-			i.Disks[0].InitializeParams.DiskSizeGb, spec.RootDeviceSize))
-	}
-
 	// TODO(vincepri): Validate other fields.
 	return errs
 }


### PR DESCRIPTION
InitializeParams is an input-only field, and thus this validation was
causing panics.  In practice we want to prevent machine changes at the
API level, I believe, rather than here.


<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #