### PR TITLE
Fix make target for test with coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ test/e2e/config/gcp-ci-envsubst.yaml
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage.*
 
 # Ansible
 *.retry

--- a/Makefile
+++ b/Makefile
@@ -181,9 +181,9 @@ test-e2e-run: $(ENVSUBST) $(KUBECTL) $(GINKGO) e2e-image ## Run the end-to-end t
 
 .PHONY: test-cover
 test-cover:  ## Run unit and integration tests and generate a coverage report
-	$(MAKE) test TEST_ARGS="$(TEST_ARGS) -coverprofile=out/coverage.out"
-	go tool cover -func=out/coverage.out -o out/coverage.txt
-	go tool cover -html=out/coverage.out -o out/coverage.html
+	$(MAKE) test TEST_ARGS="$(TEST_ARGS) -coverprofile=coverage.out"
+	go tool cover -func=coverage.out -o coverage.txt
+	go tool cover -html=coverage.out -o coverage.html
 
 .PHONY: test-junit
 test-junit: $(SETUP_ENVTEST) $(GOTESTSUM) ## Run tests with verbose setting and generate a junit report

--- a/scripts/ci-test-coverage.sh
+++ b/scripts/ci-test-coverage.sh
@@ -22,5 +22,4 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 # shellcheck source=hack/ensure-go.sh
 source "${REPO_ROOT}/hack/ensure-go.sh"
 
-cd "${REPO_ROOT}" && \
-	make test-cover
+make --directory="${REPO_ROOT}" test-cover


### PR DESCRIPTION
**What type of PR is this?**

/kind other

**What this PR does / why we need it**:

Running the `make` target for running tests with coverage fails

```
make test TEST_ARGS=" -coverprofile=out/coverage.out"
make[1]: Entering directory '/home/jose/dev/src/github.com/kubernetes-sigs/cluster-api-provider-gcp'
KUBEBUILDER_ASSETS="/home/jose/.local/share/kubebuilder-envtest/k8s/1.23.3-linux-amd64" go test ./... -coverprofile=out/coverage.out
open /home/jose/dev/src/github.com/kubernetes-sigs/cluster-api-provider-gcp/out/coverage.out: no such file or directory
make[1]: *** [Makefile:161: test] Error 1
make[1]: Leaving directory '/home/jose/dev/src/github.com/kubernetes-sigs/cluster-api-provider-gcp'
make: *** [Makefile:184: test-cover] Error 2
```

I checked [how capz is doing it](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/Makefile#L644-L648) and I think we are setting here the wrong value.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [X] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
