### PR TITLE
Minor docs / Tiltfile cleanup

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -94,7 +94,7 @@ def validate_auth():
     substitutions = settings.get("kustomize_substitutions", {})
     missing = [k for k in keys if k not in substitutions]
     if missing:
-        fail("missing kustomize_substitutions keys {} in tilt-setting.json".format(missing))
+        fail("missing kustomize_substitutions keys {} in tilt-settings.json".format(missing))
 
 tilt_helper_dockerfile_header = """
 # Tilt image
@@ -187,9 +187,9 @@ def kustomizesub(folder):
     return yaml
 
 def waitforsystem():
-    local(kubectl_cmd + "wait --for=condition=ready --timeout=300s pod --all -n capi-kubeadm-bootstrap-system")
-    local(kubectl_cmd + "wait --for=condition=ready --timeout=300s pod --all -n capi-kubeadm-control-plane-system")
-    local(kubectl_cmd + "wait --for=condition=ready --timeout=300s pod --all -n capi-system")
+    local(kubectl_cmd + " wait --for=condition=ready --timeout=300s pod --all -n capi-kubeadm-bootstrap-system")
+    local(kubectl_cmd + " wait --for=condition=ready --timeout=300s pod --all -n capi-kubeadm-control-plane-system")
+    local(kubectl_cmd + " wait --for=condition=ready --timeout=300s pod --all -n capi-system")
 
 ##############################
 # Actual work happens here

--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -105,13 +105,14 @@ rather than Windows.
 
 ### Using Tilt
 
-Both of the [Tilt](https://tilt.dev) setups below will get you started developing CAPG in a local kind cluster.The main difference is the number of components you will build from source and the scope of the changes you'd like to make. If you only want to make changes in CAPG, then follow [CAPG instructions](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/main/docs/book/src/developers/development.md#tilt-for-dev-in-capg). This will save you from having to build all of the images for CAPI, which can take a while. If the scope of your development will span both CAPG and CAPI, then follow the [CAPI and CAPG instructions](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/main/docs/book/src/developers/development.md#tilt-for-dev-in-both-capg-and-capi).
+Both of the [Tilt](https://tilt.dev) setups below will get you started developing CAPG in a local kind cluster. The main difference is the number of components you will build from source and the scope of the changes you'd like to make. If you only want to make changes in CAPG, then follow [CAPG instructions](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/main/docs/book/src/developers/development.md#tilt-for-dev-in-capg). This will save you from having to build all of the images for CAPI, which can take a while. If the scope of your development will span both CAPG and CAPI, then follow the [CAPI and CAPG instructions](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/main/docs/book/src/developers/development.md#tilt-for-dev-in-both-capg-and-capi).
 
 #### Tilt for dev in CAPG
 
 If you want to develop in CAPG and get a local development cluster working quickly, this is the path for you.
 
-From the root of the CAPG repository and after configuring the environment variables, you can run the following to generate your `tilt-settings.json` file:
+From the root of the CAPG repository, run the following to generate a `tilt-settings.json` file with your GCP
+service account credentials:
 
 ```shell
 $ cat <<EOF > tilt-settings.json
@@ -123,7 +124,7 @@ $ cat <<EOF > tilt-settings.json
 EOF
 ```
 
-Need setup some environment variables:
+Set the following environment variables with the appropriate values for your environment:
 
 ```shell
 $ export GCP_REGION="<GCP_REGION>" \
@@ -270,7 +271,8 @@ delve -a tcp://localhost:30000
 
 #### Deploying a workload cluster
 
-After your kind management cluster is up and running with Tilt, you can [configure workload cluster settings](#customizing-the-cluster-deployment) and deploy a workload cluster with the following:
+After your kind management cluster is up and running with Tilt, ensure you have all the environment variables set as
+described in [Tilt for dev in CAPG](#tilt-for-dev-in-capg), and deploy a workload cluster with the following:
 
 ```shell
 make create-workload-cluster


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Ran into some minor things when going through the Development getting started documentation:

* Minor typos in `development.md`, and a dead link / unclear instructions on creating a workload cluster
* Typo in an error message in the Tiltfile
* Bad string concatination in the Tiltfile that was resulting in invalid kubectl commands, such as `kubectlwait <...remainder of args...>` as opposed to `kubectl wait <...remainder of args...>`

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
