### PR TITLE
Register only with first component of local_hostname

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -39,7 +39,7 @@ spec:
   kubeadmConfigSpec:
     initConfiguration:
       nodeRegistration:
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
         kubeletExtraArgs:
           cloud-provider: gce
     clusterConfiguration:
@@ -53,7 +53,7 @@ spec:
           allocate-node-cidrs: "false"
     joinConfiguration:
       nodeRegistration:
-        name: '{{ ds.meta_data.local_hostname }}'
+        name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
         kubeletExtraArgs:
           cloud-provider: gce
   version: "${KUBERNETES_VERSION}"
@@ -109,6 +109,6 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
-          name: '{{ ds.meta_data.local_hostname }}'
+          name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
           kubeletExtraArgs:
             cloud-provider: gce


### PR DESCRIPTION
This avoids the 63 character limit on the kubernetes.io/hostname label.

https://github.com/kubernetes/kubernetes/issues/90686