### PR TITLE
Fix update node pool when nodeLocation is empty

### DIFF
--- a/cloud/services/container/nodepools/reconcile.go
+++ b/cloud/services/container/nodepools/reconcile.go
@@ -127,7 +127,6 @@ func (s *Service) Reconcile(ctx context.Context) (ctrl.Result, error) {
 		log.Error(errors.New("Unhandled node pool status"), fmt.Sprintf("Unhandled node pool status %s", nodePool.Status), "name", s.scope.GCPManagedMachinePool.Name)
 		return ctrl.Result{}, nil
 	}
-
 	needUpdateNodePool, nodePoolUpdateNodePool := s.checkDiffAndPrepareUpdateNodePool(nodePool)
 	if needUpdateNodePool {
 		log.Info("Node pool config update required")
@@ -357,7 +356,7 @@ func (s *Service) checkDiffAndPrepareUpdateNodePool(existingNodePool *containerp
 	}
 	// Locations
 	desiredLocations := s.scope.GCPManagedMachinePool.Spec.NodeLocations
-	if !cmp.Equal(desiredLocations, existingNodePool.Locations) {
+	if desiredLocations != nil && !cmp.Equal(desiredLocations, existingNodePool.Locations) {
 		needUpdate = true
 		updateNodePoolRequest.Locations = desiredLocations
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When the nodeLocations field of the GCPManagedMachinePool object is empty, this error appears in the reconcile process:

"error"="node pool config update (either version/labels/taints/locations/image type/network tag or all) failed: rpc error: code = InvalidArgument desc = At least one of ['node_version', 'image_type', 'updated_node_pool', 'locations', 'workload_metadata_config', 'upgrade_settings', 'kubelet_config', 'linux_node_config', 'tags', 'taints', 'labels', 'node_network_config', 'gcfs_config', 'gvnic', 'confidential_nodes', 'logging_config', 'fast_socket', 'resource_labels', 'accelerators', 'windows_node_config', 'machine_type', 'disk_type', 'disk_size_gb', 'containerd_config', 'resource_manager_tags'] must be specified.

And the status gets stuck in 'Provisioning'

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**TODOs**:
- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
NONE
```
