### PR TITLE
For internal Load Balancer use the same API port as external LB

### DIFF
--- a/cloud/services/compute/loadbalancers/reconcile.go
+++ b/cloud/services/compute/loadbalancers/reconcile.go
@@ -601,9 +601,14 @@ func (s *Service) createOrGetRegionalForwardingRule(ctx context.Context, lbname 
 	spec.LoadBalancingScheme = string(loadBalanceTrafficInternal)
 	spec.Region = s.scope.Region()
 	spec.BackendService = backendSvc.SelfLink
-	// Ports are used instead or PortRange for passthrough Load Balancer
-	// Configure ports for k8s API and ignition
-	spec.Ports = []string{"6443", "22623"}
+	// Ports is used instead or PortRange for passthrough Load Balancer
+	// Configure ports for k8s API to match the external API which is the first port of range
+	var ports []string
+	portList := strings.Split(spec.PortRange, "-")
+	ports = append(ports, portList[0])
+	// Also configure ignition port
+	ports = append(ports, "22623")
+	spec.Ports = ports
 	spec.PortRange = ""
 	subnet, err := s.getSubnet(ctx)
 	if err != nil {

--- a/cloud/services/compute/loadbalancers/reconcile_test.go
+++ b/cloud/services/compute/loadbalancers/reconcile_test.go
@@ -117,6 +117,19 @@ func getBaseClusterScopeWithSharedVPC() (*scope.ClusterScope, error) {
 	return clusterScope, nil
 }
 
+func getBaseClusterScopeWithPortSet() (*scope.ClusterScope, error) {
+	clusterScope, err := getBaseClusterScope()
+	if err != nil {
+		return nil, err
+	}
+
+	port := int32(6443)
+	clusterScope.Cluster.Spec.ClusterNetwork = &clusterv1.ClusterNetwork{
+		APIServerPort: &port,
+	}
+	return clusterScope, nil
+}
+
 func TestService_createOrGetInstanceGroup(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -811,7 +824,7 @@ func TestService_createOrGetRegionalForwardingRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
-			clusterScope, err := getBaseClusterScope()
+			clusterScope, err := getBaseClusterScopeWithPortSet()
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Sets the API port used for the Internal Load Balancer to be the same as that used for the External Load Balancer.

**Which issue(s) this PR fixes** 
Fixes #1273

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
