### PR TITLE
🐛Add NETWORK_NAME when generating example manifests

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -27,6 +27,7 @@ envsubst() {
 
 # Cluster.
 export CLUSTER_NAME="${CLUSTER_NAME:-test1}"
+export NETWORK_NAME="${NETWORK_NAME:-default}"
 export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.16.2}"
 
 # Machine settings.


### PR DESCRIPTION
Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR includes the `NETWORK_NAME` env var and a sane default when generating example manifests. This is needed for easier ramp up for beginners working with the gcp provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #238 
