### PR TITLE
Replaced `go get` with `go install` to install binaries

### DIFF
--- a/scripts/go_install.sh
+++ b/scripts/go_install.sh
@@ -51,6 +51,6 @@ cd "${tmp_dir}"
 go mod init fake/mod
 
 # install the golang module specified as the first argument
-go get -tags tools "${1}@${3}"
+go install -tags tools "${1}@${3}"
 mv "${GOBIN}/${2}" "${GOBIN}/${2}-${3}"
 ln -sf "${GOBIN}/${2}-${3}" "${GOBIN}/${2}"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
The PR replaces `go get` with `go install`, as the use of `go get` to build and install packages is deprecated.

**Which issue(s) this PR fixes** 
Fixes #492 

**Release note:**
```
NONE
```