### PR TITLE
Use SetLabels() to set ForwardingRules labels

### DIFF
--- a/cloud/services/compute/loadbalancers/reconcile.go
+++ b/cloud/services/compute/loadbalancers/reconcile.go
@@ -579,6 +579,18 @@ func (s *Service) createOrGetForwardingRule(ctx context.Context, lbname string, 
 		}
 	}
 
+	// Labels on ForwardingRules must be added after resource is created
+	labels := s.scope.AdditionalLabels()
+	if !labels.Equals(forwarding.Labels) {
+		setLabelsRequest := &compute.GlobalSetLabelsRequest{
+			LabelFingerprint: forwarding.LabelFingerprint,
+			Labels:           labels,
+		}
+		if err = s.forwardingrules.SetLabels(ctx, key, setLabelsRequest); err != nil {
+			return nil, err
+		}
+	}
+
 	return forwarding, nil
 }
 
@@ -618,6 +630,18 @@ func (s *Service) createOrGetRegionalForwardingRule(ctx context.Context, lbname 
 
 		forwarding, err = s.regionalforwardingrules.Get(ctx, key)
 		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Labels on ForwardingRules must be added after resource is created
+	labels := s.scope.AdditionalLabels()
+	if !labels.Equals(forwarding.Labels) {
+		setLabelsRequest := &compute.RegionSetLabelsRequest{
+			LabelFingerprint: forwarding.LabelFingerprint,
+			Labels:           labels,
+		}
+		if err = s.regionalforwardingrules.SetLabels(ctx, key, setLabelsRequest); err != nil {
 			return nil, err
 		}
 	}

--- a/cloud/services/compute/loadbalancers/service.go
+++ b/cloud/services/compute/loadbalancers/service.go
@@ -44,6 +44,14 @@ type forwardingrulesInterface interface {
 	Get(ctx context.Context, key *meta.Key, options ...k8scloud.Option) (*compute.ForwardingRule, error)
 	Insert(ctx context.Context, key *meta.Key, obj *compute.ForwardingRule, options ...k8scloud.Option) error
 	Delete(ctx context.Context, key *meta.Key, options ...k8scloud.Option) error
+	SetLabels(ctx context.Context, key *meta.Key, obj *compute.GlobalSetLabelsRequest, options ...k8scloud.Option) error
+}
+
+type regionalforwardingrulesInterface interface {
+	Get(ctx context.Context, key *meta.Key, options ...k8scloud.Option) (*compute.ForwardingRule, error)
+	Insert(ctx context.Context, key *meta.Key, obj *compute.ForwardingRule, options ...k8scloud.Option) error
+	Delete(ctx context.Context, key *meta.Key, options ...k8scloud.Option) error
+	SetLabels(ctx context.Context, key *meta.Key, obj *compute.RegionSetLabelsRequest, options ...k8scloud.Option) error
 }
 
 type healthchecksInterface interface {
@@ -89,7 +97,7 @@ type Service struct {
 	backendservices         backendservicesInterface
 	regionalbackendservices backendservicesInterface
 	forwardingrules         forwardingrulesInterface
-	regionalforwardingrules forwardingrulesInterface
+	regionalforwardingrules regionalforwardingrulesInterface
 	healthchecks            healthchecksInterface
 	regionalhealthchecks    healthchecksInterface
 	instancegroups          instancegroupsInterface


### PR DESCRIPTION
 **What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The ForwardingRules resource requires that the SetLabels() method be used to add the labels after the resource has been created. This resource is different than, for example, Instances or Disks. See Issue #1276 for more information.

**Which issue(s) this PR fixes** 
Fixes #1276 

**Special notes for your reviewer**:

This is the comment for `ForwardingRules` in https://github.com/googleapis/google-api-go-client/blame/main/compute/v1/compute-gen.go
```
       // Labels: Labels for this resource. These can only be added or modified
       // by the setLabels method. 
        Labels map[string]string `json:"labels,omitempty"
```

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
"NONE"
```
