### PR TITLE
Subnet role must be passed

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -213,6 +213,7 @@ func (s *ClusterScope) SubnetSpecs() []*compute.Subnetwork {
 			Description:           pointer.StringDeref(subnetwork.Description, infrav1.ClusterTagKey(s.Name())),
 			Network:               s.NetworkLink(),
 			Purpose:               pointer.StringDeref(subnetwork.Purpose, "PRIVATE_RFC_1918"),
+			Role:                  "ACTIVE",
 		})
 	}
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When creating a new [proxy-only subnet](https://cloud.google.com/load-balancing/docs/proxy-only-subnets) using the `REGIONAL_MANAGED_PROXY` purpose, we need to pass the subnet Role.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set subnet role to ACTIVE
```
