### PR TITLE
chore: update sig-cluster-lifecycle links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Cluster API maintainers may add "LGTM" (Looks Good To Me) or an equivalent comme
 
 ### Google Doc Viewing Permissions
 
-To gain viewing permissions to google docs in this project, please join either the [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) or [kubernetes-sig-cluster-lifecycle](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle) google group.
+To gain viewing permissions to google docs in this project, please join either the [kubernetes-dev](https://groups.google.com/a/kubernetes.io/g/dev) or [kubernetes-sig-cluster-lifecycle](https://groups.google.com/a/kubernetes.io/g/sig-cluster-lifecycle) google group.
 
 ### Issue and Pull Request Management
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If you have an active interest and you want to get involved, you have real power
 
 ### Office hours
 
-- Join the [SIG Cluster Lifecycle](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle) Google Group for access to documents and calendars.
+- Join the [SIG Cluster Lifecycle](https://groups.google.com/a/kubernetes.io/g/sig-cluster-lifecycle) Google Group for access to documents and calendars.
 - Participate in the conversations on [Kubernetes Discuss][kubernetes discuss]
 - Provider implementers office hours (CAPI)
     - Weekly on Wednesdays @ 10:00 am PT (Pacific Time) on [Zoom](https://zoom.us/j/861487554)
@@ -129,4 +129,4 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [#cluster-api-gcp]: https://sigs.k8s.io/cluster-api-provider-gcp
 [bug report]: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/new?assignees=&labels=&template=bug_report.md
 [feature request]: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/new?assignees=&labels=&template=feature_request.md
-[kubernetes discuss]: https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle
+[kubernetes discuss]: https://groups.google.com/a/kubernetes.io/g/sig-cluster-lifecycle


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The `sig-cluster-lifecycle` Google mailing list address has finally been migrated to https://groups.google.com/a/kubernetes.io/g/sig-cluster-lifecycle (you have probably received a number of meeting invites in the last few days) and at some point the old group will be blocked. This PR updates references to the old Google group.

This migration is great for CAPG because we now have an official entry in the calendar for the office hours! You can import it to your personal calendar.

**Which issue(s) this PR fixes**:
Fixes #1334 

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
