### PR TITLE
✨ Skip cleanup for local development scenario

### DIFF
--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -354,7 +354,10 @@ EOF
 
   # create temp dir and setup cleanup
   TMP_DIR=$(mktemp -d)
-  trap cleanup EXIT
+  SKIP_CLEANUP=${SKIP_CLEANUP:-""}
+  if [[ -z "${SKIP_CLEANUP}" ]]; then
+    trap cleanup EXIT
+  fi
   # ensure artifacts exists when not in CI
   ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
   export ARTIFACTS


### PR DESCRIPTION
Add a `SKIP_CLEANUP` to let the cluster stay alive for help with debugging.

Change-Id: I0c970288b2c0ebabf0cf87255475223550e33fad

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
