### PR TITLE
Fix child kubeconfig generation to use gke-gcloud-auth-plugin

### DIFF
--- a/cloud/services/container/clusters/kubeconfig.go
+++ b/cloud/services/container/clusters/kubeconfig.go
@@ -108,18 +108,15 @@ func (s *Service) createUserKubeconfigSecret(ctx context.Context, cluster *conta
 		return fmt.Errorf("creating base kubeconfig: %w", err)
 	}
 
-	authProviderConfig := &api.AuthProviderConfig{
-		Name: "gcp",
-		Config: map[string]string{
-			"cmd-args":   "config config-helper --format=json",
-			"cmd-path":   "gcloud",
-			"expiry-key": "'{.credential.token_expiry}'",
-			"token-key":  "'{.credential.access_token}'",
-		},
+	execConfig := &api.ExecConfig{
+		APIVersion:         "client.authentication.k8s.io/v1beta1",
+		Command:            "gke-gcloud-auth-plugin",
+		InstallHint:        "Install gke-gcloud-auth-plugin for use with kubectl by following https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke",
+		ProvideClusterInfo: true,
 	}
 	cfg.AuthInfos = map[string]*api.AuthInfo{
 		contextName: {
-			AuthProvider: authProviderConfig,
+			Exec: execConfig,
 		},
 	}
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: Updates the `createUserKubeconfigSecret` to use the `gke-gcloud-auth-plugin` and the `ExecConfig` instead of the `AuthProviderConfig`. This is needed as without it we see this error when using the generated kubeconfig:

```
> k --kubeconfig=managed-test.kubeconfig get nodes
error: The gcp auth plugin has been removed.
Please use the "gke-gcloud-auth-plugin" kubectl/client-go credential plugin instead.
See https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke for further details
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
