### PR TITLE
Bump cert-manager to v1.14.4 to align with CAPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,9 @@ GOTESTSUM_VER := v1.6.4
 GOTESTSUM_BIN := gotestsum
 GOTESTSUM := $(TOOLS_BIN_DIR)/$(GOTESTSUM_BIN)
 
+# Other tools versions
+CERT_MANAGER_VER := v1.14.4
+
 # Define Docker related variables. Releases should modify and double check these vars.
 export GCP_PROJECT ?= $(shell gcloud config get-value project)
 REGISTRY ?= gcr.io/$(GCP_PROJECT)
@@ -461,7 +464,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KIND) $(KUBECTL)
 	$(KIND) create cluster --name=clusterapi
 
 	# Install cert manager and wait for availability
-	./hack/install-cert-manager.sh
+	./hack/install-cert-manager.sh $(CERT_MANAGER_VER)
 
 	# Deploy CAPI
 	curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.2/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -

--- a/Tiltfile
+++ b/Tiltfile
@@ -19,7 +19,7 @@ settings = {
     "preload_images_for_kind": True,
     "kind_cluster_name": "capg",
     "capi_version": "v1.7.0",
-    "cert_manager_version": "v1.11.0",
+    "cert_manager_version": "v1.14.4",
     "kubernetes_version": "v1.29.3",
 }
 

--- a/hack/install-cert-manager.sh
+++ b/hack/install-cert-manager.sh
@@ -18,6 +18,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+CERT_MANAGER_VERSION=${1}
+
 TEST_RESOURCE=$(cat <<-END
 apiVersion: v1
 kind: Namespace
@@ -52,7 +54,7 @@ KUBECTL="${REPO_ROOT}/hack/tools/bin/kubectl"
 cd "${REPO_ROOT}" && make "${KUBECTL##*/}"
 
 ## Install cert manager and wait for availability
-"${KUBECTL}" apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
+"${KUBECTL}" apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook


### PR DESCRIPTION
**What type of PR is this?**
/kind support

**What this PR does / why we need it**:
Bump cert-manager to v1.14.4 to align with CAPI

**Release note**:
```release-note
Bump cert-manager to v1.14.4
```
