### PR TITLE
fix: improve compareMasterAuthorizedNetworksConfig

### DIFF
--- a/cloud/services/container/clusters/reconcile.go
+++ b/cloud/services/container/clusters/reconcile.go
@@ -27,6 +27,7 @@ import (
 	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
@@ -473,7 +474,7 @@ func compareMasterAuthorizedNetworksConfig(a, b *containerpb.MasterAuthorizedNet
 	if (a.CidrBlocks == nil && b.CidrBlocks != nil && len(b.GetCidrBlocks()) == 0) || (b.CidrBlocks == nil && a.CidrBlocks != nil && len(a.GetCidrBlocks()) == 0) {
 		return true
 	}
-	if !cmp.Equal(a.GetCidrBlocks(), b.GetCidrBlocks()) {
+	if !cmp.Equal(a.GetCidrBlocks(), b.GetCidrBlocks(), cmpopts.IgnoreUnexported(containerpb.MasterAuthorizedNetworksConfig_CidrBlock{})) {
 		return false
 	}
 	return true


### PR DESCRIPTION
 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

This PR fixes a bug that causes a panic in the reconciler when handling unexported fields in the `compareMasterAuthorizedNetworksConfig` function. The bug occurs when creating a GKE cluster with a master authorized network.

**Special notes for your reviewer**:

The proposed solution is to ignore the unexported field using `cmpopts.IgnoreUnexported`.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix:  compareMasterAuthorizedNetworksConfig avoid panic in reconciler
```
