### PR TITLE
:running: [ci-conformance] fix unbound variable

### DIFF
--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -313,7 +313,7 @@ create_cluster() {
   GCP_NETWORK_NAME=${GCP_NETWORK_NAME} \
   GCP_B64ENCODED_CREDENTIALS=$(base64 -w0 "$GOOGLE_APPLICATION_CREDENTIALS") \
   CLUSTER_NAME="${CLUSTER_NAME}" \
-  CI_VERSION=${CI_VERSION} \
+  CI_VERSION=${CI_VERSION:-} \
   IMAGE_ID="projects/${GCP_PROJECT}/global/images/${image_id}" \
     make create-cluster)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fixes unbound variable CI_VERSION in hack/ci/e2e-conformance.sh when run without CI_VERSION or USE_CI_ARTIFACTS set, such as in the failed periodic job here: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-cluster-api-provider-gcp-make-conformance-v1alpha3/1253661850336235521

