### PR TITLE
Fix node pool update when MachinePool version is set

### DIFF
--- a/cloud/services/container/nodepools/reconcile.go
+++ b/cloud/services/container/nodepools/reconcile.go
@@ -355,9 +355,12 @@ func (s *Service) checkDiffAndPrepareUpdateConfig(existingNodePool *containerpb.
 	desiredNodePool := scope.ConvertToSdkNodePool(*s.scope.GCPManagedMachinePool, *s.scope.MachinePool, isRegional, s.scope.GCPManagedControlPlane.Spec.ClusterName)
 
 	// Node version
-	if s.scope.NodePoolVersion() != nil && *s.scope.NodePoolVersion() != infrav1exp.ConvertFromSdkNodeVersion(existingNodePool.Version) {
-		needUpdate = true
-		updateNodePoolRequest.NodeVersion = *s.scope.NodePoolVersion()
+	if s.scope.NodePoolVersion() != nil {
+		desiredNodePoolVersion := infrav1exp.ConvertFromSdkNodeVersion(*s.scope.NodePoolVersion())
+		if desiredNodePoolVersion != infrav1exp.ConvertFromSdkNodeVersion(existingNodePool.Version) {
+			needUpdate = true
+			updateNodePoolRequest.NodeVersion = desiredNodePoolVersion
+		}
 	}
 	// Kubernetes labels
 	if !cmp.Equal(desiredNodePool.Config.GetLabels(), existingNodePool.Config.Labels) {

--- a/exp/api/v1beta1/types.go
+++ b/exp/api/v1beta1/types.go
@@ -110,5 +110,5 @@ func ConvertToSdkAutoscaling(autoscaling *NodePoolAutoScaling) *containerpb.Node
 // ConvertFromSdkNodeVersion converts GCP SDK node version to k8s version.
 func ConvertFromSdkNodeVersion(sdkNodeVersion string) string {
 	// For example, the node version returned from GCP SDK can be 1.27.2-gke.2100, we want to convert it to 1.27.2
-	return strings.Split(sdkNodeVersion, "-")[0]
+	return strings.Replace(strings.Split(sdkNodeVersion, "-")[0], "v", "", 1)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When the version is defined in the MachinePool object, the following error occurs in the reconciliation process:

E1211 13:28:24.009959       1 gcpmanagedmachinepool_controller.go:342]  "msg"="Reconcile error" "error"="node pool config update (either version/labels/taints/locations/image type/network tag or all) failed: rpc error: code = InvalidArgument desc = Version \"v1.27.3-gke.100\" is invalid. It should have the form 1.X, 1.X.Y, 1.X.Y-.*, 'latest'

**TODOs**:
- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
Fix GKE reconciliation process when MachinePool version is set.
```
