### PR TITLE
🐛 Support running alongside other Cluster API pods in the same namespace with leader election enabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,6 +126,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "controller-leader-election-capg",
 		SyncPeriod:         &syncPeriod,
 		Namespace:          watchNamespace,
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently `LeaderElectionID` is set to the default `controller-leader-election-helper`. This causes an issue when several Cluster API pods are deployed in the same namespace. Adding a unique ID per service should resolve this. 
**Which issue(s) this PR fixes** :
Following up on https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/issues/271