### PR TITLE
Add info about the kubernetes version env variable

### DIFF
--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -130,6 +130,7 @@ $ export GCP_REGION="<GCP_REGION>" \
 $ export GCP_PROJECT="<GCP_PROJECT>" \
 $ export CONTROL_PLANE_MACHINE_COUNT=1 \
 $ export WORKER_MACHINE_COUNT=1 \
+# Make sure to use same kubernetes version here as building the GCE image
 $ export KUBERNETES_VERSION=1.23.3 \
 $ export GCP_CONTROL_PLANE_MACHINE_TYPE=n1-standard-2 \
 $ export GCP_NODE_MACHINE_TYPE=n1-standard-2 \


### PR DESCRIPTION
Add instruction to use the same k8s version as building the GCE image

Signed-off-by: Aniruddha Basak <codewithaniruddha@gmail.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
The current information [here](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/main/docs/book/src/developers/development.md#tilt-for-dev-in-capg) about the `KUBERNETES_VERSION` env variable version is being 1.23.3 my control plane is not getting ready if my GCE OS image is not the same as the version mentioned. So adding a note about checking the version while building the OS image and exporting afterward will always help. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add instruction to use the same k8s version as building the GCE image
```
