### PR TITLE
fix: use right name for EnableFlowLogs field

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -147,7 +147,7 @@ type SubnetSpec struct {
 	// If this field is not explicitly set, it will not appear in get
 	// listings. If not set the default behavior is to disable flow logging.
 	// +optional
-	EnableFlowLogs *bool `json:"routeTableId"`
+	EnableFlowLogs *bool `json:"enableFlowLogs"`
 }
 
 // String returns a string representation of the subnet.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -565,6 +565,12 @@ spec:
                           description: Description is an optional description associated
                             with the resource.
                           type: string
+                        enableFlowLogs:
+                          description: 'EnableFlowLogs: Whether to enable flow logging
+                            for this subnetwork. If this field is not explicitly set,
+                            it will not appear in get listings. If not set the default
+                            behavior is to disable flow logging.'
+                          type: boolean
                         name:
                           description: Name defines a unique identifier to reference
                             this resource.
@@ -578,12 +584,6 @@ spec:
                           description: Region is the name of the region where the
                             Subnetwork resides.
                           type: string
-                        routeTableId:
-                          description: 'EnableFlowLogs: Whether to enable flow logging
-                            for this subnetwork. If this field is not explicitly set,
-                            it will not appear in get listings. If not set the default
-                            behavior is to disable flow logging.'
-                          type: boolean
                         secondaryCidrBlocks:
                           additionalProperties:
                             type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -282,6 +282,13 @@ spec:
                                   description: Description is an optional description
                                     associated with the resource.
                                   type: string
+                                enableFlowLogs:
+                                  description: 'EnableFlowLogs: Whether to enable
+                                    flow logging for this subnetwork. If this field
+                                    is not explicitly set, it will not appear in get
+                                    listings. If not set the default behavior is to
+                                    disable flow logging.'
+                                  type: boolean
                                 name:
                                   description: Name defines a unique identifier to
                                     reference this resource.
@@ -295,13 +302,6 @@ spec:
                                   description: Region is the name of the region where
                                     the Subnetwork resides.
                                   type: string
-                                routeTableId:
-                                  description: 'EnableFlowLogs: Whether to enable
-                                    flow logging for this subnetwork. If this field
-                                    is not explicitly set, it will not appear in get
-                                    listings. If not set the default behavior is to
-                                    disable flow logging.'
-                                  type: boolean
                                 secondaryCidrBlocks:
                                   additionalProperties:
                                     type: string


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

It seems like a copy paste error. The field name doesn't match with the field name when marshalling. I think this is a breaking change.

```release-note
Fix EnableFlowLogs field name
```
