### PR TITLE
Set Labels on Disks and ForwardingRules resources

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -337,6 +337,7 @@ func (s *ClusterScope) ForwardingRuleSpec(lbname string) *compute.ForwardingRule
 		IPProtocol:          "TCP",
 		LoadBalancingScheme: "EXTERNAL",
 		PortRange:           portRange,
+		Labels:              s.AdditionalLabels(),
 	}
 }
 

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -249,6 +249,7 @@ func (m *MachineScope) InstanceImageSpec() *compute.AttachedDisk {
 			DiskType:            path.Join("zones", m.Zone(), "diskTypes", string(diskType)),
 			ResourceManagerTags: shared.ResourceTagConvert(context.TODO(), m.GCPMachine.Spec.ResourceManagerTags),
 			SourceImage:         sourceImage,
+			Labels:              m.ClusterGetter.AdditionalLabels().AddLabels(m.GCPMachine.Spec.AdditionalLabels),
 		},
 	}
 

--- a/cloud/services/compute/instances/reconcile_test.go
+++ b/cloud/services/compute/instances/reconcile_test.go
@@ -237,6 +237,9 @@ func TestService_createOrGetInstance(t *testing.T) {
 							DiskType:            "zones/us-central1-c/diskTypes/pd-standard",
 							SourceImage:         "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
 							ResourceManagerTags: map[string]string{},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
 						},
 					},
 				},
@@ -302,6 +305,9 @@ func TestService_createOrGetInstance(t *testing.T) {
 							DiskType:            "zones/us-central1-c/diskTypes/pd-standard",
 							SourceImage:         "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
 							ResourceManagerTags: map[string]string{},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
 						},
 					},
 				},
@@ -369,6 +375,9 @@ func TestService_createOrGetInstance(t *testing.T) {
 							DiskType:            "zones/us-central1-c/diskTypes/pd-standard",
 							SourceImage:         "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
 							ResourceManagerTags: map[string]string{},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
 						},
 					},
 				},
@@ -436,6 +445,9 @@ func TestService_createOrGetInstance(t *testing.T) {
 							DiskType:            "zones/us-central1-c/diskTypes/pd-standard",
 							SourceImage:         "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
 							ResourceManagerTags: map[string]string{},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
 						},
 					},
 				},
@@ -506,6 +518,9 @@ func TestService_createOrGetInstance(t *testing.T) {
 							DiskType:            "zones/us-central1-c/diskTypes/pd-standard",
 							SourceImage:         "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
 							ResourceManagerTags: map[string]string{},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
 						},
 					},
 				},
@@ -569,6 +584,9 @@ func TestService_createOrGetInstance(t *testing.T) {
 							DiskType:            "zones/us-central1-a/diskTypes/pd-standard",
 							SourceImage:         "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
 							ResourceManagerTags: map[string]string{},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
 						},
 					},
 				},
@@ -639,6 +657,9 @@ func TestService_createOrGetInstance(t *testing.T) {
 							DiskType:            "zones/us-central1-c/diskTypes/pd-standard",
 							SourceImage:         "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
 							ResourceManagerTags: map[string]string{},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
 						},
 						DiskEncryptionKey: &compute.CustomerEncryptionKey{
 							KmsKeyName: "projects/my-project/locations/us-central1/keyRings/us-central1/cryptoKeys/some-key",
@@ -712,6 +733,9 @@ func TestService_createOrGetInstance(t *testing.T) {
 							DiskType:            "zones/us-central1-c/diskTypes/pd-standard",
 							SourceImage:         "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
 							ResourceManagerTags: map[string]string{},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
 						},
 						DiskEncryptionKey: &compute.CustomerEncryptionKey{
 							RawKey: "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
@@ -785,6 +809,9 @@ func TestService_createOrGetInstance(t *testing.T) {
 							DiskType:            "zones/us-central1-c/diskTypes/pd-standard",
 							SourceImage:         "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
 							ResourceManagerTags: map[string]string{},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
 						},
 						DiskEncryptionKey: &compute.CustomerEncryptionKey{
 							RsaEncryptedKey: "ieCx/NcW06PcT7Ep1X6LUTc/hLvUDYyzSZPPVCVPTVEohpeHASqC8uw5TzyO9U+Fka9JFHiz0mBibXUInrC/jEk014kCK/NPjYgEMOyssZ4ZINPKxlUh2zn1bV+MCaTICrdmuSBTWlUUiFoDiD6PYznLwh8ZNdaheCeZ8ewEXgFQ8V+sDroLaN3Xs3MDTXQEMMoNUXMCZEIpg9Vtp9x2oe==",


### PR DESCRIPTION
 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The Labels field should be set on Disks and ForwardingRules resources from the machine or cluster `AdditionalLabels` field, similar to how it is set on Instances.

Fixes #1274 

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This fix populates the Disk and ForwardingRules resources' `Labels` field from the machine/cluster `AdditionalLabels` field.
```
