### PR TITLE
ci: use prebuilt node images for CAPG

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -67,6 +67,7 @@ spec:
   template:
     spec:
       instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
+      image: "${IMAGE_ID}"
 ---
 apiVersion: cluster.x-k8s.io/v1alpha4
 kind: MachineDeployment
@@ -100,6 +101,7 @@ spec:
   template:
     spec:
       instanceType: "${GCP_NODE_MACHINE_TYPE}"
+      image: "${IMAGE_ID}"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
we can use pre-built node images to accelerate a bit the CI tests, for conformance we now have two jobs that can run for PRs
- `pull-cluster-api-provider-gcp-conformance` - it uses the prebuilt node image and a fixed k8s version, currently is 1.19
- `pull-cluster-api-provider-gcp-conformance-ci-artifacts` - build the node image and use the latest CI available

I will work to convert the conformance to use the capi framework after we merge this

/assign @dims 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ci: use prebuilt node images for CAPG
```
