### PR TITLE
Improve resilience of cluster delete

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -115,6 +115,11 @@ func (s *ClusterScope) NetworkName() string {
 	return pointer.StringDeref(s.GCPCluster.Spec.Network.Name, "default")
 }
 
+// NetworkLink returns the partial URL for the network.
+func (s *ClusterScope) NetworkLink() string {
+	return fmt.Sprintf("projects/%s/global/networks/%s", s.Project(), s.NetworkName())
+}
+
 // Network returns the cluster network object.
 func (s *ClusterScope) Network() *infrav1.Network {
 	return &s.GCPCluster.Status.Network
@@ -193,11 +198,10 @@ func (s *ClusterScope) NatRouterSpec() *compute.Router {
 
 // FirewallRulesSpec returns google compute firewall spec.
 func (s *ClusterScope) FirewallRulesSpec() []*compute.Firewall {
-	network := s.Network()
 	firewallRules := []*compute.Firewall{
 		{
 			Name:    fmt.Sprintf("allow-%s-healthchecks", s.Name()),
-			Network: *network.SelfLink,
+			Network: s.NetworkLink(),
 			Allowed: []*compute.FirewallAllowed{
 				{
 					IPProtocol: "TCP",
@@ -217,7 +221,7 @@ func (s *ClusterScope) FirewallRulesSpec() []*compute.Firewall {
 		},
 		{
 			Name:    fmt.Sprintf("allow-%s-cluster", s.Name()),
-			Network: *network.SelfLink,
+			Network: s.NetworkLink(),
 			Allowed: []*compute.FirewallAllowed{
 				{
 					IPProtocol: "all",

--- a/cloud/services/compute/firewalls/reconcile.go
+++ b/cloud/services/compute/firewalls/reconcile.go
@@ -49,7 +49,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 // Delete delete cluster firewall compoenents.
 func (s *Service) Delete(ctx context.Context) error {
 	log := log.FromContext(ctx)
-	log.Info("Deleting network resources")
+	log.Info("Deleting firewall resources")
 	for _, spec := range s.scope.FirewallRulesSpec() {
 		log.V(2).Info("Deleting firewall", "name", spec.Name)
 		firewallKey := meta.GlobalKey(spec.Name)

--- a/cloud/services/compute/instances/reconcile.go
+++ b/cloud/services/compute/instances/reconcile.go
@@ -206,7 +206,7 @@ func (s *Service) deregisterControlPlaneInstance(ctx context.Context, instance *
 		InstanceState: "RUNNING",
 	}, filter.None)
 	if err != nil {
-		return err
+		return gcperrors.IgnoreNotFound(err)
 	}
 
 	instanceSets := sets.NewString()
@@ -224,7 +224,7 @@ func (s *Service) deregisterControlPlaneInstance(ctx context.Context, instance *
 				},
 			},
 		}); err != nil {
-			return err
+			return gcperrors.IgnoreNotFound(err)
 		}
 	}
 

--- a/cloud/services/compute/networks/reconcile.go
+++ b/cloud/services/compute/networks/reconcile.go
@@ -52,7 +52,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 // Delete delete cluster network components.
 func (s *Service) Delete(ctx context.Context) error {
 	log := log.FromContext(ctx)
-	log.Info("Deleting firewall resources")
+	log.Info("Deleting network resources")
 	networkKey := meta.GlobalKey(s.scope.NetworkName())
 	log.V(2).Info("Looking for network before deleting", "name", networkKey)
 	network, err := s.networks.Get(ctx, networkKey)


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We've experienced some issue where deleting of a CAPG cluster results in the delete reconciliation getting stuck. 

In one scenario the InstanceGroup is removed without all the instances being removed and upon the next reconcile loop the code error's out when trying to find the InstanceGroup. This PR allows that to silently fail as we want to continue with the clean up of other resources anyway.

Another issue we saw was the `.Status.Network.SelfLink` being cleared but subsequent delete reconcile loops attempting to use it to build the firewall rules object - resulting in a nil pointer panic. Rather than referencing the SelfLink, we instead build the partial URL from the known project and network name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
