### PR TITLE
Install go if needed

### DIFF
--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -21,11 +21,16 @@ set -o pipefail
 # Ensure the go tool exists and is a viable version.
 verify_go_version() {
   if [[ -z "$(command -v go)" ]]; then
-    cat <<EOF
+    if [[ "${INSTALL_GO:-"true"}" == "true" ]]; then
+      curl -sSL https://golang.org/dl/go${GO_VERSION:-"1.16.3"}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+      export PATH=/usr/local/go/bin:$PATH
+    else
+      cat <<EOF
 Can't find 'go' in PATH, please fix and retry.
 See http://golang.org/doc/install for installation instructions.
 EOF
-    return 2
+      return 2
+    fi
   fi
 
   local go_version


### PR DESCRIPTION
build-image job needs `go` as the container image it runs in does not have it.

https://testgrid.k8s.io/sig-cluster-lifecycle-image-pushes#capg-build-image-nightly

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
