### PR TITLE
Make cert manager install in makefile more resilient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,10 +383,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST)
 	kind create cluster --name=clusterapi
 
 	# Install cert manager and wait for availability
-	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
-	kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
-	kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
-	kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook
+	./hack/install-cert-manager.sh
 
 	# Deploy CAPI
 	curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.2/cluster-api-components.yaml | $(ENVSUBST) | kubectl apply -f -

--- a/hack/install-cert-manager.sh
+++ b/hack/install-cert-manager.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TEST_RESOURCE=$(cat <<-END
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-test
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: test-selfdesigned
+  namespace: cert-manager-test
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: selfsigned-cert
+  namespace: cert-manager-test
+spec:
+  dnsNames:
+    - example.com
+  secretName: selfsigned-cert-tls
+  issuerRef:
+    name: test-selfsigned
+END
+)
+
+## Install cert manager and wait for availability
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.0/cert-manager.yaml
+kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
+kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
+kubectl wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook
+
+for _ in {1..6}; do
+  (echo "$TEST_RESOURCE" | kubectl apply -f -) && break
+   sleep 15
+done
+
+kubectl wait --for=condition=Ready --timeout=300s -n cert-manager-test certificate/selfsigned-cert
+echo "$TEST_RESOURCE" | kubectl delete -f -


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
This PR adds a cert manager installation script making the Makefile more resilient

<!--
Add one of the following kinds:
/kind feature
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #480 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Addition of Cert Manager installation script
```
