### PR TITLE
✨ Auto create Cloud NAT if network is created by CAPG

### DIFF
--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -44,6 +44,11 @@ type Network struct {
 	// +optional
 	FirewallRules map[string]string `json:"firewallRules,omitempty"`
 
+	// Router is the full reference to the router created within the network
+	// it'll contain the cloud nat gateway
+	// +optional
+	Router *string `json:"router,omitempty"`
+
 	// APIServerAddress is the IPV4 global address assigned to the load balancer
 	// created for the API Server.
 	// +optional

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -457,6 +457,11 @@ func (in *Network) DeepCopyInto(out *Network) {
 			(*out)[key] = val
 		}
 	}
+	if in.Router != nil {
+		in, out := &in.Router, &out.Router
+		*out = new(string)
+		**out = **in
+	}
 	if in.APIServerAddress != nil {
 		in, out := &in.APIServerAddress, &out.APIServerAddress
 		*out = new(string)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -212,6 +212,10 @@ spec:
                     description: FirewallRules is a map from the name of the rule
                       to its full reference.
                     type: object
+                  router:
+                    description: Router is the full reference to the router created
+                      within the network it'll contain the cloud nat gateway
+                    type: string
                   selfLink:
                     description: SelfLink is the link to the Network used for this
                       cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
In case where the network name is provided in GCPCluster configuration(for customisation) and the the network does not exist, in that case network and subnets are auto created by CAPG. In such a case router and Cloud NAT should also be auto created for the entire functionality to work. 
This change creates router and CloudNAT only if network is created by CAPG.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes the issue partially #267 
