### PR TITLE
build-gce-ubuntu-1804 is deprecated update to build-gce-ubuntu-2004

### DIFF
--- a/docs/book/src/developers/cluster-creation.md
+++ b/docs/book/src/developers/cluster-creation.md
@@ -23,7 +23,7 @@ For creating a cluster with clusterctl, checkout our [Cluster API Quick Start](h
    export GCP_NETWORK_NAME=default
    export GCP_B64ENCODED_CREDENTIALS=$( cat /path/to/gcp_credentials.json | base64 | tr -d '\n' )
    export CLUSTER_NAME="capg-test"
-   export IMAGE_ID=projects/k8s-staging-cluster-api-gcp/global/images/cluster-api-ubuntu-1804-v1-20-9-nightly
+   export IMAGE_ID=projects/k8s-staging-cluster-api-gcp/global/images/cluster-api-ubuntu-2004-v1-20-9-nightly
    ```
 
   You can check for other images to set the `IMAGE_ID` of your choice.

--- a/docs/book/src/topics/prerequisites.md
+++ b/docs/book/src/topics/prerequisites.md
@@ -83,10 +83,10 @@ git clone https://github.com/kubernetes-sigs/image-builder.git image-builder
 cd image-builder/images/capi
 
 # Run the Make target to generate GCE images.
-make build-gce-ubuntu-1804
+make build-gce-ubuntu-2004
 
 # Check that you can see the published images.
-gcloud compute images list --project ${GCP_PROJECT_ID} --no-standard-images --filter="family:capi-ubuntu-1804-k8s"
+gcloud compute images list --project ${GCP_PROJECT_ID} --no-standard-images --filter="family:capi-ubuntu-2004-k8s"
 
 # Export the IMAGE_ID from the above
 export IMAGE_ID="projects/${GCP_PROJECT_ID}/global/images/<image-name>"

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -88,17 +88,17 @@ EOF
       GCP_PROJECT_ID=$GCP_PROJECT \
       GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS \
       PACKER_VAR_FILES=override.json \
-      make deps-gce build-gce-ubuntu-1804)
+      make deps-gce build-gce-ubuntu-2004)
   else
     # assume we are running in the CI environment as root
     # Add a user for ansible to work properly
     groupadd -r packer && useradd -m -s /bin/bash -r -g packer packer
     chown -R packer:packer /home/prow/go/src/sigs.k8s.io/image-builder
     # use the packer user to run the build
-    su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS PACKER_VAR_FILES=override.json make deps-gce build-gce-ubuntu-1804'"
+    su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS PACKER_VAR_FILES=override.json make deps-gce build-gce-ubuntu-2004'"
   fi
 
-  filter="name~cluster-api-ubuntu-1804-${KUBERNETES_VERSION//[.+]/-}"
+  filter="name~cluster-api-ubuntu-2004-${KUBERNETES_VERSION//[.+]/-}"
   image_id=$(gcloud compute images list --project "$GCP_PROJECT" \
     --no-standard-images --filter="${filter}" --format="table[no-heading](name)")
   if [[ -z "$image_id" ]]; then

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -78,17 +78,17 @@ EOF
       GCP_PROJECT_ID=$GCP_PROJECT \
       GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS \
       PACKER_VAR_FILES=override.json \
-      make deps-gce build-gce-ubuntu-1804)
+      make deps-gce build-gce-ubuntu-2004)
   else
     # assume we are running in the CI environment as root
     # Add a user for ansible to work properly
     groupadd -r packer && useradd -m -s /bin/bash -r -g packer packer
     chown -R packer:packer /home/prow/go/src/sigs.k8s.io/image-builder
     # use the packer user to run the build
-    su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS PACKER_VAR_FILES=override.json make deps-gce build-gce-ubuntu-1804'"
+    su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS PACKER_VAR_FILES=override.json make deps-gce build-gce-ubuntu-2004'"
   fi
 
-  filter="name~cluster-api-ubuntu-1804-${KUBERNETES_VERSION//[.+]/-}"
+  filter="name~cluster-api-ubuntu-2004-${KUBERNETES_VERSION//[.+]/-}"
   image_id=$(gcloud compute images list --project "$GCP_PROJECT" \
     --no-standard-images --filter="${filter}" --format="table[no-heading](name)")
   if [[ -z "$image_id" ]]; then


### PR DESCRIPTION
/kind cleanup


**What this PR does / why we need it**:

- build-gce-ubuntu-1804 is deprecated update to build-gce-ubuntu-2004
/hold for all non required tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
build-gce-ubuntu-1804 is deprecated update to build-gce-ubuntu-2004
```
