### PR TITLE
Root Disk Image lookup should use a filter on image name rather than family

### DIFF
--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -210,8 +210,8 @@ func (m *MachineScope) InstanceImageSpec() *compute.AttachedDisk {
 	if m.Machine.Spec.Version != nil {
 		version = *m.Machine.Spec.Version
 	}
-	image := "capi-ubuntu-1804-k8s-" + strings.ReplaceAll(semver.MajorMinor(version), ".", "-")
-	sourceImage := path.Join("projects", m.ClusterGetter.Project(), "global", "images", "family", image)
+	image := "capi-ubuntu-1804-k8s-" + strings.ReplaceAll(semver.Canonical(version), ".", "-")
+	sourceImage := path.Join("projects", m.ClusterGetter.Project(), "global", "images", image)
 	if m.GCPMachine.Spec.Image != nil {
 		sourceImage = *m.GCPMachine.Spec.Image
 	} else if m.GCPMachine.Spec.ImageFamily != nil {

--- a/cloud/services/compute/instances/reconcile_test.go
+++ b/cloud/services/compute/instances/reconcile_test.go
@@ -171,7 +171,7 @@ func TestService_createOrGetInstance(t *testing.T) {
 						Boot:       true,
 						InitializeParams: &compute.AttachedDiskInitializeParams{
 							DiskType:    "zones/us-central1-c/diskTypes/pd-standard",
-							SourceImage: "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
+							SourceImage: "projects/my-proj/global/images/capi-ubuntu-1804-k8s-v1-19-11",
 						},
 					},
 				},
@@ -231,7 +231,7 @@ func TestService_createOrGetInstance(t *testing.T) {
 						Boot:       true,
 						InitializeParams: &compute.AttachedDiskInitializeParams{
 							DiskType:    "zones/us-central1-c/diskTypes/pd-standard",
-							SourceImage: "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
+							SourceImage: "projects/my-proj/global/images/capi-ubuntu-1804-k8s-v1-19-11",
 						},
 					},
 				},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
This PR look for Spec.Image instead of Spec.ImageFamily when when Version is specified but Spec.Image and Spec.ImageFamily are not. Also it include the patch version as well instead of current major minor version.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #293 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Root Disk Image lookup should use a filter on image name rather than family and include patch version
```
