### PR TITLE
🏃 Replace names with aws to say gcp

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -12,16 +12,16 @@ resources:
 #patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_awsmachines.yaml
-#- patches/webhook_in_awsclusters.yaml
-#- patches/webhook_in_awsmachinetemplates.yaml
+#- patches/webhook_in_gcpmachines.yaml
+#- patches/webhook_in_gcpclusters.yaml
+#- patches/webhook_in_gcpmachinetemplates.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_awsmachines.yaml
-#- patches/cainjection_in_awsclusters.yaml
-#- patches/cainjection_in_awsmachinetemplates.yaml
+#- patches/cainjection_in_gcpmachines.yaml
+#- patches/cainjection_in_gcpclusters.yaml
+#- patches/cainjection_in_gcpmachinetemplates.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/crd/patches/cainjection_in_gcpclusters.yaml
+++ b/config/crd/patches/cainjection_in_gcpclusters.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: awsclusters.infrastructure.cluster.x-k8s.io
+  name: gcpclusters.infrastructure.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_gcpmachines.yaml
+++ b/config/crd/patches/cainjection_in_gcpmachines.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: awsmachines.infrastructure.cluster.x-k8s.io
+  name: gcpmachines.infrastructure.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_gcpmachinetemplates.yaml
+++ b/config/crd/patches/cainjection_in_gcpmachinetemplates.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: awsmachinetemplates.infrastructure.cluster.x-k8s.io
+  name: gcpmachinetemplates.infrastructure.cluster.x-k8s.io

--- a/config/crd/patches/webhook_in_gcpclusters.yaml
+++ b/config/crd/patches/webhook_in_gcpclusters.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: awsmachinetemplates.infrastructure.cluster.x-k8s.io
+  name: gcpclusters.infrastructure.cluster.x-k8s.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/crd/patches/webhook_in_gcpmachines.yaml
+++ b/config/crd/patches/webhook_in_gcpmachines.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: awsclusters.infrastructure.cluster.x-k8s.io
+  name: gcpmachines.infrastructure.cluster.x-k8s.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/crd/patches/webhook_in_gcpmachinetemplates.yaml
+++ b/config/crd/patches/webhook_in_gcpmachinetemplates.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: awsmachines.infrastructure.cluster.x-k8s.io
+  name: gcpmachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   conversion:
     strategy: Webhook


### PR DESCRIPTION

**What this PR does / why we need it**:
Some names of file and resources said `aws` instead of saying `gcp`

