### PR TITLE
:running: [ci-conformance] Fix kustomize template to remove ami reference

### DIFF
--- a/templates/kustomizeversions.yaml
+++ b/templates/kustomizeversions.yaml
@@ -72,16 +72,6 @@ spec:
 
         echo "$LINE_SEPARATOR"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: GCPMachineTemplate
-metadata:
-  name: "${CLUSTER_NAME}-control-plane"
-spec:
-  template:
-    spec:
-      ami:
-        id: ${IMAGE_ID}
----
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
@@ -154,13 +144,3 @@ spec:
             echo "kubelet version: " $(kubelet --version)
 
             echo "$LINE_SEPARATOR"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: GCPMachineTemplate
-metadata:
-  name: ${CLUSTER_NAME}-md-0
-spec:
-  template:
-    spec:
-      ami:
-        id: ${IMAGE_ID}


### PR DESCRIPTION
**What this PR does / why we need it**:
Conformance tests against k8s master are currently broken, this fixes errors related to the kustomize templating.

