### PR TITLE
🐛Fix control-plane label to capg-controller-manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: capa-controller-manager
+    control-plane: capg-controller-manager
   name: system
 ---
 apiVersion: apps/v1
@@ -11,16 +11,16 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: capa-controller-manager
+    control-plane: capg-controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: capa-controller-manager
+      control-plane: capg-controller-manager
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: capa-controller-manager
+        control-plane: capg-controller-manager
     spec:
       containers:
       - args:

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -6,7 +6,7 @@ metadata:
     prometheus.io/scheme: https
     prometheus.io/scrape: "true"
   labels:
-    control-plane: capa-controller-manager
+    control-plane: capg-controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -15,4 +15,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: capa-controller-manager
+    control-plane: capg-controller-manager


### PR DESCRIPTION
Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR fixes the label value of `control-plane` from `capa-controller-manager` to `capg-controller-manager`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #237 
