### PR TITLE
Pick a zone for worker nodes automatically when a failureDomain is not specified in MachineDeployment

### DIFF
--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -93,9 +94,14 @@ func (m *MachineScope) Cloud() cloud.Cloud {
 // Zone returns the FailureDomain for the GCPMachine.
 func (m *MachineScope) Zone() string {
 	if m.Machine.Spec.FailureDomain == nil {
-		return ""
+		fd := m.ClusterGetter.FailureDomains()
+		zones := make([]string, 0, len(fd))
+		for zone := range fd {
+			zones = append(zones, zone)
+		}
+		sort.Strings(zones)
+		return zones[0]
 	}
-
 	return *m.Machine.Spec.FailureDomain
 }
 

--- a/cloud/services/compute/instances/reconcile_test.go
+++ b/cloud/services/compute/instances/reconcile_test.go
@@ -73,6 +73,37 @@ var fakeMachine = &clusterv1.Machine{
 	},
 }
 
+var fakeMachineWithOutFailureDomain = &clusterv1.Machine{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "my-machine",
+		Namespace: "default",
+	},
+	Spec: clusterv1.MachineSpec{
+		Bootstrap: clusterv1.Bootstrap{
+			DataSecretName: pointer.String("my-cluster-bootstrap"),
+		},
+		Version: pointer.String("v1.19.11"),
+	},
+}
+
+var fakeGCPClusterWithOutFailureDomain = &infrav1.GCPCluster{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "my-cluster",
+		Namespace: "default",
+	},
+	Spec: infrav1.GCPClusterSpec{
+		Project: "my-proj",
+		Region:  "us-central1",
+	},
+	Status: infrav1.GCPClusterStatus{
+		FailureDomains: clusterv1.FailureDomains{
+			"us-central1-a": clusterv1.FailureDomainSpec{ControlPlane: true},
+			"us-central1-b": clusterv1.FailureDomainSpec{ControlPlane: true},
+			"us-central1-c": clusterv1.FailureDomainSpec{ControlPlane: true},
+		},
+	},
+}
+
 var fakeGCPCluster = &infrav1.GCPCluster{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "my-cluster",
@@ -116,6 +147,25 @@ func TestService_createOrGetInstance(t *testing.T) {
 		Machine:       fakeMachine,
 		GCPMachine:    fakeGCPMachine,
 		ClusterGetter: clusterScope,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clusterScopeWithoutFailureDomain, err := scope.NewClusterScope(scope.ClusterScopeParams{
+		Client:     fakec,
+		Cluster:    fakeCluster,
+		GCPCluster: fakeGCPClusterWithOutFailureDomain,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machineScopeWithoutFailureDomain, err := scope.NewMachineScope(scope.MachineScopeParams{
+		Client:        fakec,
+		Machine:       fakeMachineWithOutFailureDomain,
+		GCPMachine:    fakeGCPMachine,
+		ClusterGetter: clusterScopeWithoutFailureDomain,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -269,6 +319,63 @@ func TestService_createOrGetInstance(t *testing.T) {
 					},
 				},
 				Zone: "us-central1-c",
+			},
+		},
+		{
+			name:  "FailureDomain not given (should pick up a failure domain from the cluster)",
+			scope: func() Scope { return machineScopeWithoutFailureDomain },
+			mockInstance: &cloud.MockInstances{
+				ProjectRouter: &cloud.SingleProjectRouter{ID: "proj-id"},
+				Objects:       map[meta.Key]*cloud.MockInstancesObj{},
+			},
+			wantErr: false,
+			want: &compute.Instance{
+				Name:         "my-machine",
+				CanIpForward: false,
+				Disks: []*compute.AttachedDisk{
+					{
+						AutoDelete: true,
+						Boot:       true,
+						InitializeParams: &compute.AttachedDiskInitializeParams{
+							DiskType:    "zones/us-central1-a/diskTypes/pd-standard",
+							SourceImage: "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
+						},
+					},
+				},
+				Labels: map[string]string{
+					"capg-role":               "node",
+					"capg-cluster-my-cluster": "owned",
+					"foo":                     "bar",
+				},
+				MachineType: "zones/us-central1-a/machineTypes",
+				Metadata: &compute.Metadata{
+					Items: []*compute.MetadataItems{
+						{
+							Key:   "user-data",
+							Value: pointer.String("Zm9vCg=="),
+						},
+					},
+				},
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{
+						Network: "projects/my-proj/global/networks/default",
+					},
+				},
+				SelfLink:   "https://www.googleapis.com/compute/v1/projects/proj-id/zones/us-central1-a/instances/my-machine",
+				Scheduling: &compute.Scheduling{},
+				ServiceAccounts: []*compute.ServiceAccount{
+					{
+						Email:  "default",
+						Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
+					},
+				},
+				Tags: &compute.Tags{
+					Items: []string{
+						"my-cluster-node",
+						"my-cluster",
+					},
+				},
+				Zone: "us-central1-a",
 			},
 		},
 	}

--- a/test/e2e/data/infrastructure-gcp/cluster-template-ci.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-ci.yaml
@@ -85,7 +85,6 @@ spec:
   template:
     spec:
       clusterName: "${CLUSTER_NAME}"
-      failureDomain: "${GCP_REGION}-a"
       version: "${KUBERNETES_VERSION}"
       bootstrap:
         configRef:

--- a/test/e2e/data/infrastructure-gcp/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-kcp-remediation.yaml
@@ -85,7 +85,6 @@ spec:
   template:
     spec:
       clusterName: "${CLUSTER_NAME}"
-      failureDomain: "${GCP_REGION}-a"
       version: "${KUBERNETES_VERSION}"
       bootstrap:
         configRef:

--- a/test/e2e/data/infrastructure-gcp/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-md-remediation.yaml
@@ -87,7 +87,6 @@ spec:
         e2e.remediation.label: ""
     spec:
       clusterName: "${CLUSTER_NAME}"
-      failureDomain: "${GCP_REGION}-a"
       version: "${KUBERNETES_VERSION}"
       bootstrap:
         configRef:

--- a/test/e2e/data/infrastructure-gcp/cluster-template-prow-ci-version.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-prow-ci-version.yaml
@@ -157,7 +157,6 @@ spec:
         nodepool: pool1
     spec:
       clusterName: "${CLUSTER_NAME}"
-      failureDomain: "${GCP_REGION}-a"
       version: "${KUBERNETES_VERSION}"
       bootstrap:
         configRef:

--- a/test/e2e/data/infrastructure-gcp/cluster-template-topology.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-topology.yaml
@@ -19,7 +19,6 @@ spec:
         - class: "default-worker"
           name: "md-0"
           replicas: ${WORKER_MACHINE_COUNT}
-          failureDomain: ${GCP_REGION}-a
     variables:
       - name: region
         value: ${GCP_REGION}

--- a/test/e2e/data/infrastructure-gcp/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-upgrades.yaml
@@ -85,7 +85,6 @@ spec:
   template:
     spec:
       clusterName: "${CLUSTER_NAME}"
-      failureDomain: "${GCP_REGION}-a"
       version: "${KUBERNETES_VERSION}"
       bootstrap:
         configRef:


### PR DESCRIPTION
Signed-off-by: Aniruddha Basak <codewithaniruddha@gmail.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

This PR is about picking a zone automatically when failureDomain is not specified in MachineDeployment

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [#569](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/569#)

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Pick a zone for worker nodes automatically
```
