### PR TITLE
Fix GKE reconciliation when the version is set in the machine pool

### DIFF
--- a/cloud/scope/managedmachinepool.go
+++ b/cloud/scope/managedmachinepool.go
@@ -19,6 +19,7 @@ package scope
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud"
@@ -227,7 +228,7 @@ func ConvertToSdkNodePool(nodePool infrav1exp.GCPManagedMachinePool, machinePool
 		}
 	}
 	if machinePool.Spec.Template.Spec.Version != nil {
-		sdkNodePool.Version = *machinePool.Spec.Template.Spec.Version
+		sdkNodePool.Version = strings.Replace(*machinePool.Spec.Template.Spec.Version, "v", "", 1)
 	}
 	return &sdkNodePool
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
"When the version is configured in the Machine Pool object, a 'v' is added, and the reconciliation process fails with the following error:"
E1201 12:53:35.740062     515 gcpmanagedmachinepool_controller.go:342]  "msg"="Reconcile error" "error"="node pool config update (either version/labels/taints/locations/image type/network tag or all) failed: rpc error: code = InvalidArgument desc = Version \"v1.27.3-gke.100\" is invalid. It should have the form 1.X, 1.X.Y, 1.X.Y-.*, 'latest', or ''.

**TODOs**:
- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
NONE
```
