### PR TITLE
Build/use gcp cluster-api-provider image explicitly

### DIFF
--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -10,3 +10,4 @@ spec:
       # Change the value of image field below to your controller image URL
       - image: gcr.io/k8s-staging-cluster-api-gcp/cluster-api-gcp-controller:latest
         name: manager
+        imagePullPolicy: Always


### PR DESCRIPTION
So far we have been using the `gcr.io/k8s-staging-cluster-api-gcp/cluster-api-gcp-controller:latest` container image by default. We should build and push an image from the source code into the project specific repo (that we get from boskos) and use that to start the gcp controller in the kind cluster. We should do the same irrespective of whether this is a periodic job or a pre-submit job to ensure that we are testing the exact changes by building the image from the code.

Change-Id: I2d2cc8dd2c6e3ad8808fbf4bc9130e115f00c050

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
