### PR TITLE
Make AdditionalMetadata Key field required

### DIFF
--- a/api/v1alpha3/gcpmachine_types.go
+++ b/api/v1alpha3/gcpmachine_types.go
@@ -112,7 +112,7 @@ type GCPMachineSpec struct {
 // MetadataItem defines a single piece of metadata associated with an instance.
 type MetadataItem struct {
 	// Key is the identifier for the metadata entry.
-	Key string `json:"key,omitempty"`
+	Key string `json:"key"`
 	// Value is the value of the metadata entry.
 	Value *string `json:"value,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
@@ -82,6 +82,8 @@ spec:
                     value:
                       description: Value is the value of the metadata entry.
                       type: string
+                  required:
+                  - key
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
@@ -71,6 +71,8 @@ spec:
                             value:
                               description: Value is the value of the metadata entry.
                               type: string
+                          required:
+                          - key
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:


### PR DESCRIPTION

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind api-change


**What this PR does / why we need it**:

Using x-kubernetes-list-type with v1 CRDs requires that one specify that
the key field is either required or has a default value. In the case of
AdditionalMetadata, the key field should be required.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

**Which issue(s) this PR fixes**:

Partial revert of #342 

**Special notes for your reviewer**:

See https://github.com/kubernetes/kubernetes/issues/91395 for more info.

/assign @detiber @justinsb @cpanato 

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
