### PR TITLE
Use reference for Internal LB address

### DIFF
--- a/cloud/services/compute/loadbalancers/reconcile.go
+++ b/cloud/services/compute/loadbalancers/reconcile.go
@@ -234,7 +234,7 @@ func (s *Service) createInternalLoadBalancer(ctx context.Context, name string, l
 	if err != nil {
 		return err
 	}
-	s.scope.Network().APIInternalAddress = ptr.To[string](addr.Address)
+	s.scope.Network().APIInternalAddress = ptr.To[string](addr.SelfLink)
 	if lbType == infrav1.Internal {
 		// If only creating an internal Load Balancer, set the control plane endpoint
 		endpoint := s.scope.ControlPlaneEndpoint()


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

To be consistent with how all the other fields are set, including APIServerAddress, the resource selfLink should be used, not the actual IP address.

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
None
```
