### PR TITLE
Fix clusterctl move command by updating ControlPlane initialized cond…

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanes.yaml
@@ -162,6 +162,11 @@ spec:
                 description: CurrentVersion shows the current version of the GKE control
                   plane.
                 type: string
+              initialized:
+                description: Initialized is true when the control plane is available
+                  for initial contact. This may occur before the control plane is
+                  fully ready.
+                type: boolean
               ready:
                 default: false
                 description: Ready denotes that the GCPManagedControlPlane API Server

--- a/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
+++ b/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
@@ -61,6 +61,11 @@ type GCPManagedControlPlaneStatus struct {
 	// +kubebuilder:default=false
 	Ready bool `json:"ready"`
 
+	// Initialized is true when the control plane is available for initial contact.
+	// This may occur before the control plane is fully ready.
+	// +optional
+	Initialized bool `json:"initialized,omitempty"`
+
 	// Conditions specifies the conditions for the managed control plane
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: 
Fix bug for cluster move operation. It adds a variable `intialized` in the `status` of `GCPManagedControlPlane` object, which should be true before doing `clusterctl move` operation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #877 

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:
```
Fixed bug for cluster move operation.
```
