### PR TITLE
:running: Fix conformance script for recent image-builder change

### DIFF
--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -227,8 +227,8 @@ init_image() {
     cat << EOF > "$(go env GOPATH)/src/sigs.k8s.io/image-builder/images/capi/override.json"
 {
   "build_timestamp": "0",
-  "kubernetes_source_type": "url",
-  "kubernetes_cni_source_type": "url",
+  "kubernetes_source_type": "http",
+  "kubernetes_cni_source_type": "http",
   "kubernetes_http_source": "https://storage.googleapis.com/kubernetes-release-dev/ci",
   "kubernetes_series": "v${KUBERNETES_MAJOR_VERSION}.${KUBERNETES_MINOR_VERSION}",
   "kubernetes_semver": "${KUBERNETES_VERSION}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the conformance script for a recent change in imagee-builder (https://github.com/kubernetes-sigs/image-builder/pull/218)

