### PR TITLE
Better check for OSTYPE & ensure GOPATH/bin is in PATH

### DIFF
--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -24,6 +24,7 @@ verify_go_version() {
     if [[ "${INSTALL_GO:-"true"}" == "true" ]]; then
       curl -sSL https://golang.org/dl/go${GO_VERSION:-"1.16.3"}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
       export PATH=/usr/local/go/bin:$PATH
+      export PATH=$(go env GOPATH)/bin:$PATH
     else
       cat <<EOF
 Can't find 'go' in PATH, please fix and retry.

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -26,7 +26,7 @@ verify_kind_version() {
 
   # If kind is not available on the path, get it
   if ! [ -x "$(command -v kind)" ]; then
-    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+    if [[ "${OSTYPE}" == "linux"* ]]; then
       echo 'kind not found, installing'
       if ! [ -d "${GOPATH_BIN}" ]; then
         mkdir -p "${GOPATH_BIN}"

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -26,7 +26,7 @@ verify_kubectl_version() {
 
   # If kubectl is not available on the path, get it
   if ! [ -x "$(command -v kubectl)" ]; then
-    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+    if [[ "${OSTYPE}" == "linux"* ]]; then
       if ! [ -d "${GOPATH_BIN}" ]; then
         mkdir -p "${GOPATH_BIN}"
       fi

--- a/hack/ensure-kustomize.sh
+++ b/hack/ensure-kustomize.sh
@@ -26,7 +26,7 @@ verify_kustomize_version() {
 
   # If kustomize is not available on the path, get it
   if ! [ -x "$(command -v kustomize)" ]; then
-    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+    if [[ "${OSTYPE}" == "linux"* ]]; then
       echo 'kustomize not found, installing'
       if ! [ -d "${GOPATH_BIN}" ]; then
         mkdir -p "${GOPATH_BIN}"


### PR DESCRIPTION
the OSTYPE check fails in some containers (that report `linux-musl`), also forgot to ensure $GOPATH/bin is present in PATH.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
