### PR TITLE
fix: invalid string for manager's deployment containerPort

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
         - containerPort: 9440
           name: healthz
           protocol: TCP
-        - containerPort: ${CAPG_DIAGNOSTICS_PORT:=8443}
+        - containerPort: 8443
           name: metrics
           protocol: TCP
         readinessProbe:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
It fixes an invalid containerPort in the manager Deployment's config.
The string was set as an envsubst string but the containerPort field is an int32, and this may break at kustomization/parsing time depending on how the tooling is configured (e.g. for the upstream cluster-api-operator).

**Release note**:
```release-note
fix: invalid string for manager's deployment containerPort
```
