### PR TITLE
chore: improve apiserver loadbalancer healthcheck

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -314,10 +314,11 @@ func (s *ClusterScope) ForwardingRuleSpec() *compute.ForwardingRule {
 func (s *ClusterScope) HealthCheckSpec() *compute.HealthCheck {
 	return &compute.HealthCheck{
 		Name: fmt.Sprintf("%s-%s", s.Name(), infrav1.APIServerRoleTagValue),
-		Type: "SSL",
-		SslHealthCheck: &compute.SSLHealthCheck{
+		Type: "HTTPS",
+		HttpsHealthCheck: &compute.HTTPSHealthCheck{
 			Port:              6443,
 			PortSpecification: "USE_FIXED_PORT",
+			RequestPath:       "/readyz",
 		},
 		CheckIntervalSec:   10,
 		TimeoutSec:         5,


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
In some cases when kubelet running on a node accidentally stops working, it can lead to errors since the node appears as healthy backend in the apiserver load balancer even though etcd probe is returning `etcd failed reason withheld`

```bash
[+]ping ok
[+]log ok
[-]etcd failed: reason withheld
[+]informer-sync ok
[+]poststarthook/start-kube-apiserver-admission-initializer ok
[+]poststarthook/generic-apiserver-start-informers ok
[+]poststarthook/priority-and-fairness-config-consumer ok
[+]poststarthook/priority-and-fairness-filter ok
[+]poststarthook/start-apiextensions-informers ok
[+]poststarthook/start-apiextensions-controllers ok
[+]poststarthook/crd-informer-synced ok
[+]poststarthook/bootstrap-controller ok
[+]poststarthook/rbac/bootstrap-roles ok
[+]poststarthook/scheduling/bootstrap-system-priority-classes ok
[+]poststarthook/priority-and-fairness-config-producer ok
[+]poststarthook/start-cluster-authentication-info-controller ok
[+]poststarthook/aggregator-reload-proxy-client-cert ok
[+]poststarthook/start-kube-aggregator-informers ok
[+]poststarthook/apiservice-registration-controller ok
[+]poststarthook/apiservice-status-available-controller ok
[+]poststarthook/kube-apiserver-autoregistration ok
[+]autoregister-completion ok
[+]poststarthook/apiservice-openapi-controller ok
[+]shutdown ok
readyz check failed
```

In that scenario, the different calls made to the apiserver load balancer by the pieces on k8s may try to reach an unresponsive backend generating massive cluster issues.

Fixes #

**Special notes for your reviewer**:

**TODOs**:

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
Improve health check probe of the apiserver load balancer
```
