### PR TITLE
:running: [ci-conformance] Fix kustomize template to better handle envsubst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ BIN_DIR := bin
 
 # Binaries.
 CLUSTERCTL := $(BIN_DIR)/clusterctl
-KUSTOMIZE := $(abspath $(TOOLS_BIN_DIR)/kustomize)
+KUSTOMIZE := $(TOOLS_BIN_DIR)/kustomize
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen
 ENVSUBST := $(TOOLS_BIN_DIR)/envsubst
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
@@ -52,14 +52,14 @@ RELEASE_NOTES_BIN := bin/release-notes
 RELEASE_NOTES := $(TOOLS_DIR)/$(RELEASE_NOTES_BIN)
 
 # Define Docker related variables. Releases should modify and double check these vars.
-GCP_PROJECT ?= $(shell gcloud config get-value project)
+export GCP_PROJECT ?= $(shell gcloud config get-value project)
 REGISTRY ?= gcr.io/$(GCP_PROJECT)
 STAGING_REGISTRY := gcr.io/k8s-staging-cluster-api-gcp
 PROD_REGISTRY := us.gcr.io/k8s-artifacts-prod/cluster-api-gcp
 IMAGE_NAME ?= cluster-api-gcp-controller
-CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= dev
-ARCH ?= amd64
+export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
+export TAG ?= dev
+export ARCH ?= amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
 # Allow overriding manifest generation destination directory
@@ -267,23 +267,23 @@ release-notes: $(RELEASE_NOTES)
 
 # This is used in the get-kubeconfig call below in the create-cluster target. It may be overridden by the
 # e2e-conformance.sh script, which is why we need it as a variable here.
+
 CLUSTER_NAME ?= test1
 
-.PHONY: create-cluster
-create-cluster: $(CLUSTERCTL) $(KUSTOMIZE) $(ENVSUBST) ## Create a development Kubernetes cluster on GCP in a KIND management cluster.
+.PHONY: create-management-cluster
+create-management-cluster: $(KUSTOMIZE) $(ENVSUBST)
+	## Create kind management cluster.
 	kind create cluster --name=clusterapi
-	@if [ ! -z "${LOAD_IMAGE}" ]; then \
-		echo "loading ${LOAD_IMAGE} into kind cluster ..." && \
-		kind --name="clusterapi" load docker-image "${LOAD_IMAGE}"; \
-	fi
+
 	# Install cert manager and wait for availability
 	kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v0.11.1/cert-manager.yaml
 	kubectl wait --for=condition=Available --timeout=5m apiservice v1beta1.webhook.cert-manager.io
 
 	# Deploy CAPI
-	kubectl apply -f https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.2/cluster-api-components.yaml
+	kubectl apply -f https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.3/cluster-api-components.yaml
 
 	# Deploy CAPG
+	kind load docker-image $(CONTROLLER_IMG)-$(ARCH):$(TAG) --name=clusterapi
 	$(KUSTOMIZE) build config | $(ENVSUBST) | kubectl apply -f -
 
 	# Wait for CAPI pods
@@ -291,21 +291,40 @@ create-cluster: $(CLUSTERCTL) $(KUSTOMIZE) $(ENVSUBST) ## Create a development K
 	kubectl wait --for=condition=Ready --timeout=5m -n capi-kubeadm-bootstrap-system pod -l cluster.x-k8s.io/provider=bootstrap-kubeadm
 	kubectl wait --for=condition=Ready --timeout=5m -n capi-kubeadm-control-plane-system pod -l cluster.x-k8s.io/provider=control-plane-kubeadm
 
-	# Wait for CAPG pod
-	kubectl wait --for=condition=Ready --timeout=5m -n capg-system pod -l control-plane=capg-controller-manager
+	# Wait for CAPG pods
+	kubectl wait --for=condition=Ready --timeout=5m -n capg-system pod -l cluster.x-k8s.io/provider=infrastructure-gcp
 
