### PR TITLE
Fix broken `TestGCPClusterTemplate_ValidateUpdate` test

### DIFF
--- a/api/v1beta1/gcpclustertemplate_webhook_test.go
+++ b/api/v1beta1/gcpclustertemplate_webhook_test.go
@@ -77,6 +77,7 @@ func TestGCPClusterTemplate_ValidateUpdate(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			err := test.newTemplate.ValidateUpdate(test.oldTemplate)


### PR DESCRIPTION
/kind failing-test

More like "not running" test rather than failing

**What this PR does / why we need it**:

Parallel test closures execute in a goroutine, possibly after the next
loop iteration has already began. As a result, the loop var they
capture changes before the test execute, leading to all of them
executing just the last test in the list.

This fixes that by making the closure capture a local variable rather
than the loop variable

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

None

**Special notes for your reviewer**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

```release-note
NONE
```