### PR TITLE
hack/ci: Use ci/latest version marker for retrieving cross builds

### DIFF
--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -485,7 +485,7 @@ EOF
   fi
 
   if [[ -n ${CI_VERSION:-} || -n ${USE_CI_ARTIFACTS:-} ]]; then
-    CI_VERSION=${CI_VERSION:-$(curl -sSL https://dl.k8s.io/ci/k8s-master.txt)}
+    CI_VERSION=${CI_VERSION:-$(curl -sSL https://dl.k8s.io/ci/latest.txt)}
     KUBERNETES_VERSION=${CI_VERSION}
     KUBERNETES_MAJOR_VERSION=$(echo "${KUBERNETES_VERSION}" | cut -d '.' -f1 - | sed 's/v//')
     KUBERNETES_MINOR_VERSION=$(echo "${KUBERNETES_VERSION}" | cut -d '.' -f2 -)


### PR DESCRIPTION
(Follow-up to https://github.com/kubernetes/test-infra/pull/18290.)

[Now](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-build/1288265272272097280) that the `ci/latest` version marker again represents a cross build of `kubernetes/kubernetes@master`, we should stop using the `ci/k8s-master` generic version marker.

ref: https://github.com/kubernetes/test-infra/blob/master/docs/kubernetes-versions.md, https://github.com/kubernetes/sig-release/issues/850

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

Fixes: https://github.com/kubernetes/kubernetes/issues/93309
cc: @detiber 