### PR TITLE
feat: Upgrade Cert-Manager version to the latest(v1.9.1)

### DIFF
--- a/hack/install-cert-manager.sh
+++ b/hack/install-cert-manager.sh
@@ -52,7 +52,7 @@ KUBECTL="${REPO_ROOT}/hack/tools/bin/kubectl"
 cd "${REPO_ROOT}" && make "${KUBECTL##*/}"
 
 ## Install cert manager and wait for availability
-"${KUBECTL}" apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.yaml
+"${KUBECTL}" apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
Feature, upgrade the Cert Manager version to `v1.9.1`

**What this PR does / why we need it**:
Installs the latest version `v.1.9.1`(at the moment) when executing the script: `hack/install-cert-manager.sh`
We are using the `v1.7.1`.
Cert Manager releases: [link](https://cert-manager.io/docs/installation/supported-releases/)
Cert Manager Release 1.9: [link](https://cert-manager.io/docs/release-notes/release-notes-1.9/)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
_There is no issue crated_

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._
Yes, this is the only change.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrade Cert Manager to v1.9.1
```

/kind feature