### PR TITLE
Add cloudbuild-nightly.yaml + release-staging-nightly target

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -10,7 +10,7 @@ steps:
     - TAG=$_GIT_TAG
     - PULL_BASE_REF=$_PULL_BASE_REF
     args:
-    - release-staging
+    - release-staging-nightly
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution


### PR DESCRIPTION
**What type of PR is this?**

/kind support

**What this PR does / why we need it**:

For nightly builds purpose, this PR adds the `cloudbuild-nightly.yaml` file, that gets invoked by image-builder launched via the configured nightly periodic job (https://github.com/kubernetes/test-infra/pull/32501).
`cloudbuild-nightly.yaml` in turn references the `release-staging-nightly` make target, that performs the image and manifests build and push to the staging bucket/registry.

This approach is mostly copied from CAPA ([1](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/63c66352579ef08bd365abd529e1924cde6f0d26/Makefile#L620-L626), [2](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/63c66352579ef08bd365abd529e1924cde6f0d26/cloudbuild-nightly.yaml#L1), [3](https://github.com/kubernetes/test-infra/blob/a34912308735bc89946b69b69c0b9eff4b0c66fc/config/jobs/image-pushing/k8s-staging-cluster-api.yaml#L473-L505))

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
