### PR TITLE
Add additional disk types

### DIFF
--- a/api/v1beta1/gcpmachine_types.go
+++ b/api/v1beta1/gcpmachine_types.go
@@ -47,6 +47,8 @@ type AttachedDiskSpec struct {
 	// 1. "pd-standard" - Standard (HDD) persistent disk
 	// 2. "pd-ssd" - SSD persistent disk
 	// 3. "local-ssd" - Local SSD disk (https://cloud.google.com/compute/docs/disks/local-ssd).
+	// 4. "pd-balanced" - Balanced Persistent Disk
+	// 5. "hyperdisk-balanced" - Hyperdisk Balanced
 	// Default is "pd-standard".
 	// +optional
 	DeviceType *DiskType `json:"deviceType,omitempty"`
@@ -281,6 +283,8 @@ type GCPMachineSpec struct {
 	// Supported types of root volumes:
 	// 1. "pd-standard" - Standard (HDD) persistent disk
 	// 2. "pd-ssd" - SSD persistent disk
+	// 3. "pd-balanced" - Balanced Persistent Disk
+	// 4. "hyperdisk-balanced" - Hyperdisk Balanced
 	// Default is "pd-standard".
 	// +optional
 	RootDeviceType *DiskType `json:"rootDeviceType,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
@@ -74,6 +74,8 @@ spec:
                         1. "pd-standard" - Standard (HDD) persistent disk
                         2. "pd-ssd" - SSD persistent disk
                         3. "local-ssd" - Local SSD disk (https://cloud.google.com/compute/docs/disks/local-ssd).
+                        4. "pd-balanced" - Balanced Persistent Disk
+                        5. "hyperdisk-balanced" - Hyperdisk Balanced
                         Default is "pd-standard".
                       type: string
                     encryptionKey:
@@ -297,6 +299,8 @@ spec:
                   Supported types of root volumes:
                   1. "pd-standard" - Standard (HDD) persistent disk
                   2. "pd-ssd" - SSD persistent disk
+                  3. "pd-balanced" - Balanced Persistent Disk
+                  4. "hyperdisk-balanced" - Hyperdisk Balanced
                   Default is "pd-standard".
                 type: string
               rootDiskEncryptionKey:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
@@ -87,6 +87,8 @@ spec:
                                 1. "pd-standard" - Standard (HDD) persistent disk
                                 2. "pd-ssd" - SSD persistent disk
                                 3. "local-ssd" - Local SSD disk (https://cloud.google.com/compute/docs/disks/local-ssd).
+                                4. "pd-balanced" - Balanced Persistent Disk
+                                5. "hyperdisk-balanced" - Hyperdisk Balanced
                                 Default is "pd-standard".
                               type: string
                             encryptionKey:
@@ -312,6 +314,8 @@ spec:
                           Supported types of root volumes:
                           1. "pd-standard" - Standard (HDD) persistent disk
                           2. "pd-ssd" - SSD persistent disk
+                          3. "pd-balanced" - Balanced Persistent Disk
+                          4. "hyperdisk-balanced" - Hyperdisk Balanced
                           Default is "pd-standard".
                         type: string
                       rootDiskEncryptionKey:

--- a/exp/api/v1beta1/gcpmanagedmachinepool_types.go
+++ b/exp/api/v1beta1/gcpmanagedmachinepool_types.go
@@ -39,6 +39,8 @@ const (
 	SSD DiskType = "pd-ssd"
 	// Balanced disk type.
 	Balanced DiskType = "pd-balanced"
+	// HyperdiskBalanced disk type
+	HyperdiskBalanced DiskType = "hyperdisk-balanced"
 )
 
 // GCPManagedMachinePoolSpec defines the desired state of GCPManagedMachinePool.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->
/kind api-change

**What this PR does / why we need it**:
There are missing disk types that are used by downstream services. This PR adds the pd-balanced and hyperdisk-balanced disk types so that others can create machines with these disk types.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add the ability to use the pd-balanced and hyperdisk-balanced for the root device type and the addition disks.
```