-	# Create Cluster.
+	# required sleep for when creating management and workload cluster simultaneously
 	sleep 10
-	kustomize build templates | $(ENVSUBST) | kubectl apply -f -
+	@echo 'Set kubectl context to the kind management cluster by running "kubectl config set-context kind-clusterapi"'
+
+.PHONY: create-workload-cluster
+create-workload-cluster: $(KUSTOMIZE) $(ENVSUBST)
+	# Create workload Cluster.
+	$(KUSTOMIZE) build templates | $(ENVSUBST) | kubectl apply -f -
 
 	# Wait for the kubeconfig to become available.
-	timeout 300 bash -c "while ! kubectl get secrets | grep $(CLUSTER_NAME)-kubeconfig; do sleep 1; done"
+	timeout 5m bash -c "while ! kubectl get secrets | grep $(CLUSTER_NAME)-kubeconfig; do sleep 1; done"
 	# Get kubeconfig and store it locally.
 	kubectl get secrets $(CLUSTER_NAME)-kubeconfig -o json | jq -r .data.value | base64 --decode > ./kubeconfig
-	timeout 600 bash -c "while ! kubectl --kubeconfig=./kubeconfig get nodes | grep master; do sleep 1; done"
+	timeout 15m bash -c "while ! kubectl --kubeconfig=./kubeconfig get nodes | grep master; do sleep 1; done"
 
 	# Deploy calico
 	kubectl --kubeconfig=./kubeconfig apply -f https://docs.projectcalico.org/manifests/calico.yaml
+
+	@echo 'run "kubectl --kubeconfig=./kubeconfig ..." to work with the new target cluster'
+
+.PHONY: create-cluster
+create-cluster: create-management-cluster create-workload-cluster ## Create a development Kubernetes cluster on GCP in a KIND management cluster.
+
+.PHONY: delete-workload-cluster
+delete-workload-cluster: ## Deletes the example workload Kubernetes cluster
+	@echo 'Your GCP resources will now be deleted, this can take up to 20 minutes'
+	kubectl delete cluster $(CLUSTER_NAME)
+
+.PHONY: delete-cluster
+delete-cluster: delete-workload-cluster  ## Deletes the example kind cluster "clusterapi"
+	kind delete cluster --name=clusterapi
 
 .PHONY: kind-reset
 kind-reset: ## Destroys the "clusterapi" kind cluster.

--- a/controllers/gcpcluster_controller.go
+++ b/controllers/gcpcluster_controller.go
@@ -50,7 +50,7 @@ func (r *GCPClusterReconciler) SetupWithManager(mgr ctrl.Manager, options contro
 		WithOptions(options).
 		For(&infrav1.GCPCluster{}).
 		Watches(
-			&source.Kind{Type: &infrav1.GCPCluster{}},
+			&source.Kind{Type: &infrav1.GCPMachine{}},
 			&handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(r.GCPMachineToGCPCluster)},
 		).
 		WithEventFilter(pausePredicates).

