### PR TITLE
generate: don't concat machinedeployment output

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -99,7 +99,7 @@ kustomize build "${SOURCE_DIR}/controlplane" | envsubst > "${CONTROLPLANE_GENERA
 echo "Generated ${CONTROLPLANE_GENERATED_FILE}"
 
 # Generate machinedeployment resources.
-kustomize build "${SOURCE_DIR}/machinedeployment" | envsubst >> "${MACHINEDEPLOYMENT_GENERATED_FILE}"
+kustomize build "${SOURCE_DIR}/machinedeployment" | envsubst > "${MACHINEDEPLOYMENT_GENERATED_FILE}"
 echo "Generated ${MACHINEDEPLOYMENT_GENERATED_FILE}"
 
 # Generate Cluster API provider components file.


### PR DESCRIPTION
**What this PR does / why we need it**:
this change brings the generation of machinedeployment inline with generation of the other assets (cluster, controlplane)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
