### PR TITLE
:running: [0.2] Switch Kubernetes CI URL

### DIFF
--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -283,7 +283,8 @@ generate_manifests() {
 
 # fix manifests to use k/k from CI
 fix_manifests() {
-  CI_VERSION=${CI_VERSION:-$(curl -sSL https://dl.k8s.io/ci/latest-green.txt)}
+  # TODO: revert to https://dl.k8s.io/ci/latest-green.txt once https://github.com/kubernetes/release/issues/897 is fixed.
+  CI_VERSION=${CI_VERSION:-$(curl -sSL https://dl.k8s.io/ci/k8s-master.txt)}
   echo "Overriding Kubernetes version to : ${CI_VERSION}"
   sed -i 's|kubernetesVersion: .*|kubernetesVersion: "ci/'${CI_VERSION}'"|' examples/_out/controlplane.yaml
   sed -i 's|CI_VERSION=.*|CI_VERSION='$CI_VERSION'|' examples/_out/controlplane.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the URL we use for the latest Kubernetes CI artifacts because of
a race condition in the old URL that sporadically resulted in flakey
tests because the container images were sometimes missing when the tests
ran.

(cherry picked from commit ccdb40f32465c19df173bfad6b0382ae70c73e26)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
