### PR TITLE
✨ Support FailureDomains override(optional) in GCPClusterSpec

### DIFF
--- a/api/v1alpha3/gcpcluster_types.go
+++ b/api/v1alpha3/gcpcluster_types.go
@@ -43,6 +43,12 @@ type GCPClusterSpec struct {
 	// +optional
 	Network NetworkSpec `json:"network"`
 
+	// FailureDomains is an optional field which is used to assign selected availability zones to a cluster
+	// FailureDomains if empty, defaults to all the zones in the selected region and if specified would override
+	// the default zones.
+	// +optional
+	FailureDomains []string `json:"failureDomains,omitempty"`
+
 	// AdditionalLabels is an optional set of tags to add to GCP resources managed by the GCP provider, in addition to the
 	// ones added by default.
 	// +optional

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -138,6 +138,11 @@ func (in *GCPClusterSpec) DeepCopyInto(out *GCPClusterSpec) {
 	*out = *in
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	in.Network.DeepCopyInto(&out.Network)
+	if in.FailureDomains != nil {
+		in, out := &in.FailureDomains, &out.FailureDomains
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.AdditionalLabels != nil {
 		in, out := &in.AdditionalLabels, &out.AdditionalLabels
 		*out = make(Labels, len(*in))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -78,6 +78,14 @@ spec:
                 - host
                 - port
                 type: object
+              failureDomains:
+                description: FailureDomains is an optional field which is used to
+                  assign selected availability zones to a cluster FailureDomains if
+                  empty, defaults to all the zones in the selected region and if specified
+                  would override the default zones.
+                items:
+                  type: string
+                type: array
               network:
                 description: NetworkSpec encapsulates all things related to GCP network.
                 properties:

--- a/controllers/gcpcluster_controller.go
+++ b/controllers/gcpcluster_controller.go
@@ -192,8 +192,20 @@ func (r *GCPClusterReconciler) reconcile(clusterScope *scope.ClusterScope) (ctrl
 	}
 	gcpCluster.Status.FailureDomains = make(clusterv1.FailureDomains, len(zones))
 	for _, zone := range zones {
-		gcpCluster.Status.FailureDomains[zone] = clusterv1.FailureDomainSpec{
-			ControlPlane: true,
+		if len(gcpCluster.Spec.FailureDomains) > 0 {
+			found := false
+			for _, fd := range gcpCluster.Spec.FailureDomains {
+				if fd == zone {
+					found = true
+				}
+			}
+			gcpCluster.Status.FailureDomains[zone] = clusterv1.FailureDomainSpec{
+				ControlPlane: found,
+			}
+		} else {
+			gcpCluster.Status.FailureDomains[zone] = clusterv1.FailureDomainSpec{
+				ControlPlane: true,
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a field FailureDomains in GCPClusterSpec which if provided, would override the default behaviour where the GCPClusterStatus.FailureDomains are defaulted to all the zones in the specified region. This change would set only the provided zones to true.

**Which issue(s) this PR fixes**:
This PR would control the cluster components creation in the specified zones and thus unblock #303 to some extent.
