### PR TITLE
Use GA TargetTcpProxies after updated upstream

### DIFF
--- a/cloud/scope/clients.go
+++ b/cloud/scope/clients.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
-	computebeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 
 	"k8s.io/client-go/util/flowcontrol"
@@ -29,8 +28,7 @@ import (
 
 // GCPServices contains all the gcp services used by the scopes.
 type GCPServices struct {
-	Compute     *compute.Service
-	ComputeBeta *computebeta.Service
+	Compute *compute.Service
 }
 
 // GCPRateLimiter implements cloud.RateLimiter.
@@ -56,7 +54,6 @@ func (rl *GCPRateLimiter) Accept(ctx context.Context, key *cloud.RateLimitKey) e
 func newCloud(project string, service GCPServices) cloud.Cloud {
 	return cloud.NewGCE(&cloud.Service{
 		GA:            service.Compute,
-		Beta:          service.ComputeBeta,
 		ProjectRouter: &cloud.SingleProjectRouter{ID: project},
 		RateLimiter:   &GCPRateLimiter{},
 	})

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	computebeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 
 	"k8s.io/utils/pointer"
@@ -58,17 +57,8 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 		return nil, errors.Errorf("failed to create gcp compute client: %v", err)
 	}
 
-	computeBetaSvc, err := computebeta.NewService(context.TODO())
-	if err != nil {
-		return nil, errors.Errorf("failed to create gcp compute beta client: %v", err)
-	}
-
 	if params.GCPServices.Compute == nil {
 		params.GCPServices.Compute = computeSvc
-	}
-
-	if params.GCPServices.ComputeBeta == nil {
-		params.GCPServices.ComputeBeta = computeBetaSvc
 	}
 
 	helper, err := patch.NewHelper(params.GCPCluster, params.Client)
@@ -317,8 +307,8 @@ func (s *ClusterScope) InstanceGroupSpec(zone string) *compute.InstanceGroup {
 }
 
 // TargetTCPProxySpec returns google compute target-tcp-proxy spec.
-func (s *ClusterScope) TargetTCPProxySpec() *computebeta.TargetTcpProxy {
-	return &computebeta.TargetTcpProxy{
+func (s *ClusterScope) TargetTCPProxySpec() *compute.TargetTcpProxy {
+	return &compute.TargetTcpProxy{
 		Name:        fmt.Sprintf("%s-%s", s.Name(), infrav1.APIServerRoleTagValue),
 		ProxyHeader: "NONE",
 	}

--- a/cloud/services/compute/loadbalancers/reconcile.go
+++ b/cloud/services/compute/loadbalancers/reconcile.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	computebeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 
 	"k8s.io/utils/pointer"
@@ -203,7 +202,7 @@ func (s *Service) createOrGetBackendService(ctx context.Context, instancegroups 
 	return backendsvc, nil
 }
 
-func (s *Service) createOrGetTargetTCPProxy(ctx context.Context, service *compute.BackendService) (*computebeta.TargetTcpProxy, error) {
+func (s *Service) createOrGetTargetTCPProxy(ctx context.Context, service *compute.BackendService) (*compute.TargetTcpProxy, error) {
 	log := log.FromContext(ctx)
 	targetSpec := s.scope.TargetTCPProxySpec()
 	targetSpec.Service = service.SelfLink
@@ -260,7 +259,7 @@ func (s *Service) createOrGetAddress(ctx context.Context) (*compute.Address, err
 	return addr, nil
 }
 
-func (s *Service) createForwardingRule(ctx context.Context, target *computebeta.TargetTcpProxy, addr *compute.Address) error {
+func (s *Service) createForwardingRule(ctx context.Context, target *compute.TargetTcpProxy, addr *compute.Address) error {
 	log := log.FromContext(ctx)
 	spec := s.scope.ForwardingRuleSpec()
 	key := meta.GlobalKey(spec.Name)

--- a/cloud/services/compute/loadbalancers/service.go
+++ b/cloud/services/compute/loadbalancers/service.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	computebeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud"
@@ -60,8 +59,8 @@ type instancegroupsInterface interface {
 }
 
 type targettcpproxiesInterface interface {
-	Get(ctx context.Context, key *meta.Key) (*computebeta.TargetTcpProxy, error)
-	Insert(ctx context.Context, key *meta.Key, obj *computebeta.TargetTcpProxy) error
+	Get(ctx context.Context, key *meta.Key) (*compute.TargetTcpProxy, error)
+	Insert(ctx context.Context, key *meta.Key, obj *compute.TargetTcpProxy) error
 	Delete(ctx context.Context, key *meta.Key) error
 }
 
@@ -73,7 +72,7 @@ type Scope interface {
 	ForwardingRuleSpec() *compute.ForwardingRule
 	HealthCheckSpec() *compute.HealthCheck
 	InstanceGroupSpec(zone string) *compute.InstanceGroup
-	TargetTCPProxySpec() *computebeta.TargetTcpProxy
+	TargetTCPProxySpec() *compute.TargetTcpProxy
 }
 
 // Service implements loadbalancers reconciler.
@@ -98,6 +97,6 @@ func New(scope Scope) *Service {
 		forwardingrules:  scope.Cloud().GlobalForwardingRules(),
 		healthchecks:     scope.Cloud().HealthChecks(),
 		instancegroups:   scope.Cloud().InstanceGroups(),
-		targettcpproxies: scope.Cloud().BetaTargetTcpProxies(), // This is temporary to use beta API.
+		targettcpproxies: scope.Cloud().TargetTcpProxies(),
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,6 @@ require (
 )
 
 replace (
-	github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v1.16.1-0.20210622065854-abbfeadc9fda
+	github.com/GoogleCloudPlatform/k8s-cloud-provider => github.com/GoogleCloudPlatform/k8s-cloud-provider v1.16.1-0.20210702162410-39a62816f3fa
 	sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/GoogleCloudPlatform/k8s-cloud-provider v1.16.1-0.20210622065854-abbfeadc9fda h1:I18CajUZOZ9o6BOSMF7uI2/xozIK4SEfMY+GtM4QxUE=
-github.com/GoogleCloudPlatform/k8s-cloud-provider v1.16.1-0.20210622065854-abbfeadc9fda/go.mod h1:8XasY4ymP2V/tn2OOV9ZadmiTE1FIB/h3W+yNlPttKw=
+github.com/GoogleCloudPlatform/k8s-cloud-provider v1.16.1-0.20210702162410-39a62816f3fa h1:AjKpB9LHpRkOWBJ1hecMcjJRkLDQqA3ORoXiU8HQBnY=
+github.com/GoogleCloudPlatform/k8s-cloud-provider v1.16.1-0.20210702162410-39a62816f3fa/go.mod h1:8XasY4ymP2V/tn2OOV9ZadmiTE1FIB/h3W+yNlPttKw=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Use GA TargetTcpProxies instead of Beta version after added in upstream https://github.com/GoogleCloudPlatform/k8s-cloud-provider/pull/61

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
