### PR TITLE
use k8s-staging-test-infra/gcb-docker-gcloud

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/1523
  - https://github.com/kubernetes/test-infra/pull/23656

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>