### PR TITLE
Update link to image-builder git repo

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -40,7 +40,7 @@ export GCP_PROJECT_ID=<project-id>
 export GOOGLE_APPLICATION_CREDENTIALS=</path/to/serviceaccount-key.json>
 
 # Clone the image builder repository if you haven't already.
-git clone https://sigs.k8s.io/image-builder.git image-builder
+git clone https://github.com/kubernetes-sigs/image-builder.git image-builder
 
 # Change directory to images/capi within the image builder repository
 cd image-builder/images/capi


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Fixes link to git repo for image-builder in prerequisites that seems to have changed -

```
$ git clone https://sigs.k8s.io/image-builder.git
Cloning into 'image-builder'...
fatal: repository 'https://sigs.k8s.io/image-builder.git/' not found
```