--- a/hack/ensure-kustomize.sh
+++ b/hack/ensure-kustomize.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GOPATH_BIN="$(go env GOPATH)/bin/"
+MINIMUM_KUSTOMIZE_VERSION=3.1.0
+
+# Ensure the kustomize tool exists and is a viable version, or installs it
+verify_kustomize_version() {
+
+  # If kustomize is not available on the path, get it
+  if ! [ -x "$(command -v kustomize)" ]; then
+    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+      echo 'kustomize not found, installing'
+      if ! [ -d "${GOPATH_BIN}" ]; then
+        mkdir -p "${GOPATH_BIN}"
+      fi
+      curl -sLo "${GOPATH_BIN}/kustomize" https://github.com/kubernetes-sigs/kustomize/releases/download/v${MINIMUM_KUSTOMIZE_VERSION}/kustomize_${MINIMUM_KUSTOMIZE_VERSION}_linux_amd64
+      chmod +x "${GOPATH_BIN}/kustomize"
+    else
+      echo "Missing required binary in path: kustomize"
+      return 2
+    fi
+  fi
+
+  local kustomize_version
+  kustomize_version=$(kustomize version)
+  if [[ "${MINIMUM_KUSTOMIZE_VERSION}" != $(echo -e "${MINIMUM_KUSTOMIZE_VERSION}\n${kustomize_version}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
+    cat <<EOF
+Detected kustomize version: ${kustomize_version}.
+Requires ${MINIMUM_KUSTOMIZE_VERSION} or greater.
+Please install ${MINIMUM_KUSTOMIZE_VERSION} or later.
+EOF
+    return 2
+  fi
+}
+
+verify_kustomize_version

--- a/templates/kustomizeversions.yaml
+++ b/templates/kustomizeversions.yaml
@@ -4,143 +4,24 @@ metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   kubeadmConfigSpec:
+    useExperimentalRetryJoin: true
     clusterConfiguration:
-      kubernetesVersion: "ci/latest"
-    preKubeadmCommands:
-    - bash -c /tmp/kubeadm-bootstrap.sh
-    files:
-    - path: /tmp/kubeadm-bootstrap.sh
-      owner: "root:root"
-      permissions: "0744"
-      content: |
-        #!/bin/bash
-
-        set -o nounset
-        set -o pipefail
-        set -o errexit
-
-        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-        GSUTIL=gsutil
-        if ! command -v ${GSUTIL} > /dev/null; then
-          curl -sSL https://sdk.cloud.google.com > /tmp/gcl && bash /tmp/gcl --install-dir=~/gcloud --disable-prompts > /dev/null 2>&1
-          GSUTIL=~/gcloud/google-cloud-sdk/bin/gsutil
-        fi
-        ${GSUTIL} version
-
-        # This test installs debian packages that are a result of the CI and release builds.
-        # It runs '... --version' commands to verify that the binaries are correctly installed
-        # and finally uninstalls the packages.
-        # For the release packages it tests all versions in the support skew.
-
-        LINE_SEPARATOR="*************************************************"
-        echo "$LINE_SEPARATOR"
-
-        CI_VERSION=${CI_VERSION:-""}
-        if [[ "${CI_VERSION}" != "" ]]; then
-          CI_DIR=/tmp/k8s-ci
-          mkdir -p $CI_DIR
-          CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
-          declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-          PACKAGE_EXT="deb"
-          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-          CONTAINER_EXT="tar"
-
-          echo "* testing CI version $CI_VERSION"
-
-          for CI_PACKAGE in "${PACKAGES_TO_TEST[@]}"; do
-          echo "* downloading package: $CI_URL/$CI_PACKAGE.$PACKAGE_EXT"
-          ${GSUTIL} cp "$CI_URL/$CI_PACKAGE.$PACKAGE_EXT" "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT"
-          ${SUDO} dpkg -i "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT" || echo "* ignoring expected 'dpkg -i' result"
-          done
-
-          for CI_CONTAINER in "${CONTAINERS_TO_TEST[@]}"; do
-          echo "* downloading package: $CI_URL/$CI_CONTAINER.$CONTAINER_EXT"
-          ${GSUTIL} cp "$CI_URL/$CI_CONTAINER.$CONTAINER_EXT" "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT"
-          ${SUDO} ctr -n k8s.io images import "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
-          ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" k8s.gcr.io/$CI_CONTAINER:"${CI_VERSION//+/_}"
-          ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" gcr.io/kubernetes-ci-images/$CI_CONTAINER:"${CI_VERSION//+/_}"
-          done
-        fi
-
-        echo "* checking binary versions"
-
-        echo "ctr version: " $(ctr version)
-        echo "kubeadm version: " $(kubeadm version -o=short)
-        echo "kubectl version: " $(kubectl version --client=true --short=true)
-        echo "kubelet version: " $(kubelet --version)
-
-        echo "$LINE_SEPARATOR"
+      kubernetesVersion: "ci/${CI_VERSION}"
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-kind: KubeadmConfigTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: GCPMachineTemplate
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
     spec:
-      preKubeadmCommands:
-        - bash -c /tmp/kubeadm-bootstrap.sh
-      files:
-        - path: /tmp/kubeadm-bootstrap.sh
-          owner: "root:root"
-          permissions: "0744"
-          content: |
-            #!/bin/bash
-
-            set -o nounset
-            set -o pipefail
-            set -o errexit
-
-            [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-            GSUTIL=gsutil
-            if ! command -v ${GSUTIL} > /dev/null; then
-              curl -sSL https://sdk.cloud.google.com > /tmp/gcl && bash /tmp/gcl --install-dir=~/gcloud --disable-prompts > /dev/null 2>&1
-              GSUTIL=~/gcloud/google-cloud-sdk/bin/gsutil
-            fi
-            ${GSUTIL} version
-
-            # This test installs debian packages that are a result of the CI and release builds.
-            # It runs '... --version' commands to verify that the binaries are correctly installed
-            # and finally uninstalls the packages.
-            # For the release packages it tests all versions in the support skew.
-
-            LINE_SEPARATOR="*************************************************"
-            echo "$LINE_SEPARATOR"
-
-            CI_VERSION=${CI_VERSION:-""}
-            if [[ "${CI_VERSION}" != "" ]]; then
-              CI_DIR=/tmp/k8s-ci
-              mkdir -p $CI_DIR
-              CI_URL="gs://kubernetes-release-dev/ci/$CI_VERSION-bazel/bin/linux/amd64"
-              declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-              PACKAGE_EXT="deb"
-              declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-              CONTAINER_EXT="tar"
-
-              echo "* testing CI version $CI_VERSION"
-
-              for CI_PACKAGE in "${PACKAGES_TO_TEST[@]}"; do
-              echo "* downloading package: $CI_URL/$CI_PACKAGE.$PACKAGE_EXT"
-              ${GSUTIL} cp "$CI_URL/$CI_PACKAGE.$PACKAGE_EXT" "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT"
-              ${SUDO} dpkg -i "$CI_DIR/$CI_PACKAGE.$PACKAGE_EXT" || echo "* ignoring expected 'dpkg -i' result"
-              done
-
-              for CI_CONTAINER in "${CONTAINERS_TO_TEST[@]}"; do
-              echo "* downloading package: $CI_URL/$CI_CONTAINER.$CONTAINER_EXT"
-              ${GSUTIL} cp "$CI_URL/$CI_CONTAINER.$CONTAINER_EXT" "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT"
-              ${SUDO} ctr -n k8s.io images import "$CI_DIR/$CI_CONTAINER.$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
-              ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" k8s.gcr.io/$CI_CONTAINER:"${CI_VERSION//+/_}"
-              ${SUDO} ctr -n k8s.io images tag k8s.gcr.io/$CI_CONTAINER-amd64:"${CI_VERSION//+/_}" gcr.io/kubernetes-ci-images/$CI_CONTAINER:"${CI_VERSION//+/_}"
-              done
-            fi
-
-            echo "* checking binary versions"
-
-            echo "ctr version: " $(ctr version)
-            echo "kubeadm version: " $(kubeadm version -o=short)
-            echo "kubectl version: " $(kubectl version --client=true --short=true)
-            echo "kubelet version: " $(kubelet --version)
-
-            echo "$LINE_SEPARATOR"
+      image: ${IMAGE_ID}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: GCPMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      image: ${IMAGE_ID}


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the script used during conformance testing against upstream k8s to remove bash variables other than the ones we replace with the call to envsubst, since envsubst is replacing them with empty strings currently.
