### PR TITLE
Automated cherry pick of #248: work with pod utils - fix go/src directory location

### DIFF
--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -234,7 +234,7 @@ init_image() {
     # Add a user for ansible to work properly
     groupadd -r packer && useradd -m -s /bin/bash -r -g packer packer
     # use the packer user to run the build
-    su - packer -c "bash -c 'cd /go/src/sigs.k8s.io/image-builder/images/capi && GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS make build-gce-default'"
+    su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS make build-gce-default'"
   fi
 }
 


### PR DESCRIPTION
Cherry pick of #248 on release-0.2.

#248: work with pod utils - fix go/src directory location

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.