### PR TITLE
Fix GCPMachineTemplate specs incorrect reference

### DIFF
--- a/api/v1beta1/gcpmachinetemplate_webhook.go
+++ b/api/v1beta1/gcpmachinetemplate_webhook.go
@@ -67,19 +67,26 @@ func (r *GCPMachineTemplate) ValidateUpdate(old runtime.Object) error {
 	newGCPMachineTemplateSpec := newGCPMachineTemplate["spec"].(map[string]interface{})
 	oldGCPMachineTemplateSpec := oldGCPMachineTemplate["spec"].(map[string]interface{})
 
+	newGCPMachineTemplateSpecTemplate := newGCPMachineTemplateSpec["template"].(map[string]interface{})
+	oldGCPMachineTemplateSpecTemplate := oldGCPMachineTemplateSpec["template"].(map[string]interface{})
+
+	newGCPMachineTemplateSpecTemplateSpec := newGCPMachineTemplateSpecTemplate["spec"].(map[string]interface{})
+	oldGCPMachineTemplateSpecTemplateSpec := oldGCPMachineTemplateSpecTemplate["spec"].(map[string]interface{})
 	// allow changes to providerID
-	delete(oldGCPMachineTemplateSpec, "providerID")
-	delete(newGCPMachineTemplateSpec, "providerID")
+	delete(oldGCPMachineTemplateSpecTemplateSpec, "providerID")
+	delete(newGCPMachineTemplateSpecTemplateSpec, "providerID")
 
 	// allow changes to additionalLabels
-	delete(oldGCPMachineTemplateSpec, "additionalLabels")
-	delete(newGCPMachineTemplateSpec, "additionalLabels")
+	delete(oldGCPMachineTemplateSpecTemplateSpec, "additionalLabels")
+	delete(newGCPMachineTemplateSpecTemplateSpec, "additionalLabels")
 
 	// allow changes to additionalNetworkTags
-	delete(oldGCPMachineTemplateSpec, "additionalNetworkTags")
-	delete(newGCPMachineTemplateSpec, "additionalNetworkTags")
+	delete(oldGCPMachineTemplateSpecTemplateSpec, "additionalNetworkTags")
+	delete(newGCPMachineTemplateSpecTemplateSpec, "additionalNetworkTags")
 
-	if !reflect.DeepEqual(oldGCPMachineTemplateSpec, newGCPMachineTemplateSpec) {
+	delete(newGCPMachineTemplateSpecTemplateSpec, "ipForwarding")
+
+	if !reflect.DeepEqual(oldGCPMachineTemplateSpecTemplateSpec, newGCPMachineTemplateSpecTemplateSpec) {
 		return apierrors.NewInvalid(GroupVersion.WithKind("GCPMachineTemplate").GroupKind(), r.Name, field.ErrorList{
 			field.Forbidden(field.NewPath("spec"), "cannot be modified"),
 		})


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
The specs providerID, additionalLabels, additionalNetworkTags and ipForwarding follow the hierarchy `GCPMachineTemplate/Spec/Template/Spec`and not `GCPMachineTemplate/Spec`. Due to this during K8s updation, the worker node is not getting updated and throwing "invalid spec" error. This PR fixes the incorrect reference of GCPMachineTemplate specs in api/v1beta1/gcpmachinetemplate_webhook.go file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #824 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
Fix GCPMachineTemplate specs incorrect reference
```
