### PR TITLE
test: adding e2e tests for gke (GKE Part 6)

### DIFF
--- a/cloud/providerid/doc.go
+++ b/cloud/providerid/doc.go
@@ -1,9 +1,12 @@
 /*
-Copyright 2021 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,9 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloud
-
-const (
-	// DefaultNumRegionsPerZone is the default number of zones per region.
-	DefaultNumRegionsPerZone = 3
-)
+// Package providerid implements functionality for creating kubernetes provider ids for nodes.
+package providerid

--- a/cloud/providerid/providerid.go
+++ b/cloud/providerid/providerid.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providerid
+
+import (
+	"errors"
+	"fmt"
+	"path"
+
+	"sigs.k8s.io/cluster-api-provider-gcp/util/resourceurl"
+)
+
+const (
+	// Prefix is the gce provider id prefix.
+	Prefix = "gce://"
+)
+
+// ProviderID represents the id for a GCP cluster.
+type ProviderID interface {
+	Project() string
+	Location() string
+	Name() string
+	fmt.Stringer
+}
+
+// NewFromResourceURL creates a provider from a GCP resource url.
+func NewFromResourceURL(url string) (ProviderID, error) {
+	resourceURL, err := resourceurl.Parse(url)
+	if err != nil {
+		return nil, fmt.Errorf("parsing resource url %s: %w", url, err)
+	}
+
+	return New(resourceURL.Project, resourceURL.Location, resourceURL.Name)
+}
+
+// New creates a new provider id.
+func New(project, location, name string) (ProviderID, error) {
+	if project == "" {
+		return nil, errors.New("project required for provider id")
+	}
+	if location == "" {
+		return nil, errors.New("location required for provider id")
+	}
+	if name == "" {
+		return nil, errors.New("name required for provider id")
+	}
+
+	return &providerID{
+		project:  project,
+		location: location,
+		name:     name,
+	}, nil
+}
+
+type providerID struct {
+	project  string
+	location string
+	name     string
+}
+
+func (p *providerID) Project() string {
+	return p.project
+}
+
+func (p *providerID) Location() string {
+	return p.location
+}
+
+func (p *providerID) Name() string {
+	return p.name
+}
+
+func (p *providerID) String() string {
+	return Prefix + path.Join(p.project, p.location, p.name)
+}

--- a/cloud/providerid/providerid_test.go
+++ b/cloud/providerid/providerid_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providerid_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/cluster-api-provider-gcp/cloud/providerid"
+)
+
+func TestProviderID_New(t *testing.T) {
+	RegisterTestingT(t)
+
+	testCases := []struct {
+		testname           string
+		project            string
+		location           string
+		name               string
+		expectedProviderID string
+		expectError        bool
+	}{
+		{
+			testname:    "no project, should fail",
+			project:     "",
+			location:    "eu-west4",
+			name:        "vm1",
+			expectError: true,
+		},
+		{
+			testname:    "no location, should fail",
+			project:     "proj1",
+			location:    "",
+			name:        "vm1",
+			expectError: true,
+		},
+		{
+			testname:    "no name, should fail",
+			project:     "proj1",
+			location:    "eu-west4",
+			name:        "",
+			expectError: true,
+		},
+		{
+			testname:           "with all details, should pass",
+			project:            "proj1",
+			location:           "eu-west4",
+			name:               "vm1",
+			expectError:        false,
+			expectedProviderID: "gce://proj1/eu-west4/vm1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testname, func(t *testing.T) {
+			providerID, err := providerid.New(tc.project, tc.location, tc.name)
+
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(providerID.String()).To(Equal(tc.expectedProviderID))
+			}
+		})
+	}
+}
+
+func TestProviderID_NewFromResourceURL(t *testing.T) {
+	RegisterTestingT(t)
+
+	testCases := []struct {
+		testname           string
+		resourceURL        string
+		expectedProviderID string
+		expectError        bool
+	}{
+		{
+			testname:    "invalid url, should fail",
+			resourceURL: "hvfnhdkdk",
+			expectError: true,
+		},
+		{
+			testname:           "valid instance url, should pass",
+			resourceURL:        "https://www.googleapis.com/compute/v1/projects/myproject/zones/europe-west2-a/instances/gke-capg-dskczmdculd-capg-e2e-ebs0oy--014f89ba-sx2p",
+			expectError:        false,
+			expectedProviderID: "gce://myproject/europe-west2-a/gke-capg-dskczmdculd-capg-e2e-ebs0oy--014f89ba-sx2p",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testname, func(t *testing.T) {
+			providerID, err := providerid.NewFromResourceURL(tc.resourceURL)
+
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(providerID.String()).To(Equal(tc.expectedProviderID))
+			}
+		})
+	}
+}

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud"
+	"sigs.k8s.io/cluster-api-provider-gcp/cloud/providerid"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -169,8 +170,8 @@ func (m *MachineScope) GetProviderID() string {
 
 // SetProviderID sets the GCPMachine providerID in spec.
 func (m *MachineScope) SetProviderID() {
-	providerID := cloud.ProviderIDPrefix + path.Join(m.ClusterGetter.Project(), m.Zone(), m.Name())
-	m.GCPMachine.Spec.ProviderID = pointer.StringPtr(providerID)
+	providerID, _ := providerid.New(m.ClusterGetter.Project(), m.Zone(), m.Name())
+	m.GCPMachine.Spec.ProviderID = pointer.StringPtr(providerID.String())
 }
 
 // GetInstanceStatus returns the GCPMachine instance status.

--- a/cloud/scope/managedcontrolplane.go
+++ b/cloud/scope/managedcontrolplane.go
@@ -215,3 +215,8 @@ func (s *ManagedControlPlaneScope) SetEndpoint(host string) {
 		Port: APIServerPort,
 	}
 }
+
+// IsAutopilotCluster returns true if this is an autopilot cluster.
+func (s *ManagedControlPlaneScope) IsAutopilotCluster() bool {
+	return s.GCPManagedControlPlane.Spec.EnableAutopilot
+}

--- a/cloud/services/container/clusters/errors.go
+++ b/cloud/services/container/clusters/errors.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusters
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// ErrAutopilotClusterMachinePoolsNotAllowed is used when there are machine pools specified for an autopilot enabled cluster.
+	ErrAutopilotClusterMachinePoolsNotAllowed = errors.New("cannot use machine pools with an autopilot enabled cluster")
+)
+
+// NewErrUnexpectedClusterStatus creates a new error for an unexpected cluster status.
+func NewErrUnexpectedClusterStatus(status string) error {
+	return &errUnexpectedClusterStatus{status}
+}
+
+type errUnexpectedClusterStatus struct {
+	status string
+}
+
+func (e *errUnexpectedClusterStatus) Error() string {
+	return fmt.Sprintf("unexpected error status: %s", e.status)
+}

--- a/cloud/services/container/clusters/kubeconfig.go
+++ b/cloud/services/container/clusters/kubeconfig.go
@@ -23,6 +23,7 @@ import (
 
 	"cloud.google.com/go/container/apiv1/containerpb"
 	"cloud.google.com/go/iam/credentials/apiv1/credentialspb"
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,7 +41,8 @@ const (
 	GkeScope = "https://www.googleapis.com/auth/cloud-platform"
 )
 
-func (s *Service) reconcileKubeconfig(ctx context.Context, cluster *containerpb.Cluster) error {
+func (s *Service) reconcileKubeconfig(ctx context.Context, cluster *containerpb.Cluster, log *logr.Logger) error {
+	log.Info("Reconciling kubeconfig")
 	clusterRef := types.NamespacedName{
 		Name:      s.scope.Cluster.Name,
 		Namespace: s.scope.Cluster.Namespace,
@@ -49,13 +51,16 @@ func (s *Service) reconcileKubeconfig(ctx context.Context, cluster *containerpb.
 	configSecret, err := secret.GetFromNamespacedName(ctx, s.scope.Client(), clusterRef, secret.Kubeconfig)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "failed to get kubeconfig secret")
+			log.Error(err, "getting kubeconfig secret", "name", clusterRef)
+			return fmt.Errorf("getting kubeconfig secret %s: %w", clusterRef, err)
 		}
+		log.Info("kubeconfig secret not found, creating")
 
 		if createErr := s.createCAPIKubeconfigSecret(
 			ctx,
 			cluster,
 			&clusterRef,
+			log,
 		); createErr != nil {
 			return fmt.Errorf("creating kubeconfig secret: %w", createErr)
 		}
@@ -66,7 +71,8 @@ func (s *Service) reconcileKubeconfig(ctx context.Context, cluster *containerpb.
 	return nil
 }
 
-func (s *Service) reconcileAdditionalKubeconfigs(ctx context.Context, cluster *containerpb.Cluster) error {
+func (s *Service) reconcileAdditionalKubeconfigs(ctx context.Context, cluster *containerpb.Cluster, log *logr.Logger) error {
+	log.Info("Reconciling additional kubeconfig")
 	clusterRef := types.NamespacedName{
 		Name:      s.scope.Cluster.Name + "-user",
 		Namespace: s.scope.Cluster.Namespace,
@@ -76,7 +82,7 @@ func (s *Service) reconcileAdditionalKubeconfigs(ctx context.Context, cluster *c
 	_, err := secret.GetFromNamespacedName(ctx, s.scope.Client(), clusterRef, secret.Kubeconfig)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "failed to get kubeconfig (user) secret")
+			return fmt.Errorf("getting kubeconfig (user) secret %s: %w", clusterRef, err)
 		}
 
 		createErr := s.createUserKubeconfigSecret(
@@ -85,7 +91,7 @@ func (s *Service) reconcileAdditionalKubeconfigs(ctx context.Context, cluster *c
 			&clusterRef,
 		)
 		if createErr != nil {
-			return err
+			return fmt.Errorf("creating additional kubeconfig secret: %w", err)
 		}
 	}
 
@@ -119,29 +125,31 @@ func (s *Service) createUserKubeconfigSecret(ctx context.Context, cluster *conta
 
 	out, err := clientcmd.Write(*cfg)
 	if err != nil {
-		return errors.Wrap(err, "failed to serialize config to yaml")
+		return fmt.Errorf("serialize kubeconfig to yaml: %w", err)
 	}
 
 	kubeconfigSecret := kubeconfig.GenerateSecretWithOwner(*clusterRef, out, controllerOwnerRef)
 	if err := s.scope.Client().Create(ctx, kubeconfigSecret); err != nil {
-		return errors.Wrap(err, "failed to create kubeconfig secret")
+		return fmt.Errorf("creating secret: %w", err)
 	}
 
 	return nil
 }
 
-func (s *Service) createCAPIKubeconfigSecret(ctx context.Context, cluster *containerpb.Cluster, clusterRef *types.NamespacedName) error {
+func (s *Service) createCAPIKubeconfigSecret(ctx context.Context, cluster *containerpb.Cluster, clusterRef *types.NamespacedName, log *logr.Logger) error {
 	controllerOwnerRef := *metav1.NewControllerRef(s.scope.GCPManagedControlPlane, infrav1exp.GroupVersion.WithKind("GCPManagedControlPlane"))
 
 	contextName := s.getKubeConfigContextName(false)
 
 	cfg, err := s.createBaseKubeConfig(contextName, cluster)
 	if err != nil {
+		log.Error(err, "failed creating base config")
 		return fmt.Errorf("creating base kubeconfig: %w", err)
 	}
 
 	token, err := s.generateToken(ctx)
 	if err != nil {
+		log.Error(err, "failed generating token")
 		return err
 	}
 	cfg.AuthInfos = map[string]*api.AuthInfo{
@@ -152,12 +160,14 @@ func (s *Service) createCAPIKubeconfigSecret(ctx context.Context, cluster *conta
 
 	out, err := clientcmd.Write(*cfg)
 	if err != nil {
-		return errors.Wrap(err, "failed to serialize config to yaml")
+		log.Error(err, "failed serializing kubeconfig to yaml")
+		return fmt.Errorf("serialize kubeconfig to yaml: %w", err)
 	}
 
 	kubeconfigSecret := kubeconfig.GenerateSecretWithOwner(*clusterRef, out, controllerOwnerRef)
 	if err := s.scope.Client().Create(ctx, kubeconfigSecret); err != nil {
-		return errors.Wrap(err, "failed to create kubeconfig secret")
+		log.Error(err, "failed creating secret")
+		return fmt.Errorf("creating secret: %w", err)
 	}
 
 	return nil

--- a/cloud/services/shared/doc.go
+++ b/cloud/services/shared/doc.go
@@ -1,9 +1,12 @@
 /*
-Copyright 2021 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,9 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloud
-
-const (
-	// DefaultNumRegionsPerZone is the default number of zones per region.
-	DefaultNumRegionsPerZone = 3
-)
+// Package shared implements functionality that is shared across different services.
+package shared

--- a/cloud/services/shared/machinepool.go
+++ b/cloud/services/shared/machinepool.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+
+	"sigs.k8s.io/cluster-api-provider-gcp/cloud"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
+)
+
+// ManagedMachinePoolPreflightCheck will perform checks against the machine pool before its created.
+func ManagedMachinePoolPreflightCheck(managedPool *infrav1exp.GCPManagedMachinePool, machinePool *clusterv1exp.MachinePool, location string) error {
+	if machinePool.Spec.Template.Spec.InfrastructureRef.Name != managedPool.Name {
+		return fmt.Errorf("expect machinepool infraref (%s) to match managed machine pool name (%s)", machinePool.Spec.Template.Spec.InfrastructureRef.Name, managedPool.Name)
+	}
+
+	if IsRegional(location) {
+		if *machinePool.Spec.Replicas%cloud.DefaultNumRegionsPerZone != 0 {
+			return fmt.Errorf("a machine pool (%s) in a regional cluster must have replicas with a multiple of %d", machinePool.Name, cloud.DefaultNumRegionsPerZone)
+		}
+	}
+
+	return nil
+}
+
+// ManagedMachinePoolsPreflightCheck will perform checks against a slice of machine pool before they are created.
+func ManagedMachinePoolsPreflightCheck(managedPools []infrav1exp.GCPManagedMachinePool, machinePools []clusterv1exp.MachinePool, location string) error {
+	if len(machinePools) != len(managedPools) {
+		return errors.New("each machinepool must have a matching gcpmanagedmachinepool")
+	}
+
+	for i := range machinePools {
+		machinepool := machinePools[i]
+		managedPool := managedPools[i]
+
+		if err := ManagedMachinePoolPreflightCheck(&managedPool, &machinepool, location); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// IsRegional will check if a given location is a region (if not its a zone).
+func IsRegional(location string) bool {
+	return strings.Count(location, "-") == 1
+}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanes.yaml
@@ -19,7 +19,25 @@ spec:
     singular: gcpmanagedcontrolplane
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Cluster to which this GCPManagedControlPlane belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Control plane is ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: The current Kubernetes version
+      jsonPath: .status.currentVersion
+      name: CurrentVersion
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.endpoint
+      name: Endpoint
+      priority: 1
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GCPManagedControlPlane is the Schema for the gcpmanagedcontrolplanes
@@ -79,7 +97,7 @@ spec:
                 type: string
               releaseChannel:
                 description: ReleaseChannel represents the release channel of the
-                  GKE cluster. If not specified, it defaults to `regular`.
+                  GKE cluster.
                 enum:
                 - rapid
                 - regular
@@ -95,7 +113,7 @@ spec:
               GCPManagedControlPlane.
             properties:
               conditions:
-                description: Conditions specifies the cpnditions for the managed control
+                description: Conditions specifies the conditions for the managed control
                   plane
                 items:
                   description: Condition defines an observation of a Cluster API resource
@@ -140,7 +158,14 @@ spec:
                   - type
                   type: object
                 type: array
+              currentVersion:
+                description: CurrentVersion shows the current version of the GKE control
+                  plane.
+                type: string
               ready:
+                default: false
+                description: Ready denotes that the GCPManagedControlPlane API Server
+                  is ready to receive requests.
                 type: boolean
             required:
             - ready

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedmachinepools.yaml
@@ -51,12 +51,6 @@ spec:
                   GCP resources managed by the GCP provider, in addition to the ones
                   added by default.
                 type: object
-              initialNodeCount:
-                description: InitialNodeCount represents the initial number of nodes
-                  for the pool. In regional or multi-zonal clusters, this is the number
-                  of nodes per zone.
-                format: int32
-                type: integer
               kubernetesLabels:
                 additionalProperties:
                   type: string
@@ -111,8 +105,6 @@ spec:
                     format: int32
                     type: integer
                 type: object
-            required:
-            - initialNodeCount
             type: object
           status:
             description: GCPManagedMachinePoolStatus defines the observed state of

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,6 +23,7 @@ spec:
         - --leader-elect
         - --feature-gates=GKE=${EXP_CAPG_GKE:=false}
         - "--metrics-bind-addr=localhost:8080"
+        - "--v=${CAPG_LOGLEVEL:=0}"
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,8 +21,12 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - cluster.x-k8s.io

--- a/docs/book/src/topics/gke/enabling.md
+++ b/docs/book/src/topics/gke/enabling.md
@@ -6,3 +6,5 @@ Enabling GKE support is done via the **GKE** feature flag by setting it to true.
 export EXP_CAPG_GKE=true
 clusterctl init --infrastructure gcp
 ```
+
+> IMPORTANT: To use GKE the service account used for CAPG will need the `iam.serviceAccountTokenCreator` role assigned.

--- a/docs/book/src/topics/prerequisites.md
+++ b/docs/book/src/topics/prerequisites.md
@@ -59,7 +59,11 @@ gcloud compute routers nats create "${CLUSTER_NAME}-mynat" --project="${GCP_PROJ
 
 To create and manage clusters, this infrastructure provider uses a service account to authenticate with GCP's APIs.
 
-From your cloud console, follow [these instructions](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating) to create a new service account with `Editor` permissions. Afterwards, generate a JSON Key and store it somewhere safe.
+From your cloud console, follow [these instructions](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating) to create a new service account with `Editor` permissions.
+
+If you plan yo use GKE the the service account will also need the `iam.serviceAccountTokenCreator` role.
+
+Afterwards, generate a JSON Key and store it somewhere safe.
 
 ### Building images
 

--- a/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
+++ b/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
@@ -41,7 +41,7 @@ type GCPManagedControlPlaneSpec struct {
 	Location string `json:"location"`
 	// EnableAutopilot indicates whether to enable autopilot for this GKE cluster.
 	EnableAutopilot bool `json:"enableAutopilot"`
-	// ReleaseChannel represents the release channel of the GKE cluster. If not specified, it defaults to `regular`.
+	// ReleaseChannel represents the release channel of the GKE cluster.
 	// +optional
 	ReleaseChannel *ReleaseChannel `json:"releaseChannel,omitempty"`
 	// ControlPlaneVersion represents the control plane version of the GKE cluster.
@@ -56,16 +56,27 @@ type GCPManagedControlPlaneSpec struct {
 
 // GCPManagedControlPlaneStatus defines the observed state of GCPManagedControlPlane.
 type GCPManagedControlPlaneStatus struct {
+	// Ready denotes that the GCPManagedControlPlane API Server is ready to
+	// receive requests.
+	// +kubebuilder:default=false
 	Ready bool `json:"ready"`
 
-	// Conditions specifies the cpnditions for the managed control plane
+	// Conditions specifies the conditions for the managed control plane
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+
+	// CurrentVersion shows the current version of the GKE control plane.
+	// +optional
+	CurrentVersion string `json:"currentVersion,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=gcpmanagedcontrolplanes,scope=Namespaced,categories=cluster-api,shortName=gcpmcp
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this GCPManagedControlPlane belongs"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Control plane is ready"
+// +kubebuilder:printcolumn:name="CurrentVersion",type="string",JSONPath=".status.currentVersion",description="The current Kubernetes version"
+// +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".spec.endpoint",description="API Endpoint",priority=1
 
 // GCPManagedControlPlane is the Schema for the gcpmanagedcontrolplanes API.
 type GCPManagedControlPlane struct {

--- a/exp/api/v1beta1/gcpmanagedcontrolplane_webhook.go
+++ b/exp/api/v1beta1/gcpmanagedcontrolplane_webhook.go
@@ -84,6 +84,10 @@ func (r *GCPManagedControlPlane) ValidateCreate() error {
 		)
 	}
 
+	if r.Spec.EnableAutopilot && r.Spec.ReleaseChannel == nil {
+		allErrs = append(allErrs, field.Required(field.NewPath("spec", "ReleaseChannel"), "Release channel is required for an autopilot enabled cluster"))
+	}
+
 	if len(allErrs) == 0 {
 		return nil
 	}

--- a/exp/api/v1beta1/gcpmanagedmachinepool_types.go
+++ b/exp/api/v1beta1/gcpmanagedmachinepool_types.go
@@ -34,9 +34,6 @@ type GCPManagedMachinePoolSpec struct {
 	// then a default name will be created based on the namespace and name of the managed machine pool.
 	// +optional
 	NodePoolName string `json:"nodePoolName,omitempty"`
-	// InitialNodeCount represents the initial number of nodes for the pool.
-	// In regional or multi-zonal clusters, this is the number of nodes per zone.
-	InitialNodeCount int32 `json:"initialNodeCount"`
 	// Scaling specifies scaling for the node pool
 	// +optional
 	Scaling *NodePoolAutoScaling `json:"scaling,omitempty"`

--- a/templates/cluster-template-gke-autopilot.yaml
+++ b/templates/cluster-template-gke-autopilot.yaml
@@ -33,29 +33,4 @@ metadata:
 spec:
   project: "${GCP_PROJECT}"
   location: "${GCP_REGION}"
----
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachinePool
-metadata:
-  name: "${CLUSTER_NAME}-mp-0"
-spec:
-  clusterName: "${CLUSTER_NAME}"
-  replicas: ${WORKER_MACHINE_COUNT}
-  template:
-    spec:
-      bootstrap:
-        dataSecretName: ""
-      clusterName: "${CLUSTER_NAME}"
-      infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: GCPManagedMachinePool
-        name: "${CLUSTER_NAME}-mp-0"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: GCPManagedMachinePool
-metadata:
-  name: "${CLUSTER_NAME}-mp-0"
-spec: {}
-
-
-
+  enableAutopilot: true

--- a/test/e2e/config/gcp-ci.yaml
+++ b/test/e2e/config/gcp-ci.yaml
@@ -69,6 +69,8 @@ providers:
     - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-topology.yaml"
     - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/clusterclass-quick-start.yaml"
     - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-creds.yaml"
+    - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-gke.yaml"
+    - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-gke-autopilot.yaml"
 
 variables:
   KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.25.5}"
@@ -92,12 +94,18 @@ variables:
   KUBETEST_CONFIGURATION: "${PWD}/test/e2e/data/kubetest/conformance.yaml"
   IMAGE_ID: "${IMAGE_ID}"
   IP_FAMILY: "IPv4"
+  EXP_CAPG_GKE: "true"
+  EXP_MACHINE_POOL: "true"
+  GKE_MACHINE_POOL_MIN: "1"
+  GKE_MACHINE_POOL_MAX: "2"
+  CAPG_LOGLEVEL: "4"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]
   default/wait-cluster: ["20m", "10s"]
   default/wait-control-plane: ["30m", "10s"]
   default/wait-worker-nodes: ["30m", "10s"]
+  default/wait-worker-machine-pools: ["30m", "10s"]
   default/wait-delete-cluster: ["20m", "10s"]
   default/wait-machine-upgrade: ["50m", "10s"]
   default/wait-machine-remediation: ["30m", "10s"]

--- a/test/e2e/data/infrastructure-gcp/cluster-template-ci-gke-autopilot.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-ci-gke-autopilot.yaml
@@ -26,36 +26,12 @@ spec:
   network:
     name: "${GCP_NETWORK_NAME}"
 ---
-kind: GCPManagedControlPlane
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPManagedControlPlane
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   project: "${GCP_PROJECT}"
   location: "${GCP_REGION}"
----
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachinePool
-metadata:
-  name: "${CLUSTER_NAME}-mp-0"
-spec:
-  clusterName: "${CLUSTER_NAME}"
-  replicas: ${WORKER_MACHINE_COUNT}
-  template:
-    spec:
-      bootstrap:
-        dataSecretName: ""
-      clusterName: "${CLUSTER_NAME}"
-      infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: GCPManagedMachinePool
-        name: "${CLUSTER_NAME}-mp-0"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: GCPManagedMachinePool
-metadata:
-  name: "${CLUSTER_NAME}-mp-0"
-spec: {}
-
-
-
+  enableAutopilot: true
+  releaseChannel: "regular"

--- a/test/e2e/data/infrastructure-gcp/cluster-template-ci-gke.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-ci-gke.yaml
@@ -26,36 +26,38 @@ spec:
   network:
     name: "${GCP_NETWORK_NAME}"
 ---
-kind: GCPManagedControlPlane
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPManagedControlPlane
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   project: "${GCP_PROJECT}"
   location: "${GCP_REGION}"
+  releaseChannel: "regular"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: "${CLUSTER_NAME}-mp-0"
+  name: ${CLUSTER_NAME}-mp-0
 spec:
-  clusterName: "${CLUSTER_NAME}"
+  clusterName: ${CLUSTER_NAME}
   replicas: ${WORKER_MACHINE_COUNT}
   template:
     spec:
       bootstrap:
         dataSecretName: ""
-      clusterName: "${CLUSTER_NAME}"
+      clusterName: ${CLUSTER_NAME}
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: GCPManagedMachinePool
-        name: "${CLUSTER_NAME}-mp-0"
+        name: ${CLUSTER_NAME}-mp-0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: GCPManagedMachinePool
 metadata:
-  name: "${CLUSTER_NAME}-mp-0"
-spec: {}
-
-
+  name: ${CLUSTER_NAME}-mp-0
+spec:
+  scaling:
+    minCount: ${GKE_MACHINE_POOL_MIN}
+    maxCount: ${GKE_MACHINE_POOL_MAX}
 

--- a/test/e2e/e2e_gke_test.go
+++ b/test/e2e/e2e_gke_test.go
@@ -1,0 +1,162 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+const (
+	defaultNumZonesPerRegion = 3
+)
+
+var _ = Describe("GKE workload cluster creation", func() {
+	var (
+		ctx                 = context.TODO()
+		specName            = "create-gke-workload-cluster"
+		namespace           *corev1.Namespace
+		cancelWatches       context.CancelFunc
+		result              *ApplyManagedClusterTemplateAndWaitResult
+		clusterName         string
+		clusterctlLogFolder string
+	)
+
+	BeforeEach(func() {
+		Expect(e2eConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
+		Expect(clusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. clusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(bootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. bootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
+
+		Expect(e2eConfig.Variables).To(HaveKey(KubernetesVersion))
+
+		clusterName = fmt.Sprintf("capg-e2e-%s", util.RandomString(6))
+
+		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
+
+		result = new(ApplyManagedClusterTemplateAndWaitResult)
+
+		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
+		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
+	})
+
+	AfterEach(func() {
+		cleanInput := cleanupInput{
+			SpecName:        specName,
+			Cluster:         result.Cluster,
+			ClusterProxy:    bootstrapClusterProxy,
+			Namespace:       namespace,
+			CancelWatches:   cancelWatches,
+			IntervalsGetter: e2eConfig.GetIntervals,
+			SkipCleanup:     skipCleanup,
+			ArtifactFolder:  artifactFolder,
+		}
+
+		dumpSpecResourcesAndCleanup(ctx, cleanInput)
+	})
+
+	Context("Creating a GKE cluster without autopilot", func() {
+		It("Should create a cluster with 1 machine pool and scale", func() {
+			By("Initializes with 1 machine pool")
+
+			minPoolSize, ok := e2eConfig.Variables["GKE_MACHINE_POOL_MIN"]
+			Expect(ok).To(BeTrue(), "must have min pool size set via the GKE_MACHINE_POOL_MIN variable")
+			maxPoolSize, ok := e2eConfig.Variables["GKE_MACHINE_POOL_MAX"]
+			Expect(ok).To(BeTrue(), "must have max pool size set via the GKE_MACHINE_POOL_MAX variable")
+
+			ApplyManagedClusterTemplateAndWait(ctx, ApplyManagedClusterTemplateAndWaitInput{
+				ClusterProxy: bootstrapClusterProxy,
+				ConfigCluster: clusterctl.ConfigClusterInput{
+					LogFolder:                clusterctlLogFolder,
+					ClusterctlConfigPath:     clusterctlConfigPath,
+					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+					Flavor:                   "ci-gke",
+					Namespace:                namespace.Name,
+					ClusterName:              clusterName,
+					KubernetesVersion:        e2eConfig.GetVariable(KubernetesVersion),
+					ControlPlaneMachineCount: pointer.Int64Ptr(1),
+					WorkerMachineCount:       pointer.Int64Ptr(3),
+					ClusterctlVariables: map[string]string{
+						"GKE_MACHINE_POOL_MIN": minPoolSize,
+						"GKE_MACHINE_POOL_MAX": maxPoolSize,
+					},
+				},
+				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+				WaitForMachinePools:          e2eConfig.GetIntervals(specName, "wait-worker-machine-pools"),
+			}, result)
+
+			By("Scaling the machine pool up")
+			framework.ScaleMachinePoolAndWait(ctx, framework.ScaleMachinePoolAndWaitInput{
+				ClusterProxy:              bootstrapClusterProxy,
+				Cluster:                   result.Cluster,
+				Replicas:                  6,
+				MachinePools:              result.MachinePools,
+				WaitForMachinePoolToScale: e2eConfig.GetIntervals(specName, "wait-worker-machine-pools"),
+			})
+
+			By("Scaling the machine pool down")
+			framework.ScaleMachinePoolAndWait(ctx, framework.ScaleMachinePoolAndWaitInput{
+				ClusterProxy:              bootstrapClusterProxy,
+				Cluster:                   result.Cluster,
+				Replicas:                  3,
+				MachinePools:              result.MachinePools,
+				WaitForMachinePoolToScale: e2eConfig.GetIntervals(specName, "wait-worker-machine-pools"),
+			})
+		})
+	})
+
+	Context("Creating a GKE cluster with autopilot", func() {
+		It("Should create a cluster with 1 machine pool and scale", func() {
+			By("Initializes with 1 machine pool")
+
+			ApplyManagedClusterTemplateAndWait(ctx, ApplyManagedClusterTemplateAndWaitInput{
+				ClusterProxy: bootstrapClusterProxy,
+				ConfigCluster: clusterctl.ConfigClusterInput{
+					LogFolder:                clusterctlLogFolder,
+					ClusterctlConfigPath:     clusterctlConfigPath,
+					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+					Flavor:                   "ci-gke-autopilot",
+					Namespace:                namespace.Name,
+					ClusterName:              clusterName,
+					KubernetesVersion:        e2eConfig.GetVariable(KubernetesVersion),
+					ControlPlaneMachineCount: pointer.Int64Ptr(1),
+					WorkerMachineCount:       pointer.Int64Ptr(0),
+				},
+				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+				WaitForMachinePools:          e2eConfig.GetIntervals(specName, "wait-worker-machine-pools"),
+			}, result)
+		})
+	})
+})

--- a/test/e2e/gke.go
+++ b/test/e2e/gke.go
@@ -1,0 +1,208 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+
+	infrav1exp "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
+)
+
+const (
+	retryableOperationInterval = 3 * time.Second
+	retryableOperationTimeout  = 3 * time.Minute
+)
+
+// ApplyManagedClusterTemplateAndWaitInput is the input type for ApplyManagedClusterTemplateAndWait.
+type ApplyManagedClusterTemplateAndWaitInput struct {
+	ClusterProxy                   framework.ClusterProxy
+	ConfigCluster                  clusterctl.ConfigClusterInput
+	WaitForClusterIntervals        []interface{}
+	WaitForControlPlaneIntervals   []interface{}
+	WaitForMachinePools            []interface{}
+	Args                           []string // extra args to be used during `kubectl apply`
+	PreWaitForCluster              func()
+	PostMachinesProvisioned        func()
+	WaitForControlPlaneInitialized Waiter
+}
+
+// Waiter is a function that runs and waits for a long-running operation to finish and updates the result.
+type Waiter func(ctx context.Context, input ApplyManagedClusterTemplateAndWaitInput, result *ApplyManagedClusterTemplateAndWaitResult)
+
+// ApplyManagedClusterTemplateAndWaitResult is the output type for ApplyClusterTemplateAndWait.
+type ApplyManagedClusterTemplateAndWaitResult struct {
+	ClusterClass *clusterv1.ClusterClass
+	Cluster      *clusterv1.Cluster
+	ControlPlane *infrav1exp.GCPManagedControlPlane
+	MachinePools []*expv1.MachinePool
+}
+
+// ApplyManagedClusterTemplateAndWait gets a managed cluster template using clusterctl, and waits for the cluster to be ready.
+// Important! this method assumes the cluster uses a GCPManagedControlPlane and MachinePools.
+func ApplyManagedClusterTemplateAndWait(ctx context.Context, input ApplyManagedClusterTemplateAndWaitInput, result *ApplyManagedClusterTemplateAndWaitResult) {
+	setDefaults(&input)
+	Expect(ctx).NotTo(BeNil(), "ctx is required for ApplyManagedClusterTemplateAndWait")
+	Expect(input.ClusterProxy).ToNot(BeNil(), "Invalid argument. input.ClusterProxy can't be nil when calling ApplyManagedClusterTemplateAndWait")
+	Expect(result).ToNot(BeNil(), "Invalid argument. result can't be nil when calling ApplyManagedClusterTemplateAndWait")
+	Expect(input.ConfigCluster.Flavor).ToNot(BeEmpty(), "Invalid argument. input.ConfigCluster.Flavor can't be empty")
+	Expect(input.ConfigCluster.ControlPlaneMachineCount).ToNot(BeNil())
+	Expect(input.ConfigCluster.WorkerMachineCount).ToNot(BeNil())
+
+	Byf("Creating the GKE workload cluster with name %q using the %q template (Kubernetes %s)",
+		input.ConfigCluster.ClusterName, input.ConfigCluster.Flavor, input.ConfigCluster.KubernetesVersion)
+
+	By("Getting the cluster template yaml")
+	workloadClusterTemplate := clusterctl.ConfigCluster(ctx, clusterctl.ConfigClusterInput{
+		// pass reference to the management cluster hosting this test
+		KubeconfigPath: input.ConfigCluster.KubeconfigPath,
+		// pass the clusterctl config file that points to the local provider repository created for this test,
+		ClusterctlConfigPath: input.ConfigCluster.ClusterctlConfigPath,
+		// select template
+		Flavor: input.ConfigCluster.Flavor,
+		// define template variables
+		Namespace:                input.ConfigCluster.Namespace,
+		ClusterName:              input.ConfigCluster.ClusterName,
+		KubernetesVersion:        input.ConfigCluster.KubernetesVersion,
+		ControlPlaneMachineCount: input.ConfigCluster.ControlPlaneMachineCount,
+		WorkerMachineCount:       input.ConfigCluster.WorkerMachineCount,
+		InfrastructureProvider:   input.ConfigCluster.InfrastructureProvider,
+		// setup clusterctl logs folder
+		LogFolder:           input.ConfigCluster.LogFolder,
+		ClusterctlVariables: input.ConfigCluster.ClusterctlVariables,
+	})
+	Expect(workloadClusterTemplate).ToNot(BeNil(), "Failed to get the cluster template")
+
+	By("Applying the cluster template yaml to the cluster")
+	Eventually(func() error {
+		return input.ClusterProxy.Apply(ctx, workloadClusterTemplate, input.Args...)
+	}, 10*time.Second).Should(Succeed(), "Failed to apply the cluster template")
+
+	// Once we applied the cluster template we can run PreWaitForCluster.
+	// Note: This can e.g. be used to verify the BeforeClusterCreate lifecycle hook is executed
+	// and blocking correctly.
+	if input.PreWaitForCluster != nil {
+		By("Calling PreWaitForCluster")
+		input.PreWaitForCluster()
+	}
+
+	By("Waiting for the cluster infrastructure to be provisioned")
+	result.Cluster = framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{
+		Getter:    input.ClusterProxy.GetClient(),
+		Namespace: input.ConfigCluster.Namespace,
+		Name:      input.ConfigCluster.ClusterName,
+	}, input.WaitForClusterIntervals...)
+
+	By("Waiting for managed control plane to be initialized")
+	input.WaitForControlPlaneInitialized(ctx, input, result)
+
+	By("Waiting for the machine pools to be provisioned")
+	result.MachinePools = framework.DiscoveryAndWaitForMachinePools(ctx, framework.DiscoveryAndWaitForMachinePoolsInput{
+		Getter:  input.ClusterProxy.GetClient(),
+		Lister:  input.ClusterProxy.GetClient(),
+		Cluster: result.Cluster,
+	}, input.WaitForMachinePools...)
+
+	if input.PostMachinesProvisioned != nil {
+		By("Calling PostMachinesProvisioned")
+		input.PostMachinesProvisioned()
+	}
+}
+
+type ManagedControlPlaneResult struct {
+	clusterctl.ApplyClusterTemplateAndWaitResult
+
+	ManagedControlPlane *infrav1exp.GCPManagedControlPlane
+}
+
+// DiscoveryAndWaitFoManagedControlPlaneInitializedInput is the input type for DiscoveryAndWaitForManagedControlPlaneInitialized.
+type DiscoveryAndWaitForManagedControlPlaneInitializedInput struct {
+	Lister  framework.Lister
+	Cluster *clusterv1.Cluster
+}
+
+// DiscoveryAndWaitForManagedControlPlaneInitialized discovers the KubeadmControlPlane object attached to a cluster and waits for it to be initialized.
+func DiscoveryAndWaitForManagedControlPlaneInitialized(ctx context.Context, input DiscoveryAndWaitForManagedControlPlaneInitializedInput, intervals ...interface{}) *infrav1exp.GCPManagedControlPlane {
+	Expect(ctx).NotTo(BeNil(), "ctx is required for DiscoveryAndWaitForManagedControlPlaneInitialized")
+	Expect(input.Lister).ToNot(BeNil(), "Invalid argument. input.Lister can't be nil when calling DiscoveryAndWaitForManagedControlPlaneInitialized")
+	Expect(input.Cluster).ToNot(BeNil(), "Invalid argument. input.Cluster can't be nil when calling DiscoveryAndWaitForManagedControlPlaneInitialized")
+
+	By("Getting GCPManagedControlPlane control plane")
+
+	var controlPlane *infrav1exp.GCPManagedControlPlane
+	Eventually(func(g Gomega) {
+		controlPlane = GetManagedControlPlaneByCluster(ctx, GetManagedControlPlaneByClusterInput{
+			Lister:      input.Lister,
+			ClusterName: input.Cluster.Name,
+			Namespace:   input.Cluster.Namespace,
+		})
+		g.Expect(controlPlane).ToNot(BeNil())
+	}, "10s", "1s").Should(Succeed(), "Couldn't get the control plane for the cluster %s", klog.KObj(input.Cluster))
+
+	return controlPlane
+}
+
+// GetManagedontrolPlaneByClusterInput is the input for GetManagedControlPlaneByCluster.
+type GetManagedControlPlaneByClusterInput struct {
+	Lister      framework.Lister
+	ClusterName string
+	Namespace   string
+}
+
+// GetManagedControlPlaneByCluster returns the GCPManagedControlPlane objects for a cluster.
+func GetManagedControlPlaneByCluster(ctx context.Context, input GetManagedControlPlaneByClusterInput) *infrav1exp.GCPManagedControlPlane {
+	opts := []client.ListOption{
+		client.InNamespace(input.Namespace),
+		client.MatchingLabels{
+			clusterv1.ClusterLabelName: input.ClusterName,
+		},
+	}
+
+	controlPlaneList := &infrav1exp.GCPManagedControlPlaneList{}
+	Eventually(func() error {
+		return input.Lister.List(ctx, controlPlaneList, opts...)
+	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to list GCPManagedControlPlane object for Cluster %s", klog.KRef(input.Namespace, input.ClusterName))
+	Expect(len(controlPlaneList.Items)).ToNot(BeNumerically(">", 1), "Cluster %s should not have more than 1 GCPManagedControlPlane object", klog.KRef(input.Namespace, input.ClusterName))
+	if len(controlPlaneList.Items) == 1 {
+		return &controlPlaneList.Items[0]
+	}
+	return nil
+}
+
+func setDefaults(input *ApplyManagedClusterTemplateAndWaitInput) {
+	if input.WaitForControlPlaneInitialized == nil {
+		input.WaitForControlPlaneInitialized = func(ctx context.Context, input ApplyManagedClusterTemplateAndWaitInput, result *ApplyManagedClusterTemplateAndWaitResult) {
+			result.ControlPlane = DiscoveryAndWaitForManagedControlPlaneInitialized(ctx, DiscoveryAndWaitForManagedControlPlaneInitializedInput{
+				Lister:  input.ClusterProxy.GetClient(),
+				Cluster: result.Cluster,
+			}, input.WaitForControlPlaneIntervals...)
+		}
+	}
+}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
 	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
@@ -186,6 +187,7 @@ func initScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	framework.TryAddDefaultSchemes(scheme)
 	Expect(infrav1.AddToScheme(scheme)).To(Succeed())
+	Expect(infrav1exp.AddToScheme(scheme)).To(Succeed())
 
 	return scheme
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

This also makes the following changes to the existing merged GKE code:
- InitialNodeCount has been made optional. If specified it will overwrite the Replicas values on the MachinePool (which defaults to 1)
- The ProviderID logic for the  GKE node group instances  has been changed as it didn't work. We were using the instance resource url.  As part of this a new `providerid` package has been created.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [x] adds e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds e2e tests for GKE
```
