### PR TITLE
WIP: Label GCP instances with GCPMachine UID

### DIFF
--- a/cloud/services/compute/instances.go
+++ b/cloud/services/compute/instances.go
@@ -121,9 +121,10 @@ func (s *Service) CreateInstance(scope *scope.MachineScope) (*compute.Instance, 
 	}
 
 	input.Labels = infrav1.Build(infrav1.BuildParams{
-		ClusterName: s.scope.Name(),
-		Lifecycle:   infrav1.ResourceLifecycleOwned,
-		Role:        pointer.StringPtr(scope.Role()),
+		ClusterName:      s.scope.Name(),
+		Lifecycle:        infrav1.ResourceLifecycleOwned,
+		Role:             pointer.StringPtr(scope.Role()),
+		KubernetesObject: scope.GCPMachine,
 		// TODO(vincepri): Check what needs to be added for the cloud provider label.
 		Additional: s.scope.
 			GCPCluster.Spec.


### PR DESCRIPTION
This allows for easy identification of the associated machine, even
across clusters, and can help with idempotent creation.

/kind feature

```release-note
Created GCP instances will now have a label k8s-io-owner-uid to
indicate the controlling GCPMachine object.
```