### PR TITLE
feat: Add ability to specify MTU when creating Network

### DIFF
--- a/api/v1beta1/gcpcluster_webhook.go
+++ b/api/v1beta1/gcpcluster_webhook.go
@@ -92,6 +92,20 @@ func (c *GCPCluster) ValidateUpdate(oldRaw runtime.Object) (admission.Warnings, 
 		)
 	}
 
+	if c.Spec.Network.Mtu < int64(1300) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "Network", "Mtu"),
+				c.Spec.Network.Mtu, "field cannot be lesser than 1300"),
+		)
+	}
+
+	if c.Spec.Network.Mtu > int64(8896) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "Network", "Mtu"),
+				c.Spec.Network.Mtu, "field cannot be greater than 8896"),
+		)
+	}
+
 	if len(allErrs) == 0 {
 		return nil, nil
 	}

--- a/api/v1beta1/gcpcluster_webhook_test.go
+++ b/api/v1beta1/gcpcluster_webhook_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGCPCluster_ValidateUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name       string
+		newCluster *GCPCluster
+		oldCluster *GCPCluster
+		wantErr    bool
+	}{
+		{
+			name: "GCPCluster with MTU field is within the limits of more than 1300 and less than 8896",
+			newCluster: &GCPCluster{
+				Spec: GCPClusterSpec{
+					Network: NetworkSpec{
+						Mtu: int64(1500),
+					},
+				},
+			},
+			oldCluster: &GCPCluster{
+				Spec: GCPClusterSpec{
+					Network: NetworkSpec{
+						Mtu: int64(1400),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "GCPCluster with MTU field more than 8896",
+			newCluster: &GCPCluster{
+				Spec: GCPClusterSpec{
+					Network: NetworkSpec{
+						Mtu: int64(10000),
+					},
+				},
+			},
+			oldCluster: &GCPCluster{
+				Spec: GCPClusterSpec{
+					Network: NetworkSpec{
+						Mtu: int64(1500),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "GCPCluster with MTU field less than 8896",
+			newCluster: &GCPCluster{
+				Spec: GCPClusterSpec{
+					Network: NetworkSpec{
+						Mtu: int64(1250),
+					},
+				},
+			},
+			oldCluster: &GCPCluster{
+				Spec: GCPClusterSpec{
+					Network: NetworkSpec{
+						Mtu: int64(1500),
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			warn, err := test.newCluster.ValidateUpdate(test.oldCluster)
+			if test.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			g.Expect(warn).To(BeNil())
+		})
+	}
+}

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -137,9 +137,13 @@ type NetworkSpec struct {
 	// +optional
 	HostProject *string `json:"hostProject,omitempty"`
 
-	// Mtu: Maximum Transmission Unit (MTU), in bytes, of packets passing through
-	// this interconnect attachment. Only 1440 and 1500 are allowed. If not
-	// specified, the value will default to 1440.
+	// Mtu: Maximum Transmission Unit in bytes. The minimum value for this field is
+	// 1300 and the maximum value is 8896. The suggested value is 1500, which is
+	// the default MTU used on the Internet, or 8896 if you want to use Jumbo
+	// frames. If unspecified, the value defaults to 1460.
+	// More info: https://pkg.go.dev/google.golang.org/api/compute/v1#Network
+	// +kubebuilder:validation:Minimum:=1300
+	// +kubebuilder:validation:Maximum:=8896
 	// +optional
 	Mtu int64 `json:"mtu,omitempty"`
 }

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -144,6 +144,7 @@ type NetworkSpec struct {
 	// More info: https://pkg.go.dev/google.golang.org/api/compute/v1#Network
 	// +kubebuilder:validation:Minimum:=1300
 	// +kubebuilder:validation:Maximum:=8896
+	// +kubebuilder:default:=1460
 	// +optional
 	Mtu int64 `json:"mtu,omitempty"`
 }

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -136,6 +136,12 @@ type NetworkSpec struct {
 	// HostProject is the name of the project hosting the shared VPC network resources.
 	// +optional
 	HostProject *string `json:"hostProject,omitempty"`
+
+	// Mtu: Maximum Transmission Unit (MTU), in bytes, of packets passing through
+	// this interconnect attachment. Only 1440 and 1500 are allowed. If not
+	// specified, the value will default to 1440.
+	// +optional
+	Mtu int64 `json:"mtu,omitempty"`
 }
 
 // LoadBalancerType defines the Load Balancer that should be created.

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -131,6 +131,15 @@ func (s *ClusterScope) NetworkName() string {
 	return ptr.Deref(s.GCPCluster.Spec.Network.Name, "default")
 }
 
+// NetworkMtu returns the Network MTU of 1440 which is the default, otherwise returns back what is being set.
+// https://cloud.google.com/vpc/docs/mtu
+func (s *ClusterScope) NetworkMtu() int64 {
+	if s.GCPCluster.Spec.Network.Mtu == 0 {
+		return int64(1440)
+	}
+	return s.GCPCluster.Spec.Network.Mtu
+}
+
 // NetworkLink returns the partial URL for the network.
 func (s *ClusterScope) NetworkLink() string {
 	return fmt.Sprintf("projects/%s/global/networks/%s", s.NetworkProject(), s.NetworkName())
@@ -206,6 +215,7 @@ func (s *ClusterScope) NetworkSpec() *compute.Network {
 		Description:           infrav1.ClusterTagKey(s.Name()),
 		AutoCreateSubnetworks: createSubnet,
 		ForceSendFields:       []string{"AutoCreateSubnetworks"},
+		Mtu:                   s.NetworkMtu(),
 	}
 
 	return network

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -132,10 +132,16 @@ func (s *ClusterScope) NetworkName() string {
 }
 
 // NetworkMtu returns the Network MTU of 1440 which is the default, otherwise returns back what is being set.
-// https://cloud.google.com/vpc/docs/mtu
+// Mtu: Maximum Transmission Unit in bytes. The minimum value for this field is
+// 1300 and the maximum value is 8896. The suggested value is 1500, which is
+// the default MTU used on the Internet, or 8896 if you want to use Jumbo
+// frames. If unspecified, the value defaults to 1460.
+// More info
+// - https://pkg.go.dev/google.golang.org/api/compute/v1#Network
+// - https://cloud.google.com/vpc/docs/mtu
 func (s *ClusterScope) NetworkMtu() int64 {
 	if s.GCPCluster.Spec.Network.Mtu == 0 {
-		return int64(1440)
+		return int64(1460)
 	}
 	return s.GCPCluster.Spec.Network.Mtu
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -168,6 +168,13 @@ spec:
                       (useful for changing apiserver port)
                     format: int32
                     type: integer
+                  mtu:
+                    description: |-
+                      Mtu: Maximum Transmission Unit (MTU), in bytes, of packets passing through
+                      this interconnect attachment. Only 1440 and 1500 are allowed. If not
+                      specified, the value will default to 1440.
+                    format: int64
+                    type: integer
                   name:
                     description: Name is the name of the network to be used.
                     type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -170,10 +170,14 @@ spec:
                     type: integer
                   mtu:
                     description: |-
-                      Mtu: Maximum Transmission Unit (MTU), in bytes, of packets passing through
-                      this interconnect attachment. Only 1440 and 1500 are allowed. If not
-                      specified, the value will default to 1440.
+                      Mtu: Maximum Transmission Unit in bytes. The minimum value for this field is
+                      1300 and the maximum value is 8896. The suggested value is 1500, which is
+                      the default MTU used on the Internet, or 8896 if you want to use Jumbo
+                      frames. If unspecified, the value defaults to 1460.
+                      More info: https://pkg.go.dev/google.golang.org/api/compute/v1#Network
                     format: int64
+                    maximum: 8896
+                    minimum: 1300
                     type: integer
                   name:
                     description: Name is the name of the network to be used.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -169,6 +169,7 @@ spec:
                     format: int32
                     type: integer
                   mtu:
+                    default: 1460
                     description: |-
                       Mtu: Maximum Transmission Unit in bytes. The minimum value for this field is
                       1300 and the maximum value is 8896. The suggested value is 1500, which is

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -186,6 +186,7 @@ spec:
                             format: int32
                             type: integer
                           mtu:
+                            default: 1460
                             description: |-
                               Mtu: Maximum Transmission Unit in bytes. The minimum value for this field is
                               1300 and the maximum value is 8896. The suggested value is 1500, which is

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -185,6 +185,13 @@ spec:
                               backend (useful for changing apiserver port)
                             format: int32
                             type: integer
+                          mtu:
+                            description: |-
+                              Mtu: Maximum Transmission Unit (MTU), in bytes, of packets passing through
+                              this interconnect attachment. Only 1440 and 1500 are allowed. If not
+                              specified, the value will default to 1440.
+                            format: int64
+                            type: integer
                           name:
                             description: Name is the name of the network to be used.
                             type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -187,10 +187,14 @@ spec:
                             type: integer
                           mtu:
                             description: |-
-                              Mtu: Maximum Transmission Unit (MTU), in bytes, of packets passing through
-                              this interconnect attachment. Only 1440 and 1500 are allowed. If not
-                              specified, the value will default to 1440.
+                              Mtu: Maximum Transmission Unit in bytes. The minimum value for this field is
+                              1300 and the maximum value is 8896. The suggested value is 1500, which is
+                              the default MTU used on the Internet, or 8896 if you want to use Jumbo
+                              frames. If unspecified, the value defaults to 1460.
+                              More info: https://pkg.go.dev/google.golang.org/api/compute/v1#Network
                             format: int64
+                            maximum: 8896
+                            minimum: 1300
                             type: integer
                           name:
                             description: Name is the name of the network to be used.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -166,10 +166,14 @@ spec:
                     type: integer
                   mtu:
                     description: |-
-                      Mtu: Maximum Transmission Unit (MTU), in bytes, of packets passing through
-                      this interconnect attachment. Only 1440 and 1500 are allowed. If not
-                      specified, the value will default to 1440.
+                      Mtu: Maximum Transmission Unit in bytes. The minimum value for this field is
+                      1300 and the maximum value is 8896. The suggested value is 1500, which is
+                      the default MTU used on the Internet, or 8896 if you want to use Jumbo
+                      frames. If unspecified, the value defaults to 1460.
+                      More info: https://pkg.go.dev/google.golang.org/api/compute/v1#Network
                     format: int64
+                    maximum: 8896
+                    minimum: 1300
                     type: integer
                   name:
                     description: Name is the name of the network to be used.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -165,6 +165,7 @@ spec:
                     format: int32
                     type: integer
                   mtu:
+                    default: 1460
                     description: |-
                       Mtu: Maximum Transmission Unit in bytes. The minimum value for this field is
                       1300 and the maximum value is 8896. The suggested value is 1500, which is

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -164,6 +164,13 @@ spec:
                       (useful for changing apiserver port)
                     format: int32
                     type: integer
+                  mtu:
+                    description: |-
+                      Mtu: Maximum Transmission Unit (MTU), in bytes, of packets passing through
+                      this interconnect attachment. Only 1440 and 1500 are allowed. If not
+                      specified, the value will default to 1440.
+                    format: int64
+                    type: integer
                   name:
                     description: Name is the name of the network to be used.
                     type: string


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**


/kind feature


**What this PR does / why we need it**:

User can set `GCPCluster.Spec.Network.Mtu` for setting the MTU for the network being created. If nothing is passed the MTU will default to 1440 which is the default set here https://cloud.google.com/vpc/docs/mtu

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1246

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
feat: Add ability to add GCPCluster.Spec.Network.Mtu 
```
