### PR TITLE
🏃Bump kubernetes version in generated examples to 1.16.2

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -27,7 +27,7 @@ envsubst() {
 
 # Cluster.
 export CLUSTER_NAME="${CLUSTER_NAME:-test1}"
-export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.16.1}"
+export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.16.2}"
 
 # Machine settings.
 export CONTROL_PLANE_MACHINE_TYPE="${CONTROL_PLANE_MACHINE_TYPE:-n1-standard-2}"

--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -23,7 +23,7 @@ GCP_PROJECT=${GCP_PROJECT:-""}
 GCP_REGION=${GCP_REGION:-"us-east4"}
 CLUSTER_NAME=${CLUSTER_NAME:-"test1"}
 NETWORK_NAME=${NETWORK_NAME:-"${CLUSTER_NAME}-mynetwork"}
-KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.16.1"}
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.16.2"}
 
 TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -223,7 +223,7 @@ init_image() {
       ln -s $PWD/packer /usr/local/bin/packer
   fi
   (cd "$(go env GOPATH)/src/sigs.k8s.io/image-builder/images/capi" && \
-    sed -i 's/1\.15\.4/1.16.1/' packer/config/kubernetes.json && \
+    sed -i 's/1\.15\.4/1.16.2/' packer/config/kubernetes.json && \
     sed -i 's/1\.15/1.16/' packer/config/kubernetes.json)
   if [[ $EUID -ne 0 ]]; then
     (cd "$(go env GOPATH)/src/sigs.k8s.io/image-builder/images/capi" && \


### PR DESCRIPTION

**What this PR does / why we need it**:
 - Bump the version of Kubernetes in the generate example script from 1.16.1 to 1.16.2
 - Bump the version of Kubernrtes in the conformance test script
 - 1.16.1 has (CVE-2019-11253)


