### PR TITLE
 ⚠️ Rename cert-manager API group from certmanager.k8s.io to cert-manager.io

### DIFF
--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,6 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: certmanager.k8s.io/v1alpha2
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,16 +8,16 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: certmanager.k8s.io/v1alpha2
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
-  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  name: serving-cert # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
   # $(SERVICENAME) and $(NAMESPACE) will be substituted by kustomize
   commonName: $(SERVICENAME).$(NAMESPACE).svc
   dnsNames:
-  - $(SERVICENAME).$(NAMESPACE).svc.cluster.local
+    - $(SERVICENAME).$(NAMESPACE).svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,26 +1,26 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- certificate.yaml
+  - certificate.yaml
 # the following config is for teaching kustomize how to do var substitution
 vars:
-- name: NAMESPACE # namespace of the service and the certificate CR
-  objref:
-    kind: Service
-    version: v1
-    name: webhook-service
-  fieldref:
-    fieldpath: metadata.namespace
-- name: CERTIFICATENAME
-  objref:
-    kind: Certificate
-    group: certmanager.k8s.io
-    version: v1alpha2
-    name: serving-cert # this name should match the one in certificate.yaml
-- name: SERVICENAME
-  objref:
-    kind: Service
-    version: v1
-    name: webhook-service
+  - name: NAMESPACE # namespace of the service and the certificate CR
+    objref:
+      kind: Service
+      version: v1
+      name: webhook-service
+    fieldref:
+      fieldpath: metadata.namespace
+  - name: CERTIFICATENAME
+    objref:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1alpha2
+      name: serving-cert # this name should match the one in certificate.yaml
+  - name: SERVICENAME
+    objref:
+      kind: Service
+      version: v1
+      name: webhook-service
 configurations:
-- kustomizeconfig.yaml
+  - kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,16 +1,16 @@
 # This configuration is for teaching kustomize how to update name ref and var substitution
 nameReference:
-- kind: Issuer
-  group: certmanager.k8s.io
-  fieldSpecs:
-  - kind: Certificate
-    group: certmanager.k8s.io
-    path: spec/issuerRef/name
+  - kind: Issuer
+    group: cert-manager.io
+    fieldSpecs:
+      - kind: Certificate
+        group: cert-manager.io
+        path: spec/issuerRef/name
 
 varReference:
-- kind: Certificate
-  group: certmanager.k8s.io
-  path: spec/commonName
-- kind: Certificate
-  group: certmanager.k8s.io
-  path: spec/dnsNames
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/commonName
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/dnsNames

--- a/config/crd/patches/cainjection_in_gcpclusters.yaml
+++ b/config/crd/patches/cainjection_in_gcpclusters.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: gcpclusters.infrastructure.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_gcpmachines.yaml
+++ b/config/crd/patches/cainjection_in_gcpmachines.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: gcpmachines.infrastructure.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_gcpmachinetemplates.yaml
+++ b/config/crd/patches/cainjection_in_gcpmachinetemplates.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: gcpmachinetemplates.infrastructure.cluster.x-k8s.io

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATENAME)
+    cert-manager.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATENAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATENAME)
+    cert-manager.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATENAME)


### PR DESCRIPTION
**What this PR does / why we need it**:
 - Rename cert-manager API group from certmanager.k8s.io to cert-manager.io to be compatible with cert-manager
 
