### PR TITLE
:sparkles: Add addresses to machine status

### DIFF
--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/klogr"
 	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1alpha3"
@@ -179,6 +180,11 @@ func (m *MachineScope) SetAnnotation(key, value string) {
 		m.GCPMachine.Annotations = map[string]string{}
 	}
 	m.GCPMachine.Annotations[key] = value
+}
+
+// SetAddresses sets the addresses field on the GCPMachine.
+func (m *MachineScope) SetAddresses(addressList []v1.NodeAddress) {
+	m.GCPMachine.Status.Addresses = addressList
 }
 
 // Close the MachineScope by updating the machine spec, machine status.

--- a/controllers/gcpmachine_controller.go
+++ b/controllers/gcpmachine_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	gcompute "google.golang.org/api/compute/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1alpha3"
@@ -218,6 +219,12 @@ func (r *GCPMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 	// TODO(vincepri): Remove this annotation when clusterctl is no longer relevant.
 	machineScope.SetAnnotation("cluster-api-provider-gcp", "true")
 
+	addrs, err := r.getAddresses(instance)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	machineScope.SetAddresses(addrs)
+
 	switch infrav1.InstanceStatus(instance.Status) {
 	case infrav1.InstanceStatusRunning:
 		machineScope.Info("Machine instance is running", "instance-id", *machineScope.GetInstanceID())
@@ -299,6 +306,28 @@ func (r *GCPMachineReconciler) getOrCreate(scope *scope.MachineScope, computeSvc
 	}
 
 	return instance, nil
+}
+
+func (r *GCPMachineReconciler) getAddresses(instance *gcompute.Instance) ([]v1.NodeAddress, error) {
+	addresses := []v1.NodeAddress{}
+	for _, nic := range instance.NetworkInterfaces {
+		internalAddress := v1.NodeAddress{
+			Type:    v1.NodeInternalIP,
+			Address: nic.NetworkIP,
+		}
+		addresses = append(addresses, internalAddress)
+
+		// If access configs are associated with this nic, dig out the external IP
+		if len(nic.AccessConfigs) > 0 {
+			externalAddress := v1.NodeAddress{
+				Type:    v1.NodeExternalIP,
+				Address: nic.AccessConfigs[0].NatIP,
+			}
+			addresses = append(addresses, externalAddress)
+		}
+	}
+
+	return addresses, nil
 }
 
 func (r *GCPMachineReconciler) reconcileLBAttachment(machineScope *scope.MachineScope, clusterScope *scope.ClusterScope, i *gcompute.Instance) error {


### PR DESCRIPTION
Adding to master after merging in release-0.2.

This PR will add the ability to fish out the internal and external IPs
associated with a gcpmachine resource and populate those values in
`.status.addresses`.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>