### PR TITLE
Grab config.toml for containerd

### DIFF
--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -95,6 +95,7 @@ dump-logs() {
     ssh-to-node "${node_name}" "${node_zone}" "sudo journalctl --output=short-precise -k" > "${dir}/kern.log" || true
     ssh-to-node "${node_name}" "${node_zone}" "sudo journalctl --output=short-precise" > "${dir}/systemd.log" || true
     ssh-to-node "${node_name}" "${node_zone}" "sudo crictl version && sudo crictl info" > "${dir}/containerd.info" || true
+    ssh-to-node "${node_name}" "${node_zone}" "sudo cat /etc/containerd/config.toml" > "${dir}/containerd-config.toml" || true
     ssh-to-node "${node_name}" "${node_zone}" "sudo journalctl --no-pager -u kubelet.service" > "${dir}/kubelet.log" || true
     ssh-to-node "${node_name}" "${node_zone}" "sudo journalctl --no-pager -u containerd.service" > "${dir}/containerd.log" || true
   done


### PR DESCRIPTION
Capture more information about containerd when we run the conformance CI job (basically capture the /etc/contained/config.toml) 

/kind feature

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

