### PR TITLE
Update URL for Calico's manifest in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,7 +503,7 @@ create-workload-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL)
 	${TIMEOUT} 15m bash -c "while ! kubectl --kubeconfig=$(CAPG_WORKER_CLUSTER_KUBECONFIG) get nodes | grep master; do sleep 1; done"
 
 	# Deploy calico
-	$(KUBECTL) --kubeconfig=$(CAPG_WORKER_CLUSTER_KUBECONFIG) apply -f https://docs.projectcalico.org/manifests/calico.yaml
+	$(KUBECTL) --kubeconfig=$(CAPG_WORKER_CLUSTER_KUBECONFIG) apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/calico.yaml
 
 	@echo 'run "$(KUBECTL) --kubeconfig=$(CAPG_WORKER_CLUSTER_KUBECONFIG) ..." to work with the new target cluster'
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind other
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

cc: @richardcase @cpanato 

I updated the URL for the YAML manifest installing Calico on a workload cluster (consulted [CAPI - Quick Start](https://cluster-api.sigs.k8s.io/user/quick-start.html#deploy-a-cni-solution) doc)

**Which issue(s) this PR fixes**

- The Make command `make create-workload-cluster` failed on installing Calico:

```bash
# Deploy calico
/home/pnguyen4/Coding/cluster-api-provider-gcp/hack/tools/bin/kubectl-v1.25.5 --kubeconfig="/tmp/kubeconfig" apply -f https://docs.projectcalico.org/manifests/calico.yaml
error: unable to read URL "https://docs.projectcalico.org/manifests/calico.yaml", server reported 404 Not Found, status code=404
make: *** [Makefile:504: create-workload-cluster] Error 1
```

- The old URL `https://docs.projectcalico.org/manifests/calico.yaml` no longer exists. 
<img width="1470" alt="Screen Shot 2023-03-17 at 9 35 02 PM" src="https://user-images.githubusercontent.com/58450476/226076239-629b5606-e0d4-4f19-b263-97495d8d3863.png">

**Special notes for your reviewer**:

*My first PR on `CAPG`. Pardon me if I got anything not right :pray:*

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```bash
NULL
```