### PR TITLE
Fix GKE update version check

### DIFF
--- a/cloud/services/container/clusters/reconcile.go
+++ b/cloud/services/container/clusters/reconcile.go
@@ -377,10 +377,10 @@ func (s *Service) checkDiffAndPrepareUpdate(existingCluster *containerpb.Cluster
 	// Master version
 	if s.scope.GCPManagedControlPlane.Spec.ControlPlaneVersion != nil {
 		desiredMasterVersion := *s.scope.GCPManagedControlPlane.Spec.ControlPlaneVersion
-		if desiredMasterVersion != existingCluster.InitialClusterVersion {
+		if desiredMasterVersion != existingCluster.CurrentMasterVersion {
 			needUpdate = true
 			clusterUpdate.DesiredMasterVersion = desiredMasterVersion
-			log.V(2).Info("Master version update required", "current", existingCluster.InitialClusterVersion, "desired", desiredMasterVersion)
+			log.V(2).Info("Master version update required", "current", existingCluster.CurrentMasterVersion, "desired", desiredMasterVersion)
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The GKE update process enters an infinite loop during the reconcile process because it compares desiredMasterVersion to InitialClusterVersion instead of CurrentMasterVersion.

**TODOs**:
- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
Use current cluster version when upgrading a GKE cluster instead of the initial version. 
```
