### PR TITLE
Fix compute service initialization in tests

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -50,12 +50,12 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 		return nil, errors.New("failed to generate new scope from nil GCPCluster")
 	}
 
-	computeSvc, err := compute.NewService(context.TODO())
-	if err != nil {
-		return nil, errors.Errorf("failed to create gcp compute client: %v", err)
-	}
-
 	if params.GCPServices.Compute == nil {
+		computeSvc, err := compute.NewService(context.TODO())
+		if err != nil {
+			return nil, errors.Errorf("failed to create gcp compute client: %v", err)
+		}
+
 		params.GCPServices.Compute = computeSvc
 	}
 

--- a/cloud/services/compute/instances/reconcile_test.go
+++ b/cloud/services/compute/instances/reconcile_test.go
@@ -137,6 +137,9 @@ func TestService_createOrGetInstance(t *testing.T) {
 		Client:     fakec,
 		Cluster:    fakeCluster,
 		GCPCluster: fakeGCPCluster,
+		GCPServices: scope.GCPServices{
+			Compute: &compute.Service{},
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -156,6 +159,9 @@ func TestService_createOrGetInstance(t *testing.T) {
 		Client:     fakec,
 		Cluster:    fakeCluster,
 		GCPCluster: fakeGCPClusterWithOutFailureDomain,
+		GCPServices: scope.GCPServices{
+			Compute: &compute.Service{},
+		},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/cloud/services/compute/subnets/reconcile_test.go
+++ b/cloud/services/compute/subnets/reconcile_test.go
@@ -86,6 +86,9 @@ func TestService_Reconcile(t *testing.T) {
 		Client:     fakec,
 		Cluster:    fakeCluster,
 		GCPCluster: fakeGCPCluster,
+		GCPServices: scope.GCPServices{
+			Compute: &compute.Service{},
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -180,6 +183,9 @@ func TestService_Delete(t *testing.T) {
 		Client:     fakec,
 		Cluster:    fakeCluster,
 		GCPCluster: fakeGCPCluster,
+		GCPServices: scope.GCPServices{
+			Compute: &compute.Service{},
+		},
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
Running unit tests with no real GCP credentials fails with the following error:
```
--- FAIL: TestService_createOrGetInstance (0.00s)
    reconcile_test.go:142: failed to create gcp compute client: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
```
This is because the compute service gets initialized here https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/main/cloud/scope/cluster.go#L53 and it always tries to use real credentials.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix compute service initialization in tests
```
