### PR TITLE
fix: Prevent GCPManagedCluster reconciler to not crash if Network.Name and Network.Subnets is not passed to it

### DIFF
--- a/cloud/services/container/clusters/errors.go
+++ b/cloud/services/container/clusters/errors.go
@@ -23,6 +23,9 @@ import (
 // ErrAutopilotClusterMachinePoolsNotAllowed is used when there are machine pools specified for an autopilot enabled cluster.
 var ErrAutopilotClusterMachinePoolsNotAllowed = errors.New("cannot use machine pools with an autopilot enabled cluster")
 
+// ErrGCPManagedClusterHasNoNetworkDefined is used when there is no Network definition provided in a GCPManagedCluster.
+var ErrGCPManagedClusterHasNoNetworkDefined = errors.New("cannot reconcile GCPManagedCluster if Network is not defined")
+
 // NewErrUnexpectedClusterStatus creates a new error for an unexpected cluster status.
 func NewErrUnexpectedClusterStatus(status string) error {
 	return &UnexpectedClusterStatusError{status}


### PR DESCRIPTION


 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**


/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1187

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: Prevent GCPManagedCluster reconciler to not crash if Network.Name and Network.Subnets is not passed to it
```
