### PR TITLE
Support Kubernetes 1.29+

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -43,20 +43,24 @@ spec:
         name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
         kubeletExtraArgs:
           cloud-provider: gce
+          feature-gates: "DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false"
     clusterConfiguration:
       apiServer:
         timeoutForControlPlane: 20m
         extraArgs:
           cloud-provider: gce
+          feature-gates: "DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false"
       controllerManager:
         extraArgs:
           cloud-provider: gce
+          feature-gates: "DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false"
           allocate-node-cidrs: "false"
     joinConfiguration:
       nodeRegistration:
         name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
         kubeletExtraArgs:
           cloud-provider: gce
+          feature-gates: "DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false"
   version: "${KUBERNETES_VERSION}"
 ---
 kind: GCPMachineTemplate
@@ -114,3 +118,4 @@ spec:
           name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
           kubeletExtraArgs:
             cloud-provider: gce
+            feature-gates: "DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Related to #1331

**Special notes for your reviewer**:

Since we did not manage to get cloud-provider _external_ works properly and it's not (yet) removed, I open this PR to (at least) provide a working Out Of the Box user XP when trying to start a Kubernetes 1.29+ cluster with this provider.

I'm not sure that documentation is needed, since it's already documented upstream.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Disable required feature gates for Kubernetes 1.29+
```
