### PR TITLE
✨ Allow the ability to configure frontend and backend port for LB

### DIFF
--- a/api/v1alpha2/types.go
+++ b/api/v1alpha2/types.go
@@ -96,6 +96,10 @@ type NetworkSpec struct {
 	// Subnets configuration.
 	// +optional
 	Subnets Subnets `json:"subnets,omitempty"`
+
+	// Allow for configuration of load balancer backend (useful for changing apiserver port)
+	// +optional
+	LoadBalancerBackendPort *int32 `json:"loadBalancerBackendPort,omitempty"`
 }
 
 // APIEndpoint represents a reachable Kubernetes API endpoint.

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -130,6 +130,23 @@ func (s *ClusterScope) Region() string {
 	return s.GCPCluster.Spec.Region
 }
 
+// LoadBalancerFrontendPort returns the loadbalancer frontend if specified
+// in the cluster resource's network configuration.
+func (s *ClusterScope) LoadBalancerFrontendPort() int64 {
+	if s.Cluster.Spec.ClusterNetwork.APIServerPort != nil {
+		return int64(*s.Cluster.Spec.ClusterNetwork.APIServerPort)
+	}
+	return 443
+}
+
+// LoadBalancerBackendPort returns the loadbalancer backend if specified.
+func (s *ClusterScope) LoadBalancerBackendPort() int64 {
+	if s.GCPCluster.Spec.Network.LoadBalancerBackendPort != nil {
+		return int64(*s.GCPCluster.Spec.Network.LoadBalancerBackendPort)
+	}
+	return 6443
+}
+
 // ControlPlaneConfigMapName returns the name of the ConfigMap used to
 // coordinate the bootstrapping of control plane nodes.
 func (s *ClusterScope) ControlPlaneConfigMapName() string {

--- a/cloud/services/compute/firewalls.go
+++ b/cloud/services/compute/firewalls.go
@@ -81,7 +81,7 @@ func (s *Service) getFirewallSpecs() []*compute.Firewall {
 				{
 					IPProtocol: "TCP",
 					Ports: []string{
-						strconv.Itoa(APIServerLoadBalancerBackendPort),
+						strconv.FormatInt(s.scope.LoadBalancerBackendPort(), 10),
 					},
 				},
 			},

--- a/cloud/services/compute/instancegroup.go
+++ b/cloud/services/compute/instancegroup.go
@@ -77,7 +77,7 @@ func (s *Service) GetOrCreateInstanceGroup(zone, name string) (*compute.Instance
 			NamedPorts: []*compute.NamedPort{
 				{
 					Name: "apiserver",
-					Port: 6443,
+					Port: s.scope.LoadBalancerBackendPort(),
 				},
 			},
 		}

--- a/cloud/services/compute/loadbalancers.go
+++ b/cloud/services/compute/loadbalancers.go
@@ -36,8 +36,6 @@ const (
 	APIServerLoadBalancerScheme              = "EXTERNAL"
 	APIServerLoadBalancerIPVersion           = "IPV4"
 	APIServerLoadBalancerBackendPortName     = "apiserver"
-	APIServerLoadBalancerBackendPort         = 6443
-	APIServerLoadBalancerFrontendPortRange   = "443-443"
 )
 
 // ReconcileLoadbalancers reconciles the api server load balancer.
@@ -255,7 +253,7 @@ func (s *Service) getAPIServerHealthCheckSpec() *compute.HealthCheck {
 		Name: fmt.Sprintf("%s-%s", s.scope.Name(), infrav1.APIServerRoleTagValue),
 		Type: APIServerLoadBalancerHealthCheckProtocol,
 		SslHealthCheck: &compute.SSLHealthCheck{
-			Port:              APIServerLoadBalancerBackendPort,
+			Port:              s.scope.LoadBalancerBackendPort(),
 			PortSpecification: "USE_FIXED_PORT",
 		},
 		CheckIntervalSec:   10,
@@ -304,12 +302,13 @@ func (s *Service) getAPIServerIPAddressSpec() *compute.Address {
 }
 
 func (s *Service) getAPIServerForwardingRuleSpec() *compute.ForwardingRule {
+	frontendPortRange := fmt.Sprintf("%d-%d", s.scope.LoadBalancerFrontendPort(), s.scope.LoadBalancerFrontendPort())
 	return &compute.ForwardingRule{
 		Name:                fmt.Sprintf("%s-%s", s.scope.Name(), infrav1.APIServerRoleTagValue),
 		IPAddress:           *s.scope.Network().APIServerAddress,
 		IPProtocol:          APIServerLoadBalancerProtocol,
 		LoadBalancingScheme: APIServerLoadBalancerScheme,
-		PortRange:           APIServerLoadBalancerFrontendPortRange,
+		PortRange:           frontendPortRange,
 		Target:              *s.scope.Network().APIServerTargetProxy,
 	}
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -52,6 +52,11 @@ spec:
                     as described in Auto mode VPC network IP ranges. \n Defaults to
                     true."
                   type: boolean
+                loadBalancerBackendPort:
+                  description: Allow for configuration of load balancer backend (useful
+                    for changing apiserver port)
+                  format: int32
+                  type: integer
                 name:
                   description: Name is the name of the network to be used.
                   type: string


### PR DESCRIPTION
**What this PR does / why we need it**:

Interested to see how everyone feels about this.

This PR will add the ability to pass in ports you wish to use for the front/backends of the LB that gets created by the GCP provider. This was useful for me because I wanted to change the port k8s is listening on from 6443 to 443 all the way through. After some discussion on the cluster-api slack, I moved the frontend port to  respect what might be set in `Cluster.Spec.ClusterNetwork.APIServerPort`. This matches what is supported in the AWS provider.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
