### PR TITLE
update capi to v1.1.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -446,7 +446,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST)
 	./hack/install-cert-manager.sh
 
 	# Deploy CAPI
-	curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.5/cluster-api-components.yaml | $(ENVSUBST) | kubectl apply -f -
+	curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.6/cluster-api-components.yaml | $(ENVSUBST) | kubectl apply -f -
 
 	# Deploy CAPG
 	kind load docker-image $(CONTROLLER_IMG)-$(ARCH):$(TAG) --name=clusterapi

--- a/Tiltfile
+++ b/Tiltfile
@@ -16,7 +16,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capg",
-    "capi_version": "v1.1.5",
+    "capi_version": "v1.1.6",
     "cert_manager_version": "v1.1.0",
     "kubernetes_version": "v1.22.11",
 }

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	k8s.io/client-go v0.23.6
 	k8s.io/klog/v2 v2.70.0
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed
-	sigs.k8s.io/cluster-api v1.1.5
-	sigs.k8s.io/cluster-api/test v1.1.5
+	sigs.k8s.io/cluster-api v1.1.6
+	sigs.k8s.io/cluster-api/test v1.1.6
 	sigs.k8s.io/controller-runtime v0.11.2
 )
 
@@ -126,4 +126,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.1.5
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -1331,10 +1331,10 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
-sigs.k8s.io/cluster-api v1.1.5 h1:4gV3mg1mlwrm3bFWeXADfL9ILRyufjR47KpwBL3PT6Y=
-sigs.k8s.io/cluster-api v1.1.5/go.mod h1:WBPgw1yJdvybx/U3Ib49T9Q4JurairgnA/s0afxuE/w=
-sigs.k8s.io/cluster-api/test v1.1.5 h1:jukMEA50R3V6G7VcJMR7dMZJPd3Tuf0Orc/6CKuS9Ek=
-sigs.k8s.io/cluster-api/test v1.1.5/go.mod h1:NXFioUFKruk/PgpUt4QrprV9bN1rVUcm7OWao9dfesg=
+sigs.k8s.io/cluster-api v1.1.6 h1:fd0ap613+3YgKjZ28cN6GzPo5czyTcuyGPV4U60RtjA=
+sigs.k8s.io/cluster-api v1.1.6/go.mod h1:WBPgw1yJdvybx/U3Ib49T9Q4JurairgnA/s0afxuE/w=
+sigs.k8s.io/cluster-api/test v1.1.6 h1:FbmJk7CXM5zcv6mfni3sl3fdnJ4oKr/UXoBtHcSjzWg=
+sigs.k8s.io/cluster-api/test v1.1.6/go.mod h1:NXFioUFKruk/PgpUt4QrprV9bN1rVUcm7OWao9dfesg=
 sigs.k8s.io/controller-runtime v0.11.2 h1:H5GTxQl0Mc9UjRJhORusqfJCIjBO8UtUxGggCwL1rLA=
 sigs.k8s.io/controller-runtime v0.11.2/go.mod h1:P6QCzrEjLaZGqHsfd+os7JQ+WFZhvB8MRFsn4dWF7O4=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 h1:fD1pz4yfdADVNfFmcP2aBEtudwUQ1AlLnRBALr33v3s=

--- a/hack/install-cert-manager.sh
+++ b/hack/install-cert-manager.sh
@@ -52,7 +52,7 @@ KUBECTL="${REPO_ROOT}/hack/tools/bin/kubectl"
 cd "${REPO_ROOT}" && make "${KUBECTL##*/}"
 
 ## Install cert manager and wait for availability
-"${KUBECTL}" apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.yaml
+"${KUBECTL}" apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.2/cert-manager.yaml
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook

--- a/test/e2e/config/gcp-ci.yaml
+++ b/test/e2e/config/gcp-ci.yaml
@@ -15,8 +15,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-    - name: v1.1.5
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.5/core-components.yaml
+    - name: v1.1.6
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.6/core-components.yaml
       type: url
       files:
       - sourcePath: "../data/shared/v1beta1/metadata.yaml"
@@ -28,8 +28,8 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-    - name: v1.1.5
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.5/bootstrap-components.yaml
+    - name: v1.1.6
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.6/bootstrap-components.yaml
       type: url
       files:
       - sourcePath: "../data/shared/v1beta1/metadata.yaml"
@@ -41,8 +41,8 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-    - name: v1.1.5
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.5/control-plane-components.yaml
+    - name: v1.1.6
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.6/control-plane-components.yaml
       type: url
       files:
       - sourcePath: "../data/shared/v1beta1/metadata.yaml"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

- update capi to v1.1.6
- update certmanager to v1.9.2

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- update capi to v1.1.6
- update certmanager to v1.9.2
```
