### PR TITLE
Do not ignore coverage.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ test/e2e/config/gcp-ci-envsubst.yaml
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 coverage.*
+!**/coverage.go
 
 # Ansible
 *.retry


### PR DESCRIPTION
/kind other

**What this PR does / why we need it**:
Some vendored files are named `coverage.go` and are being ignored by `.gitignore`'s https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/797df124dd04047257411b733e91fef7c0c1581c/.gitignore#L17
E.g.:
```
vendor/golang.org/x/text/internal/language/coverage.go
vendor/golang.org/x/text/language/coverage.go
```
This causes issues when working with these files in git when vendoring.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
