### PR TITLE
Doc: Add instruction to export gcp credential env var

### DIFF
--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -18,7 +18,7 @@
    - `GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.1`.
 5. Install [Kustomize][kustomize]
    - `brew install kustomize` on macOS.
-   - [install instructions](https://kubectl.docs.kubernetes.io/installation/kustomize/) on Windows + WSL2, Linux and macOS. 
+   - [install instructions](https://kubectl.docs.kubernetes.io/installation/kustomize/) on Windows + WSL2, Linux and macOS.
 6. Install Python 3.x or 2.7.x, if neither is already installed.
 7. Install make.
    - `brew install make` on MacOS.
@@ -225,6 +225,8 @@ $ make delete-workload-cluster
 
 Pull requests and issues are highly encouraged!
 If you're interested in submitting PRs to the project, please be sure to run some initial checks prior to submission:
+
+Do make sure to set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable with the path to your JSON file. Check out the this [doc](https://cloud.google.com/docs/authentication/production) to generate the credential.
 
 ```shell
 $ make lint # Runs a suite of quick scripts to check code structure


### PR DESCRIPTION
Add instruction to add GOOGLE_APPLICATION_CREDENTIALS env var before
testing so the test doesn't fail due to "google: could not find default
credentials"

Signed-off-by: Aniruddha Basak <codewithaniruddha@gmail.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
Add info about adding GCP credentials before testing. So it will ease the process for the person using the project for the first time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Doc: Add instruction to export gcp credential env var
```
