### PR TITLE
🐛 Added common tag for control-plane and worker nodes to resolve LoadBalancer issue

### DIFF
--- a/cloud/services/compute/instances.go
+++ b/cloud/services/compute/instances.go
@@ -74,6 +74,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope) (*compute.Instance, 
 			Items: append(
 				scope.GCPMachine.Spec.AdditionalNetworkTags,
 				fmt.Sprintf("%s-%s", scope.Cluster.Name, scope.Role()),
+				scope.Cluster.Name,
 			),
 		},
 		Disks: []*compute.AttachedDisk{


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR adds a common tag named by cluster-name to all the nodes: control-plane and worker nodes
On creating a service type=LoadBalancer, creation of firewall rules gets aborted in the EnsureLoadBalancer functionality. With the common tag present, rules get created and external IP gets assigned to the service

**Which issue(s) this PR fixes** 
Fixes #304 
