### PR TITLE
✨ manager: add reconcile timeout option

### DIFF
--- a/controllers/gcpcluster_controller.go
+++ b/controllers/gcpcluster_controller.go
@@ -37,12 +37,14 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud/services/compute"
+	"sigs.k8s.io/cluster-api-provider-gcp/util/reconciler"
 )
 
 // GCPClusterReconciler reconciles a GCPCluster object
 type GCPClusterReconciler struct {
 	client.Client
-	Log logr.Logger
+	Log              logr.Logger
+	ReconcileTimeout time.Duration
 }
 
 func (r *GCPClusterReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
@@ -86,7 +88,8 @@ func (r *GCPClusterReconciler) SetupWithManager(mgr ctrl.Manager, options contro
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
 
 func (r *GCPClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) {
-	ctx := context.TODO()
+	ctx, cancel := context.WithTimeout(context.Background(), reconciler.DefaultedLoopTimeout(r.ReconcileTimeout))
+	defer cancel()
 	log := r.Log.WithValues("namespace", req.Namespace, "gcpCluster", req.Name)
 
 	// Fetch the GCPCluster instance

--- a/util/reconciler/defaults.go
+++ b/util/reconciler/defaults.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"time"
+)
+
+const (
+	// DefaultLoopTimeout is the default timeout for a reconcile loop (defaulted to the max ARM template duration)
+	DefaultLoopTimeout = 90 * time.Minute
+	// DefaultMappingTimeout is the default timeout for a controller request mapping func
+	DefaultMappingTimeout = 60 * time.Second
+)
+
+// DefaultedLoopTimeout will default the timeout if it is zero valued
+func DefaultedLoopTimeout(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		return DefaultLoopTimeout
+	}
+
+	return timeout
+}

--- a/util/reconciler/defaults_test.go
+++ b/util/reconciler/defaults_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+
+	"sigs.k8s.io/cluster-api-provider-gcp/util/reconciler"
+)
+
+func TestDefaultedTimeout(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Subject  time.Duration
+		Expected time.Duration
+	}{
+		{
+			Name:     "WithZeroValueDefaults",
+			Subject:  time.Duration(0),
+			Expected: reconciler.DefaultLoopTimeout,
+		},
+		{
+			Name:     "WithRealValue",
+			Subject:  2 * time.Hour,
+			Expected: 2 * time.Hour,
+		},
+		{
+			Name:     "WithNegativeValue",
+			Subject:  time.Duration(-2),
+			Expected: reconciler.DefaultLoopTimeout,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			g.Expect(reconciler.DefaultedLoopTimeout(c.Subject)).To(gomega.Equal(c.Expected))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add an option to a user to set the reconciliation timeout.
this also we have in other providers.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

/assign @rsmitty @detiber 