### PR TITLE
Remove inactive members from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -23,6 +23,5 @@ aliases:
     - gab-satchi
     - justinsb
     - krousey
-    - maisem
     - rsmitty
     - vincepri


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456
As a part of cleaning up inactive members (those with no activity within
the past 18 months), this commit removes maisem from the capg maintainer
list..

/kind cleanup

**Release note**:

```release-note
NONE
```
