### PR TITLE
Updating sig leads and capi mantainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,18 +2,17 @@
 
 aliases:
   sig-cluster-lifecycle-leads:
+    - fabriziopandini
     - justinsb
-    - luxas
+    - neolit123
     - timothysc
   cluster-api-admins:
-    - davidewatson
-    - detiber
     - justinsb
+    - vincepri
   cluster-api-maintainers:
     - CecileRobertMichon
-    - detiber
+    - fabriziopandini
     - justinsb
-    - ncdc
     - vincepri
   sig-gcp-leads:
     - abgworrall


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR align sig leads and CAPI admin/maintainers in the owner alias file to what is currently defined in CAPI

**TODOs**:
- [na] squashed commits
- [na] includes documentation
- [na] adds unit tests

**Release note**:
```release-note
NONE
```
