### PR TITLE
Fix GKE autoscaling conditions in reconciliation process

### DIFF
--- a/cloud/services/container/nodepools/reconcile.go
+++ b/cloud/services/container/nodepools/reconcile.go
@@ -30,6 +30,7 @@ import (
 	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud/providerid"
@@ -410,7 +411,8 @@ func (s *Service) checkDiffAndPrepareUpdateAutoscaling(existingNodePool *contain
 	setNodePoolAutoscalingRequest := containerpb.SetNodePoolAutoscalingRequest{
 		Name: s.scope.NodePoolFullName(),
 	}
-	if !cmp.Equal(desiredAutoscaling, existingNodePool.Autoscaling) {
+
+	if !cmp.Equal(desiredAutoscaling, existingNodePool.Autoscaling, cmpopts.IgnoreUnexported(containerpb.NodePoolAutoscaling{})) {
 		needUpdate = true
 		setNodePoolAutoscalingRequest.Autoscaling = desiredAutoscaling
 	}

--- a/exp/api/v1beta1/types.go
+++ b/exp/api/v1beta1/types.go
@@ -81,27 +81,30 @@ func convertToSdkLocationPolicy(locationPolicy ManagedNodePoolLocationPolicy) co
 
 // ConvertToSdkAutoscaling converts node pool autoscaling config to a value that is used by GCP SDK.
 func ConvertToSdkAutoscaling(autoscaling *NodePoolAutoScaling) *containerpb.NodePoolAutoscaling {
-	if autoscaling == nil {
-		return nil
-	}
 	sdkAutoscaling := containerpb.NodePoolAutoscaling{
-		Enabled: true, // enable autoscaling by default
+		Enabled:           true, // enable autoscaling by default
+		TotalMinNodeCount: 0,
+		TotalMaxNodeCount: 1,
+		LocationPolicy:    convertToSdkLocationPolicy(ManagedNodePoolLocationPolicyBalanced),
 	}
-	// set fields
-	if autoscaling.MinCount != nil {
-		sdkAutoscaling.TotalMinNodeCount = *autoscaling.MinCount
-	}
-	if autoscaling.MaxCount != nil {
-		sdkAutoscaling.TotalMaxNodeCount = *autoscaling.MaxCount
-	}
-	if autoscaling.EnableAutoscaling != nil {
-		sdkAutoscaling.Enabled = *autoscaling.EnableAutoscaling
-	}
-	if autoscaling.LocationPolicy != nil {
-		sdkAutoscaling.LocationPolicy = convertToSdkLocationPolicy(*autoscaling.LocationPolicy)
-	} else if sdkAutoscaling.Enabled {
-		// if location policy is not specified and autoscaling is enabled, default location policy to "any"
-		sdkAutoscaling.LocationPolicy = convertToSdkLocationPolicy(ManagedNodePoolLocationPolicyAny)
+	if autoscaling != nil {
+		// set fields
+		if autoscaling.MinCount != nil {
+			sdkAutoscaling.TotalMinNodeCount = *autoscaling.MinCount
+		}
+		if autoscaling.MaxCount != nil {
+			sdkAutoscaling.TotalMaxNodeCount = *autoscaling.MaxCount
+		}
+		if autoscaling.LocationPolicy != nil {
+			sdkAutoscaling.LocationPolicy = convertToSdkLocationPolicy(*autoscaling.LocationPolicy)
+		}
+		if autoscaling.EnableAutoscaling != nil {
+			if !*autoscaling.EnableAutoscaling {
+				sdkAutoscaling = containerpb.NodePoolAutoscaling{
+					Enabled: false,
+				}
+			}
+		}
 	}
 
 	return &sdkAutoscaling

--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -8,7 +8,8 @@
       "go.sum",
       "api",
       "cloud",
-      "controllers"
+      "controllers",
+      "exp"
     ],
     "label": "CAPG"
   }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The reconciliation process is broken in GKE. When enableAutoscaling is not defined, the reconciliation process fails because desiredAutoscaling is nil and when it is defined, it fails because the state is unexported.

**TODOs**:
- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
Fix GKE autoscaling conditions in reconciliation process.
```
