### PR TITLE
Fix panic when no failure domain found

### DIFF
--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -95,6 +95,9 @@ func (m *MachineScope) Cloud() cloud.Cloud {
 func (m *MachineScope) Zone() string {
 	if m.Machine.Spec.FailureDomain == nil {
 		fd := m.ClusterGetter.FailureDomains()
+		if len(fd) == 0 {
+			return ""
+		}
 		zones := make([]string, 0, len(fd))
 		for zone := range fd {
 			zones = append(zones, zone)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
We are using [externally managed cluster infrastructure](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210203-externally-managed-cluster-infrastructure.md) and nothing sets failure domain on cluster object, this makes controller panic when it's missing. I believe the controller should not panic here and fail in another place in this case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Fix panic when no failure domain found
```
