### PR TITLE
Make GKE enableAutopilot optional

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanes.yaml
@@ -104,7 +104,6 @@ spec:
                 - stable
                 type: string
             required:
-            - enableAutopilot
             - location
             - project
             type: object

--- a/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
+++ b/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
@@ -40,6 +40,7 @@ type GCPManagedControlPlaneSpec struct {
 	// will be created.
 	Location string `json:"location"`
 	// EnableAutopilot indicates whether to enable autopilot for this GKE cluster.
+	// +optional
 	EnableAutopilot bool `json:"enableAutopilot"`
 	// ReleaseChannel represents the release channel of the GKE cluster.
 	// +optional


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Make GKE enableAutopilot field optional.

Error out otherwise:
```
error: error validating "capi-gke-quickstart.yaml": error validating data: ValidationError(GCPManagedControlPlane.spec): missing required field "enableAutopilot" in io.x-k8s.cluster.infrastructure.v1beta1.GCPManagedControlPlane.spec; if you choose to ignore these errors, turn validation off with --validate=false
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

None

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
