### PR TITLE
Add gcloud auth in user kubeconfig secret

### DIFF
--- a/cloud/services/container/clusters/kubeconfig.go
+++ b/cloud/services/container/clusters/kubeconfig.go
@@ -108,18 +108,15 @@ func (s *Service) createUserKubeconfigSecret(ctx context.Context, cluster *conta
 		return fmt.Errorf("creating base kubeconfig: %w", err)
 	}
 
-	authProviderConfig := &api.AuthProviderConfig{
-		Name: "gcp",
-		Config: map[string]string{
-			"cmd-args":   "config config-helper --format=json",
-			"cmd-path":   "gcloud",
-			"expiry-key": "'{.credential.token_expiry}'",
-			"token-key":  "'{.credential.access_token}'",
-		},
+	execConfig := &api.ExecConfig{
+		APIVersion:         "client.authentication.k8s.io/v1beta1",
+		Command:            "gke-gcloud-auth-plugin",
+		InstallHint:        "Install gke-gcloud-auth-plugin for use with kubectl by following\n		https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke",
+		ProvideClusterInfo: true,
 	}
 	cfg.AuthInfos = map[string]*api.AuthInfo{
 		contextName: {
-			AuthProvider: authProviderConfig,
+			Exec: execConfig,
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

This PR adds `gcloud-auth` authentication in the user kubeconfig secret.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #923 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```
Add `gcloud-auth` authentication
```
