### PR TITLE
fix: Make gcpmanagedcluster.network a required field

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -293,6 +293,7 @@ spec:
                   type: object
                 type: array
             required:
+            - network
             - project
             - region
             type: object

--- a/exp/api/v1beta1/gcpmanagedcluster_types.go
+++ b/exp/api/v1beta1/gcpmanagedcluster_types.go
@@ -41,7 +41,6 @@ type GCPManagedClusterSpec struct {
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
 
 	// NetworkSpec encapsulates all things related to the GCP network.
-	// +optional
 	Network infrav1.NetworkSpec `json:"network"`
 
 	// AdditionalLabels is an optional set of tags to add to GCP resources managed by the GCP provider, in addition to the


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

This makes the `gcpmanagedcluster.network` field a required field. 
 
/kind feature
 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1187 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: Makes GCPManagedCluster Spec's network field a required field
```
