### PR TITLE
Add validation webhooks (GKE part 7)

### DIFF
--- a/exp/api/v1beta1/gcpmanagedcluster_webhook.go
+++ b/exp/api/v1beta1/gcpmanagedcluster_webhook.go
@@ -17,7 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"github.com/google/go-cmp/cmp"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -53,10 +56,37 @@ func (r *GCPManagedCluster) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *GCPManagedCluster) ValidateUpdate(old runtime.Object) error {
+func (r *GCPManagedCluster) ValidateUpdate(oldRaw runtime.Object) error {
 	gcpmanagedclusterlog.Info("validate update", "name", r.Name)
+	var allErrs field.ErrorList
+	old := oldRaw.(*GCPManagedCluster)
 
-	return nil
+	if !cmp.Equal(r.Spec.Project, old.Spec.Project) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "Project"),
+				r.Spec.Project, "field is immutable"),
+		)
+	}
+
+	if !cmp.Equal(r.Spec.Region, old.Spec.Region) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "Region"),
+				r.Spec.Region, "field is immutable"),
+		)
+	}
+
+	if !cmp.Equal(r.Spec.CredentialsRef, old.Spec.CredentialsRef) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "CredentialsRef"),
+				r.Spec.CredentialsRef, "field is immutable"),
+		)
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(GroupVersion.WithKind("GCPManagedCluster").GroupKind(), r.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/exp/api/v1beta1/gcpmanagedcontrolplane_webhook.go
+++ b/exp/api/v1beta1/gcpmanagedcontrolplane_webhook.go
@@ -20,6 +20,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api-provider-gcp/util/hash"
@@ -70,15 +75,61 @@ var _ webhook.Validator = &GCPManagedControlPlane{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *GCPManagedControlPlane) ValidateCreate() error {
 	gcpmanagedcontrolplanelog.Info("validate create", "name", r.Name)
+	var allErrs field.ErrorList
 
-	return nil
+	if len(r.Spec.ClusterName) > maxClusterNameLength {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "ClusterName"),
+				r.Spec.ClusterName, fmt.Sprintf("cluster name cannot have more than %d characters", maxClusterNameLength)),
+		)
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(GroupVersion.WithKind("GCPManagedControlPlane").GroupKind(), r.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *GCPManagedControlPlane) ValidateUpdate(old runtime.Object) error {
+func (r *GCPManagedControlPlane) ValidateUpdate(oldRaw runtime.Object) error {
 	gcpmanagedcontrolplanelog.Info("validate update", "name", r.Name)
+	var allErrs field.ErrorList
+	old := oldRaw.(*GCPManagedControlPlane)
 
-	return nil
+	if !cmp.Equal(r.Spec.ClusterName, old.Spec.ClusterName) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "ClusterName"),
+				r.Spec.ClusterName, "field is immutable"),
+		)
+	}
+
+	if !cmp.Equal(r.Spec.Project, old.Spec.Project) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "Project"),
+				r.Spec.Project, "field is immutable"),
+		)
+	}
+
+	if !cmp.Equal(r.Spec.Location, old.Spec.Location) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "Location"),
+				r.Spec.Location, "field is immutable"),
+		)
+	}
+
+	if !cmp.Equal(r.Spec.EnableAutopilot, old.Spec.EnableAutopilot) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "EnableAutopilot"),
+				r.Spec.EnableAutopilot, "field is immutable"),
+		)
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(GroupVersion.WithKind("GCPManagedControlPlane").GroupKind(), r.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This change adds validation webhooks for `GCPManagedCluster`, `GCPManagedControlPlane`, and `GCPManagedMachinePool`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates #512

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add validation webhooks for **GCPManagedCluster**, **GCPManagedControlPlane**, and **GCPManagedMachinePool**
```
