### PR TITLE
update CAPI to v1.2.2 and golang to 1.18.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.18.5 as builder
+FROM golang:1.18.6 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -464,7 +464,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KIND) $(KUBECTL)
 	./hack/install-cert-manager.sh
 
 	# Deploy CAPI
-	curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.1/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -
+	curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.2/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -
 
 	# Deploy CAPG
 	$(KIND) load docker-image $(CONTROLLER_IMG)-$(ARCH):$(TAG) --name=clusterapi

--- a/Tiltfile
+++ b/Tiltfile
@@ -18,7 +18,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capg",
-    "capi_version": "v1.2.1",
+    "capi_version": "v1.2.2",
     "cert_manager_version": "v1.1.0",
     "kubernetes_version": "v1.22.11",
 }

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	k8s.io/client-go v0.24.4
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
-	sigs.k8s.io/cluster-api v1.2.1
-	sigs.k8s.io/cluster-api/test v1.2.1
+	sigs.k8s.io/cluster-api v1.2.2
+	sigs.k8s.io/cluster-api/test v1.2.2
 	sigs.k8s.io/controller-runtime v0.12.3
 )
 
@@ -129,4 +129,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.1
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -1242,10 +1242,10 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
-sigs.k8s.io/cluster-api v1.2.1 h1:/DbsSy04mP8x/B7pzMv8vbIolE4Jh0icnJhlsh1Nlug=
-sigs.k8s.io/cluster-api v1.2.1/go.mod h1:oiuV+mlCV1QxDnuI+PfElFlAfuXHo9ZGVBojoihVtHY=
-sigs.k8s.io/cluster-api/test v1.2.1 h1:NiVPpS0BMax38CY8apwPBhagTbQX3vf9kiUb2fGBGWI=
-sigs.k8s.io/cluster-api/test v1.2.1/go.mod h1:JdMqpv9rEOFWQVQ8danpBduqxoQkZMiOvpIGJ7v8qjw=
+sigs.k8s.io/cluster-api v1.2.2 h1:acx31Eyv5s4xeublsbxWpRFjcQ5h4BmDPI0glm3sEoE=
+sigs.k8s.io/cluster-api v1.2.2/go.mod h1:oiuV+mlCV1QxDnuI+PfElFlAfuXHo9ZGVBojoihVtHY=
+sigs.k8s.io/cluster-api/test v1.2.2 h1:DUVmlCVQ0H7zY1doxzS1JuooUjXxTN80i9swc16tZd0=
+sigs.k8s.io/cluster-api/test v1.2.2/go.mod h1:JdMqpv9rEOFWQVQ8danpBduqxoQkZMiOvpIGJ7v8qjw=
 sigs.k8s.io/controller-runtime v0.12.3 h1:FCM8xeY/FI8hoAfh/V4XbbYMY20gElh9yh+A98usMio=
 sigs.k8s.io/controller-runtime v0.12.3/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=

--- a/test/e2e/config/gcp-ci.yaml
+++ b/test/e2e/config/gcp-ci.yaml
@@ -15,8 +15,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-    - name: v1.2.1
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.1/core-components.yaml
+    - name: v1.2.2
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.2/core-components.yaml
       type: url
       files:
       - sourcePath: "../data/shared/v1beta1/metadata.yaml"
@@ -28,8 +28,8 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-    - name: v1.2.1
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.1/bootstrap-components.yaml
+    - name: v1.2.2
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.2/bootstrap-components.yaml
       type: url
       files:
       - sourcePath: "../data/shared/v1beta1/metadata.yaml"
@@ -41,8 +41,8 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-    - name: v1.2.1
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.1/control-plane-components.yaml
+    - name: v1.2.2
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.2/control-plane-components.yaml
       type: url
       files:
       - sourcePath: "../data/shared/v1beta1/metadata.yaml"


### PR DESCRIPTION
Signed-off-by: cpanato <ctadeu@gmail.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

- update CAPI to v1.2.2 and golang to 1.18.6

/hold for all tests


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
update CAPI to v1.2.2 and golang to 1.18.6
```
