### PR TITLE
hack/ci/e2e-conformance.sh: update the kustomize install path

### DIFF
--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -249,7 +249,7 @@ build() {
 # generate manifests needed for creating the GCP cluster to run the tests
 generate_manifests() {
   if ! command -v kustomize >/dev/null 2>&1; then
-    GO111MODULE=on go install sigs.k8s.io/kustomize/v3/cmd/kustomize
+    GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v3
   fi
 
   GCP_PROJECT=$GCP_PROJECT \


### PR DESCRIPTION
**What this PR does / why we need it**:
attempt to fix failures in CI:
https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-cluster-api-provider-gcp#e2e-tests-master
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cluster-api-provider-gcp-make-conformance-master/1181351396365045760/build-log.txt

testing with the updated path works locally.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NONE

/kind failing-test
/priority important-soon
/assign @dims
