### PR TITLE
Do not ignore kubeconfig directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ envfile
 kind.kubeconfig
 minikube.kubeconfig
 kubeconfig
+# keep directories named kubeconfig
+!**/kubeconfig/
 
 # Example and binary output directory
 /out


### PR DESCRIPTION
/kind other

**What this PR does / why we need it**:

Some vendored folder are named kubeconfig and are being ignored by .gitignore
E.g.:
vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/encode.go

This causes issues when working with these files in git when vendoring. 

I have added `!**/kubeconfig/` to only ignore files named kubeconfig and not directories.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```