### PR TITLE
Change the default GINKGO_NODES to 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ test: $(SETUP_ENVTEST) ## Run unit and integration tests
 # Allow overriding the e2e configurations
 GINKGO_FOCUS ?= Workload cluster creation
 GINKGO_SKIP ?= API Version Upgrade
-GINKGO_NODES ?= 3
+GINKGO_NODES ?= 1
 GINKGO_NOCOLOR ?= false
 GINKGO_ARGS ?=
 ARTIFACTS ?= $(ROOT_DIR)/_artifacts

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -35,6 +35,8 @@ source "${REPO_ROOT}/hack/ensure-kind.sh"
 # shellcheck source=hack/ensure-kustomize.sh
 source "${REPO_ROOT}/hack/ensure-kustomize.sh"
 
+# Configure e2e tests
+export GINKGO_NODES=3
 ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
 mkdir -p "${ARTIFACTS}/logs/"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind other

**What this PR does / why we need it**:
For local e2e testing, GINKGO_NODES set to 3 makes it difficult to follow test output and debug.

This changes the default GINKGO_NODES to 1 but set GINKGO_NODES to 3 for CI
e2e tests to enable parallel testing and preserve the original behavior.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
