### PR TITLE
chore: add clusterclass sample template

### DIFF
--- a/templates/cluster-template-clusterclass.yaml
+++ b/templates/cluster-template-clusterclass.yaml
@@ -1,0 +1,167 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: ${CLUSTER_CLASS_NAME}
+spec:
+  controlPlane:
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: ${CLUSTER_CLASS_NAME}-control-plane
+    machineInfrastructure:
+      ref:
+        kind: GCPMachineTemplate
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        name: ${CLUSTER_CLASS_NAME}-control-plane
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: GCPClusterTemplate
+      name: ${CLUSTER_CLASS_NAME}
+  workers:
+    machineDeployments:
+      - class: default-worker
+        template:
+          bootstrap:
+            ref:
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              kind: KubeadmConfigTemplate
+              name: ${CLUSTER_CLASS_NAME}-worker-bootstraptemplate
+          infrastructure:
+            ref:
+              apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+              kind: GCPMachineTemplate
+              name: ${CLUSTER_CLASS_NAME}-worker-machinetemplate
+  variables:
+    - name: region
+      required: true
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: us-west1
+    - name: controlPlaneMachineType
+      required: true
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: n1-standard-2
+    - name: workerMachineType
+      required: true
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: n1-standard-2
+  patches:
+    - name: region
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: GCPClusterTemplate
+            matchResources:
+              infrastructureCluster: true
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/region
+              valueFrom:
+                variable: region
+    - name: controlPlaneMachineType
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: GCPMachineTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: replace
+              path: /spec/template/spec/instanceType
+              valueFrom:
+                variable: controlPlaneMachineType
+    - name: workerMachineType
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: GCPMachineTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                  - default-worker
+          jsonPatches:
+            - op: replace
+              path: /spec/template/spec/instanceType
+              valueFrom:
+                variable: workerMachineType
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPClusterTemplate
+metadata:
+  name: ${CLUSTER_CLASS_NAME}
+spec:
+  template:
+    spec:
+      project: "${GCP_PROJECT}"
+      region: "${GCP_REGION}"
+      network:
+        name: "${GCP_NETWORK_NAME}"
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: ${CLUSTER_CLASS_NAME}-control-plane
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        useExperimentalRetryJoin: true
+        initConfiguration:
+          nodeRegistration:
+            name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+            kubeletExtraArgs:
+              cloud-provider: gce
+        clusterConfiguration:
+          apiServer:
+            timeoutForControlPlane: 20m
+            extraArgs:
+              cloud-provider: gce
+          controllerManager:
+            extraArgs:
+              cloud-provider: gce
+              allocate-node-cidrs: "false"
+        joinConfiguration:
+          nodeRegistration:
+            name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+            kubeletExtraArgs:
+              cloud-provider: gce
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPMachineTemplate
+metadata:
+  name: ${CLUSTER_CLASS_NAME}-control-plane
+spec:
+  template:
+    spec:
+      instanceType: REPLACEME
+      image: "${IMAGE_ID}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPMachineTemplate
+metadata:
+  name: ${CLUSTER_CLASS_NAME}-worker-machinetemplate
+spec:
+  template:
+    spec:
+      instanceType: REPLACEME
+      image: "${IMAGE_ID}"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_CLASS_NAME}-worker-bootstraptemplate
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+          kubeletExtraArgs:
+            cloud-provider: gce

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+  labels:
+    cni: "${CLUSTER_NAME}-crs-cni"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  topology:
+    class: ${CLUSTER_CLASS_NAME}
+    version: "${KUBERNETES_VERSION}"
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    workers:
+      machineDeployments:
+        - class: "default-worker"
+          name: "md-0"
+          replicas: ${WORKER_MACHINE_COUNT}
+    variables:
+      - name: region
+        value: ${GCP_REGION}
+      - name: controlPlaneMachineType
+        value: ${GCP_CONTROL_PLANE_MACHINE_TYPE}
+      - name: workerMachineType
+        value: ${GCP_NODE_MACHINE_TYPE}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "${CLUSTER_NAME}-crs-cni"
+data: ${CNI_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: "${CLUSTER_NAME}-crs-cni"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-cni"
+  resources:
+    - name: "${CLUSTER_NAME}-crs-cni"
+      kind: ConfigMap


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

Add `ClusterClass` and `Topology` cluster templates based on existing E2E infrastructure files. These files will be referenced in the book so users can get started with cluster classes via `clusterctl generate`, similar to the existing documentation on how to create a GKE cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

A follow up to this PR will update the book and add references to these new templates.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
