### PR TITLE
:running: Exclude pprof lint warning in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,9 +19,11 @@ linters:
   disable-all: true
   # Run with --fast=false for more extensive checks
   fast: true
-issue:
+issues:
   max-same-issues: 0
   max-per-linter: 0
+  exclude:
+    - "G108: Profiling endpoint is automatically exposed on /debug/pprof"
 run:
   deadline: 4m
   skip-files:

--- a/main.go
+++ b/main.go
@@ -19,11 +19,9 @@ package main
 import (
 	"flag"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"time"
-
-	//nolint:gosec
-	_ "net/http/pprof"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Follow up to #268 
