### PR TITLE
✨ Add printer columns for gcpcluster and gcpmachine

### DIFF
--- a/api/v1alpha3/gcpcluster_types.go
+++ b/api/v1alpha3/gcpcluster_types.go
@@ -60,6 +60,10 @@ type GCPClusterStatus struct {
 // +kubebuilder:resource:path=gcpclusters,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this GCPCluster belongs"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for GCE instances"
+// +kubebuilder:printcolumn:name="Network",type="string",JSONPath=".spec.network.name",description="GCP network the cluster is using"
+// +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".status.apiEndpoints[0]",description="API Endpoint",priority=1
 
 // GCPCluster is the Schema for the gcpclusters API
 type GCPCluster struct {

--- a/api/v1alpha3/gcpmachine_types.go
+++ b/api/v1alpha3/gcpmachine_types.go
@@ -142,6 +142,11 @@ type GCPMachineStatus struct {
 // +kubebuilder:resource:path=gcpmachines,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this GCPMachine belongs"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.instanceState",description="GCE instance state"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
+// +kubebuilder:printcolumn:name="InstanceID",type="string",JSONPath=".spec.providerID",description="GCE instance ID"
+// +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this GCPMachine"
 
 // GCPMachine is the Schema for the gcpmachines API
 type GCPMachine struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -6,6 +6,24 @@ metadata:
   creationTimestamp: null
   name: gcpclusters.infrastructure.cluster.x-k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+    description: Cluster to which this GCPCluster belongs
+    name: Cluster
+    type: string
+  - JSONPath: .status.ready
+    description: Cluster infrastructure is ready for GCE instances
+    name: Ready
+    type: string
+  - JSONPath: .spec.network.name
+    description: GCP network the cluster is using
+    name: Network
+    type: string
+  - JSONPath: .status.apiEndpoints[0]
+    description: API Endpoint
+    name: Endpoint
+    priority: 1
+    type: string
   group: infrastructure.cluster.x-k8s.io
   names:
     categories:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
@@ -6,6 +6,27 @@ metadata:
   creationTimestamp: null
   name: gcpmachines.infrastructure.cluster.x-k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+    description: Cluster to which this GCPMachine belongs
+    name: Cluster
+    type: string
+  - JSONPath: .status.instanceState
+    description: GCE instance state
+    name: State
+    type: string
+  - JSONPath: .status.ready
+    description: Machine ready status
+    name: Ready
+    type: string
+  - JSONPath: .spec.providerID
+    description: GCE instance ID
+    name: InstanceID
+    type: string
+  - JSONPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+    description: Machine object which owns with this GCPMachine
+    name: Machine
+    type: string
   group: infrastructure.cluster.x-k8s.io
   names:
     categories:


### PR DESCRIPTION

**What this PR does / why we need it**:
Show more details about `gcpcluster` as shown in the following example
```
NAME            CLUSTER         READY   NETWORK
cluster-test1   cluster-test1   true    default
```
and `gcpmachine` as shown in the following example
```
NAME                           CLUSTER         STATE     READY   INSTANCEID                             MACHINE
cluster-test1-controlplane-0   cluster-test1   RUNNING   true    gce://gcp/us-east4-a/cluster-test1-controlplane-0   cluster-test1-controlplane-0
cluster-test1-controlplane-1   cluster-test1   RUNNING   true    gce://gcp/us-east4-b/cluster-test1-controlplane-1   cluster-test1-controlplane-1
cluster-test1-controlplane-2   cluster-test1   RUNNING   true    gce://gcp/us-east4-c/cluster-test1-controlplane-2   cluster-test1-controlplane-2
```
