### PR TITLE
Fix GKE MachinePool replicas per region

### DIFF
--- a/cloud/scope/managedmachinepool.go
+++ b/cloud/scope/managedmachinepool.go
@@ -159,7 +159,11 @@ func (s *ManagedMachinePoolScope) NodePoolVersion() *string {
 func ConvertToSdkNodePool(nodePool infrav1exp.GCPManagedMachinePool, machinePool clusterv1exp.MachinePool, regional bool) *containerpb.NodePool {
 	replicas := *machinePool.Spec.Replicas
 	if regional {
-		replicas /= cloud.DefaultNumRegionsPerZone
+		if len(nodePool.Spec.NodeLocations) != 0 {
+			replicas /= int32(len(nodePool.Spec.NodeLocations))
+		} else {
+			replicas /= cloud.DefaultNumRegionsPerZone
+		}
 	}
 	nodePoolName := nodePool.Spec.NodePoolName
 	if len(nodePoolName) == 0 {

--- a/cloud/services/container/nodepools/reconcile.go
+++ b/cloud/services/container/nodepools/reconcile.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"sigs.k8s.io/cluster-api-provider-gcp/cloud"
 	"sigs.k8s.io/cluster-api-provider-gcp/util/resourceurl"
 
 	"google.golang.org/api/iterator"
@@ -411,7 +410,7 @@ func (s *Service) checkDiffAndPrepareUpdateSize(existingNodePool *containerpb.No
 
 	replicas := *s.scope.MachinePool.Spec.Replicas
 	if shared.IsRegional(s.scope.Region()) {
-		replicas /= cloud.DefaultNumRegionsPerZone
+		replicas /= int32(len(existingNodePool.Locations))
 	}
 
 	if replicas != existingNodePool.InitialNodeCount {

--- a/cloud/services/shared/machinepool.go
+++ b/cloud/services/shared/machinepool.go
@@ -34,8 +34,14 @@ func ManagedMachinePoolPreflightCheck(managedPool *infrav1exp.GCPManagedMachineP
 	}
 
 	if IsRegional(location) {
-		if *machinePool.Spec.Replicas%cloud.DefaultNumRegionsPerZone != 0 {
-			return fmt.Errorf("a machine pool (%s) in a regional cluster must have replicas with a multiple of %d", machinePool.Name, cloud.DefaultNumRegionsPerZone)
+		var numRegionsPerZone int32
+		if len(managedPool.Spec.NodeLocations) != 0 {
+			numRegionsPerZone = int32(len(managedPool.Spec.NodeLocations))
+		} else {
+			numRegionsPerZone = cloud.DefaultNumRegionsPerZone
+		}
+		if *machinePool.Spec.Replicas%numRegionsPerZone != 0 {
+			return fmt.Errorf("a machine pool (%s) in a regional cluster with %d regions, must have replicas with a multiple of %d", machinePool.Name, numRegionsPerZone, numRegionsPerZone)
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
MachinePool replicas should be set based on the number of regions specified for that MachinePool.

**TODOs**:
- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
Fix GKE MachinePool number of replicas, now are based on the number of regions specified for that MachinePool.
```
