### PR TITLE
Fix Cluster Creation in User Provided Subnet

### DIFF
--- a/cloud/services/compute/subnets/reconcile.go
+++ b/cloud/services/compute/subnets/reconcile.go
@@ -43,7 +43,7 @@ func (s *Service) Delete(ctx context.Context) error {
 	logger := log.FromContext(ctx)
 	for _, subnetSpec := range s.scope.SubnetSpecs() {
 		logger.V(2).Info("Deleting a subnet", "name", subnetSpec.Name)
-		subnetKey := meta.RegionalKey(subnetSpec.Name, s.scope.Region())
+		subnetKey := meta.RegionalKey(subnetSpec.Name, s.getSubnetRegion(subnetSpec))
 		err := s.subnets.Delete(ctx, subnetKey)
 		if err != nil && !gcperrors.IsNotFound(err) {
 			logger.Error(err, "Error deleting subnet", "name", subnetSpec.Name)
@@ -60,7 +60,7 @@ func (s *Service) createOrGetSubnets(ctx context.Context) ([]*compute.Subnetwork
 	subnets := []*compute.Subnetwork{}
 	for _, subnetSpec := range s.scope.SubnetSpecs() {
 		logger.V(2).Info("Looking for subnet", "name", subnetSpec.Name)
-		subnetKey := meta.RegionalKey(subnetSpec.Name, s.scope.Region())
+		subnetKey := meta.RegionalKey(subnetSpec.Name, s.getSubnetRegion(subnetSpec))
 		subnet, err := s.subnets.Get(ctx, subnetKey)
 		if err != nil {
 			if !gcperrors.IsNotFound(err) {
@@ -85,4 +85,12 @@ func (s *Service) createOrGetSubnets(ctx context.Context) ([]*compute.Subnetwork
 	}
 
 	return subnets, nil
+}
+
+// getSubnetRegion returns subnet region if user provided it, otherwise returns default scope region.
+func (s *Service) getSubnetRegion(subnetSpec *compute.Subnetwork) string {
+	if subnetSpec.Region != "" {
+		return subnetSpec.Region
+	}
+	return s.scope.Region()
 }

--- a/cloud/services/container/clusters/reconcile.go
+++ b/cloud/services/container/clusters/reconcile.go
@@ -250,10 +250,10 @@ func (s *Service) createCluster(ctx context.Context, log *logr.Logger) error {
 	}
 
 	isRegional := shared.IsRegional(s.scope.Region())
-
 	cluster := &containerpb.Cluster{
-		Name:    s.scope.ClusterName(),
-		Network: *s.scope.GCPManagedCluster.Spec.Network.Name,
+		Name:       s.scope.ClusterName(),
+		Network:    *s.scope.GCPManagedCluster.Spec.Network.Name,
+		Subnetwork: s.getSubnetNameInClusterRegion(),
 		Autopilot: &containerpb.Autopilot{
 			Enabled: s.scope.GCPManagedControlPlane.Spec.EnableAutopilot,
 		},
@@ -293,6 +293,16 @@ func (s *Service) createCluster(ctx context.Context, log *logr.Logger) error {
 	}
 
 	return nil
+}
+
+// getSubnetNameInClusterRegion returns the subnet which is in the same region as cluster. If not found it returns empty string.
+func (s *Service) getSubnetNameInClusterRegion() string {
+	for _, subnet := range s.scope.GCPManagedCluster.Spec.Network.Subnets {
+		if subnet.Region == s.scope.Region() {
+			return subnet.Name
+		}
+	}
+	return ""
 }
 
 func (s *Service) updateCluster(ctx context.Context, updateClusterRequest *containerpb.UpdateClusterRequest, log *logr.Logger) error {

--- a/test/e2e/config/gcp-ci.yaml
+++ b/test/e2e/config/gcp-ci.yaml
@@ -71,6 +71,7 @@ providers:
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-creds.yaml"
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-gke.yaml"
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-gke-autopilot.yaml"
+      - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-gke-custom-subnet.yaml"
 
 variables:
   KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.28.3}"

--- a/test/e2e/data/infrastructure-gcp/cluster-template-ci-gke-custom-subnet.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-ci-gke-custom-subnet.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: GCPManagedCluster
+    name: "${CLUSTER_NAME}"
+  controlPlaneRef:
+    kind: GCPManagedControlPlane
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    name: "${CLUSTER_NAME}-control-plane"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPManagedCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  project: "${GCP_PROJECT}"
+  region: "${GCP_REGION}"
+  network:
+    name: "${GCP_NETWORK_NAME}"
+    autoCreateSubnetworks: false
+    subnets:
+      - name: "${GCP_SUBNET_NAME}"
+        cidrBlock: "${GCP_SUBNET_CIDR}"
+        region: "${GCP_REGION}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPManagedControlPlane
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  project: "${GCP_PROJECT}"
+  location: "${GCP_REGION}"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: ${CLUSTER_NAME}-mp-0
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  template:
+    spec:
+      bootstrap:
+        dataSecretName: ""
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: GCPManagedMachinePool
+        name: ${CLUSTER_NAME}-mp-0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPManagedMachinePool
+metadata:
+  name: ${CLUSTER_NAME}-mp-0
+spec: {}
+

--- a/test/e2e/e2e_gke_test.go
+++ b/test/e2e/e2e_gke_test.go
@@ -159,4 +159,33 @@ var _ = Describe("GKE workload cluster creation", func() {
 			}, result)
 		})
 	})
+
+	Context("Creating a GKE cluster with custom subnet", func() {
+		It("Should create a cluster with 3 machine pool and custom subnet", func() {
+			By("Initializes with 3 machine pool")
+
+			ApplyManagedClusterTemplateAndWait(ctx, ApplyManagedClusterTemplateAndWaitInput{
+				ClusterProxy: bootstrapClusterProxy,
+				ConfigCluster: clusterctl.ConfigClusterInput{
+					LogFolder:                clusterctlLogFolder,
+					ClusterctlConfigPath:     clusterctlConfigPath,
+					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+					Flavor:                   "ci-gke-custom-subnet",
+					Namespace:                namespace.Name,
+					ClusterName:              clusterName,
+					KubernetesVersion:        e2eConfig.GetVariable(KubernetesVersion),
+					ControlPlaneMachineCount: ptr.To[int64](1),
+					WorkerMachineCount:       ptr.To[int64](3),
+					ClusterctlVariables: map[string]string{
+						"GCP_SUBNET_NAME": "capg-test-subnet",
+						"GCP_SUBNET_CIDR": "172.20.0.0/16",
+					},
+				},
+				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+				WaitForMachinePools:          e2eConfig.GetIntervals(specName, "wait-worker-machine-pools"),
+			}, result)
+		})
+	})
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR enables the creation of clusters in user-provided subnets.  It also adds validation for user-provided subnets to ensure that at least one subnet is in the same region where the cluster will be created. The user-provided subnets are created in the intended region rather than the default region.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #896

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
Fix bug for the creation of clusters in user-provided subnets
```
