### PR TITLE
⚠️Rename ErrorMessage and ErrorReason to FailureMessage and FailureReason

### DIFF
--- a/api/v1alpha3/gcpmachine_types.go
+++ b/api/v1alpha3/gcpmachine_types.go
@@ -99,7 +99,7 @@ type GCPMachineStatus struct {
 	// +optional
 	InstanceStatus *InstanceStatus `json:"instanceState,omitempty"`
 
-	// ErrorReason will be set in the event that there is a terminal problem
+	// FailureReason will be set in the event that there is a terminal problem
 	// reconciling the Machine and will contain a succinct value suitable
 	// for machine interpretation.
 	//
@@ -116,9 +116,9 @@ type GCPMachineStatus struct {
 	// can be added as events to the Machine object and/or logged in the
 	// controller's output.
 	// +optional
-	ErrorReason *errors.MachineStatusError `json:"errorReason,omitempty"`
+	FailureReason *errors.MachineStatusError `json:"failureReason,omitempty"`
 
-	// ErrorMessage will be set in the event that there is a terminal problem
+	// FailureMessage will be set in the event that there is a terminal problem
 	// reconciling the Machine and will contain a more verbose string suitable
 	// for logging and human consumption.
 	//
@@ -135,7 +135,7 @@ type GCPMachineStatus struct {
 	// can be added as events to the Machine object and/or logged in the
 	// controller's output.
 	// +optional
-	ErrorMessage *string `json:"errorMessage,omitempty"`
+	FailureMessage *string `json:"failureMessage,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -301,13 +301,13 @@ func (in *GCPMachineStatus) DeepCopyInto(out *GCPMachineStatus) {
 		*out = new(InstanceStatus)
 		**out = **in
 	}
-	if in.ErrorReason != nil {
-		in, out := &in.ErrorReason, &out.ErrorReason
+	if in.FailureReason != nil {
+		in, out := &in.FailureReason, &out.FailureReason
 		*out = new(errors.MachineStatusError)
 		**out = **in
 	}
-	if in.ErrorMessage != nil {
-		in, out := &in.ErrorMessage, &out.ErrorMessage
+	if in.FailureMessage != nil {
+		in, out := &in.FailureMessage, &out.FailureMessage
 		*out = new(string)
 		**out = **in
 	}

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -164,14 +164,14 @@ func (m *MachineScope) SetReady() {
 	m.GCPMachine.Status.Ready = true
 }
 
-// SetErrorMessage sets the GCPMachine status error message.
-func (m *MachineScope) SetErrorMessage(v error) {
-	m.GCPMachine.Status.ErrorMessage = pointer.StringPtr(v.Error())
+// SetFailureMessage sets the GCPMachine status failure message.
+func (m *MachineScope) SetFailureMessage(v error) {
+	m.GCPMachine.Status.FailureMessage = pointer.StringPtr(v.Error())
 }
 
-// SetErrorReason sets the GCPMachine status error reason.
-func (m *MachineScope) SetErrorReason(v capierrors.MachineStatusError) {
-	m.GCPMachine.Status.ErrorReason = &v
+// SetFailureReason sets the GCPMachine status failure reason.
+func (m *MachineScope) SetFailureReason(v capierrors.MachineStatusError) {
+	m.GCPMachine.Status.FailureReason = &v
 }
 
 // SetAnnotation sets a key value annotation on the GCPMachine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
@@ -148,27 +148,27 @@ spec:
                 - type
                 type: object
               type: array
-            errorMessage:
-              description: "ErrorMessage will be set in the event that there is a
-                terminal problem reconciling the Machine and will contain a more verbose
-                string suitable for logging and human consumption. \n This field should
-                not be set for transitive errors that a controller faces that are
-                expected to be fixed automatically over time (like service outages),
-                but instead indicate that something is fundamentally wrong with the
-                Machine's spec or the configuration of the controller, and that manual
-                intervention is required. Examples of terminal errors would be invalid
-                combinations of settings in the spec, values that are unsupported
-                by the controller, or the responsible controller itself being critically
-                misconfigured. \n Any transient errors that occur during the reconciliation
-                of Machines can be added as events to the Machine object and/or logged
-                in the controller's output."
+            failureMessage:
+              description: "FailureMessage will be set in the event that there is
+                a terminal problem reconciling the Machine and will contain a more
+                verbose string suitable for logging and human consumption. \n This
+                field should not be set for transitive errors that a controller faces
+                that are expected to be fixed automatically over time (like service
+                outages), but instead indicate that something is fundamentally wrong
+                with the Machine's spec or the configuration of the controller, and
+                that manual intervention is required. Examples of terminal errors
+                would be invalid combinations of settings in the spec, values that
+                are unsupported by the controller, or the responsible controller itself
+                being critically misconfigured. \n Any transient errors that occur
+                during the reconciliation of Machines can be added as events to the
+                Machine object and/or logged in the controller's output."
               type: string
-            errorReason:
-              description: "ErrorReason will be set in the event that there is a terminal
-                problem reconciling the Machine and will contain a succinct value
-                suitable for machine interpretation. \n This field should not be set
-                for transitive errors that a controller faces that are expected to
-                be fixed automatically over time (like service outages), but instead
+            failureReason:
+              description: "FailureReason will be set in the event that there is a
+                terminal problem reconciling the Machine and will contain a succinct
+                value suitable for machine interpretation. \n This field should not
+                be set for transitive errors that a controller faces that are expected
+                to be fixed automatically over time (like service outages), but instead
                 indicate that something is fundamentally wrong with the Machine's
                 spec or the configuration of the controller, and that manual intervention
                 is required. Examples of terminal errors would be invalid combinations

--- a/controllers/gcpmachine_controller.go
+++ b/controllers/gcpmachine_controller.go
@@ -166,7 +166,7 @@ func (r *GCPMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reter
 func (r *GCPMachineReconciler) reconcile(ctx context.Context, machineScope *scope.MachineScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
 	machineScope.Info("Reconciling GCPMachine")
 	// If the GCPMachine is in an error state, return early.
-	if machineScope.GCPMachine.Status.ErrorReason != nil || machineScope.GCPMachine.Status.ErrorMessage != nil {
+	if machineScope.GCPMachine.Status.FailureReason != nil || machineScope.GCPMachine.Status.FailureMessage != nil {
 		machineScope.Info("Error state detected, skipping reconciliation")
 		return reconcile.Result{}, nil
 	}
@@ -195,10 +195,10 @@ func (r *GCPMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 		return reconcile.Result{}, err
 	}
 
-	// Set an error message if we couldn't find the instance.
+	// Set a failure message if we couldn't find the instance.
 	if instance == nil {
-		machineScope.SetErrorReason(capierrors.UpdateMachineError)
-		machineScope.SetErrorMessage(errors.New("GCE instance cannot be found"))
+		machineScope.SetFailureReason(capierrors.UpdateMachineError)
+		machineScope.SetFailureMessage(errors.New("GCE instance cannot be found"))
 		return reconcile.Result{}, nil
 	}
 
@@ -232,8 +232,8 @@ func (r *GCPMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 	case infrav1.InstanceStatusProvisioning, infrav1.InstanceStatusStaging:
 		machineScope.Info("Machine instance is pending", "instance-id", *machineScope.GetInstanceID())
 	default:
-		machineScope.SetErrorReason(capierrors.UpdateMachineError)
-		machineScope.SetErrorMessage(errors.Errorf("GCE instance state %q is unexpected", instance.Status))
+		machineScope.SetFailureReason(capierrors.UpdateMachineError)
+		machineScope.SetFailureMessage(errors.Errorf("GCE instance state %q is unexpected", instance.Status))
 	}
 
 	if err := r.reconcileLBAttachment(machineScope, clusterScope, instance); err != nil {

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -110,6 +110,7 @@ echo "Generated ${MACHINEDEPLOYMENT_GENERATED_FILE}"
 # Generate Cluster API provider components file.
 CAPI_BRANCH=${CAPI_BRANCH:-"master"}
 if [[ ${CAPI_BRANCH} == "stable" ]]; then
+    # TODO: Fix the version once the first v0.3.x is released.
   curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.2.7/cluster-api-components.yaml > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
   echo "Downloaded ${COMPONENTS_CLUSTER_API_GENERATED_FILE} from cluster-api stable branch - v0.2.7"
 else


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Renames the `ErrorMessage` and `ErrorReason` fields to `FailureMessage` and `FailureReason` in 
`GCPMachineStatus`.

**Which issue(s) this PR fixes** :
Fixes #256 
