### PR TITLE
use dl.k8s.io instead of hardcoded GCS URIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ $(GINKGO): ## Build ginkgo.
 $(KUBECTL): ## Build kubectl
 	mkdir -p $(TOOLS_BIN_DIR)
 	rm -f "$(KUBECTL)*"
-	curl --retry $(CURL_RETRIES) -fsL https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VER)/bin/$(GOOS)/$(GOARCH)/kubectl -o $(KUBECTL)
+	curl --retry $(CURL_RETRIES) -fsL https://dl.k8s.io/release/$(KUBECTL_VER)/bin/$(GOOS)/$(GOARCH)/kubectl -o $(KUBECTL)
 	ln -sf "$(KUBECTL)" "$(TOOLS_BIN_DIR)/$(KUBECTL_BIN)"
 	chmod +x "$(TOOLS_BIN_DIR)/$(KUBECTL_BIN)" "$(KUBECTL)"
 

--- a/hack/ci/e2e-conformance.sh
+++ b/hack/ci/e2e-conformance.sh
@@ -207,7 +207,7 @@ init_image() {
   "build_timestamp": "0",
   "kubernetes_source_type": "http",
   "kubernetes_cni_source_type": "http",
-  "kubernetes_http_source": "https://storage.googleapis.com/kubernetes-release-dev/ci",
+  "kubernetes_http_source": "https://dl.k8s.io/ci",
   "kubernetes_series": "v${KUBERNETES_MAJOR_VERSION}.${KUBERNETES_MINOR_VERSION}",
   "kubernetes_semver": "${KUBERNETES_VERSION}"
 }

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -31,7 +31,7 @@ verify_kubectl_version() {
         mkdir -p "${GOPATH_BIN}"
       fi
       echo 'kubectl not found, installing'
-      curl -sLo "${GOPATH_BIN}/kubectl" https://storage.googleapis.com/kubernetes-release/release/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl
+      curl -sLo "${GOPATH_BIN}/kubectl" https://dl.k8s.io/release/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl
       chmod +x "${GOPATH_BIN}/kubectl"
     else
       echo "Missing required binary in path: kubectl"


### PR DESCRIPTION
Use dl.k8s.io instead of hardcoded GCS URIs

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The only time a kubernetes GCS bucket name should be showing up in a
hardcoded URI is if `gsutil` is being used (e.g. gsutil cp gs://foo/bar .)

Otherwise, for tools like `curl` or `wget`, dl.k8s.io is much nicer for us
as a project, since we can transparently change where that redirects to
without having to change code everywhere

These changes will mean no changes will be necessary to accommodate a
`gs://kubernetes-release` -> `gs://k8s-release` migration equivalent of
the CI migration we're going through right now

These changes also address the `gs://kubernetes-release-dev` references
currently used by this repo (ref:
https://github.com/kubernetes/k8s.io/issues/2318)

**Special notes for your reviewer**:

I'm not sure that a release note is required for this, but I put one in
just in case

Similar / related PRs:
- https://github.com/kubernetes-sigs/image-builder/pull/656
- https://github.com/kubernetes-sigs/cluster-api/pull/4958

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] ~includes documentation~ (n/a)
- [x] ~adds unit tests~ (n/a)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubernetes artifacts are pulled from https://dl.k8s.io instead of
hardcoded GCS bucket URIs (kubernetes-release, kubernetes-release-dev)

```