### PR TITLE
docs: Add section about Machine Location

### DIFF
--- a/docs/book/src/topics/machine-locations.md
+++ b/docs/book/src/topics/machine-locations.md
@@ -1,0 +1,47 @@
+# Machine Locations
+
+This document describes how to configure the location of a CAPG cluster's compute resources. By default, CAPG requires the user to specify a [GCP region](https://cloud.google.com/compute/docs/regions-zones#available) for the cluster's machines by setting the `GCP_REGION` environment variable as outlined in the [CAPI quickstart guide](https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers). The provider then picks a zone to deploy the control plane and worker nodes in and generates the according portions of the cluster's YAML manifests.
+
+It is possible to override this default behaviour and exercise more fine-grained control over machine locations as outlined in the rest of this document.
+
+## Control Plane Machine Location
+
+Before deploying the cluster, add a `failureDomains` field to the `spec` of your `GCPCluster` definition, containing a list of allowed zones:
+
+```diff
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: GCPCluster
+metadata:
+  name: capi-quickstart
+spec:
+  network:
+    name: default
+  project: cyberscan2
+  region: europe-west3
++  failureDomains:
++    - europe-west3-b
+```
+
+In this example configuration, only a single zone has been added, ensuring the control plane is provisioned in `europe-west3-b`.
+
+## Node Pool Location
+
+Similar to the above, you can override the auto-generated GCP zone for your `MachineDeployment`, by changing the value of the `failureDomain` field at `spec.template.spec.failureDomain`:
+
+```diff
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: MachineDeployment
+metadata:
+  name: capi-quickstart-md-0
+spec:
+  clusterName: capi-quickstart
+  # [...]
+  template:
+    spec:
+      # [...]
+      clusterName: capi-quickstart
+-      failureDomain: europe-west3-a
++      failureDomain: europe-west3-b
+```
+
+When combined like this, the above configuration effectively instructs CAPG to deploy the CAPI equivalent of a [zonal GKE cluster](https://cloud.google.com/kubernetes-engine/docs/concepts/types-of-clusters#availability).


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds section to docs about machine location.

Kudos to @itspngu -- This reattempts to merge https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/455.

I unfortunately couldn't cherry-pick it as the original repo is deleted, but think this information is still highly relevant and important to people who are getting started with CAPG.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #444

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Evan Freed <evan.freed@protonmail.ch>

/kind documentation
