### PR TITLE
🐛 Change error message to say gcp/gce instead of ec2

### DIFF
--- a/cloud/services/compute/service.go
+++ b/cloud/services/compute/service.go
@@ -23,7 +23,7 @@ import (
 
 // Service holds a collection of interfaces.
 // The interfaces are broken down like this to group functions together.
-// One alternative is to have a large list of functions from the ec2 client.
+// One alternative is to have a large list of functions from the gcp client.
 type Service struct {
 	scope *scope.ClusterScope
 
@@ -41,7 +41,7 @@ type Service struct {
 	routers         *compute.RoutersService
 }
 
-// NewService returns a new service given the ec2 api client.
+// NewService returns a new service given the gcp api client.
 func NewService(scope *scope.ClusterScope) *Service {
 	return &Service{
 		scope:           scope,

--- a/controllers/gcpmachine_controller.go
+++ b/controllers/gcpmachine_controller.go
@@ -198,7 +198,7 @@ func (r *GCPMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 	// Set an error message if we couldn't find the instance.
 	if instance == nil {
 		machineScope.SetErrorReason(capierrors.UpdateMachineError)
-		machineScope.SetErrorMessage(errors.New("EC2 instance cannot be found"))
+		machineScope.SetErrorMessage(errors.New("GCE instance cannot be found"))
 		return reconcile.Result{}, nil
 	}
 
@@ -233,7 +233,7 @@ func (r *GCPMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 		machineScope.Info("Machine instance is pending", "instance-id", *machineScope.GetInstanceID())
 	default:
 		machineScope.SetErrorReason(capierrors.UpdateMachineError)
-		machineScope.SetErrorMessage(errors.Errorf("EC2 instance state %q is unexpected", instance.Status))
+		machineScope.SetErrorMessage(errors.Errorf("GCE instance state %q is unexpected", instance.Status))
 	}
 
 	if err := r.reconcileLBAttachment(machineScope, clusterScope, instance); err != nil {
@@ -282,7 +282,7 @@ func (r *GCPMachineReconciler) reconcileDelete(machineScope *scope.MachineScope,
 	return reconcile.Result{}, nil
 }
 
-// findInstance queries the EC2 apis and retrieves the instance if it exists, returns nil otherwise.
+// findInstance queries the GCP apis and retrieves the instance if it exists, returns nil otherwise.
 func (r *GCPMachineReconciler) findInstance(scope *scope.MachineScope, computeSvc *compute.Service) (*gcompute.Instance, error) {
 	instance, err := computeSvc.InstanceIfExists(scope)
 	if err != nil {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
- replace the word `EC2` in error message and comments with `GCE` or `GCP`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #243 
