### PR TITLE
[WIP] Allow assigning VPC subnet secondary ranges in GCPMachine spec

### DIFF
--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -127,16 +127,21 @@ EOF
 Set the following environment variables with the appropriate values for your environment:
 
 ```shell
-$ export GCP_REGION="<GCP_REGION>" \
-$ export GCP_PROJECT="<GCP_PROJECT>" \
-$ export CONTROL_PLANE_MACHINE_COUNT=1 \
-$ export WORKER_MACHINE_COUNT=1 \
+$ export CLUSTER_NAME="<CLUSTER_NAME>"
+$ export GCP_REGION="<GCP_REGION>"
+$ export GCP_PROJECT="<GCP_PROJECT>"
+$ export CONTROL_PLANE_MACHINE_COUNT=1
+$ export WORKER_MACHINE_COUNT=1
+# Substitute <IMAGE_ID> with the selfLink of the GCE image you built
+$ export IMAGE_ID=<IMAGE_ID>
 # Make sure to use same kubernetes version here as building the GCE image
-$ export KUBERNETES_VERSION=1.23.3 \
-$ export GCP_CONTROL_PLANE_MACHINE_TYPE=n1-standard-2 \
-$ export GCP_NODE_MACHINE_TYPE=n1-standard-2 \
-$ export GCP_NETWORK_NAME=<GCP_NETWORK_NAME or default> \
-$ export CLUSTER_NAME="<CLUSTER_NAME>" \
+$ export KUBERNETES_VERSION=1.23.3
+$ export GCP_CONTROL_PLANE_MACHINE_TYPE=n1-standard-2
+$ export GCP_NODE_MACHINE_TYPE=n1-standard-2
+# Optional: Set the following 3 variables if you want to use pre-existing custom mode VPC (sub)networks, skip otherwise
+$ export GCP_AUTO_CREATE_SUBNETWORKS=false
+$ export GCP_NETWORK_NAME=<GCP_NETWORK_NAME>
+$ export GCP_SUBNETWORK_NAME=<GCP_SUBNETWORK_NAME>
 ```
 
 To build a kind cluster and start Tilt, just run:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -24,7 +24,8 @@ spec:
   project: "${GCP_PROJECT}"
   region: "${GCP_REGION}"
   network:
-    name: "${GCP_NETWORK_NAME}"
+    name: "${GCP_NETWORK_NAME:=default}"
+    autoCreateSubnetworks: "${GCP_AUTO_CREATE_SUBNETWORKS:=true}"
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -68,6 +69,7 @@ spec:
     spec:
       instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      subnet: "${GCP_SUBNETWORK_NAME:=default}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -101,6 +103,7 @@ spec:
     spec:
       instanceType: "${GCP_NODE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      subnet: "${GCP_SUBNETWORK_NAME:=default}"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind feature

**What this PR does / why we need it**:

Allows [assigning secondary ranges](https://cloud.google.com/vpc/docs/configure-alias-ip-ranges#create_a_vm_with_multiple_interfaces_and_alias_ip_addresses) to cluster nodes using GCPMachine resources. This gives users more freedom in their cluster networking setup, for example by using [cilium's "native routing"](https://docs.cilium.io/en/v1.13/network/concepts/routing/#google-cloud) to leverage GCP's standard network stack instead of relying on overlay networking.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #902 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Feature: Allow assigning VPC subnet secondary ranges in GCPMachine spec
```
