### PR TITLE
Fix panic when ClusterNetwork is nil

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -133,7 +133,10 @@ func (s *ClusterScope) AdditionalLabels() infrav1.Labels {
 // ControlPlaneEndpoint returns the cluster control-plane endpoint.
 func (s *ClusterScope) ControlPlaneEndpoint() clusterv1.APIEndpoint {
 	endpoint := s.GCPCluster.Spec.ControlPlaneEndpoint
-	endpoint.Port = pointer.Int32Deref(s.Cluster.Spec.ClusterNetwork.APIServerPort, 443)
+	endpoint.Port = 443
+	if c := s.Cluster.Spec.ClusterNetwork; c != nil {
+		endpoint.Port = pointer.Int32Deref(c.APIServerPort, 443)
+	}
 	return endpoint
 }
 
@@ -294,7 +297,10 @@ func (s *ClusterScope) BackendServiceSpec() *compute.BackendService {
 
 // ForwardingRuleSpec returns google compute forwarding-rule spec.
 func (s *ClusterScope) ForwardingRuleSpec() *compute.ForwardingRule {
-	port := pointer.Int32Deref(s.Cluster.Spec.ClusterNetwork.APIServerPort, 443)
+	port := int32(443)
+	if c := s.Cluster.Spec.ClusterNetwork; c != nil {
+		port = pointer.Int32Deref(c.APIServerPort, 443)
+	}
 	portRange := fmt.Sprintf("%d-%d", port, port)
 	return &compute.ForwardingRule{
 		Name:                fmt.Sprintf("%s-%s", s.Name(), infrav1.APIServerRoleTagValue),


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

When `Cluster.ClusterNetwork` is not set in a deployed cluster, the provider will panic in a loop trying to reconcile the object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

`Cluster.ClusterNetwork` is a pointer and may be nil, ensure that the provider does not panic in this case.

**Special notes for your reviewer**:

Seems like a minor fix, and the code already falls back to a value if none is set, so I don't believe there are any changes needed for tests / docs.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix provider panic when ClusterNetwork is nil
```
