### PR TITLE
fix: wrap error when nodepool update/delete fails

### DIFF
--- a/cloud/services/container/nodepools/reconcile.go
+++ b/cloud/services/container/nodepools/reconcile.go
@@ -149,7 +149,7 @@ func (s *Service) Reconcile(ctx context.Context) (ctrl.Result, error) {
 		log.Info("Node pool config update required", "request", nodePoolUpdateConfigRequest)
 		err = s.updateNodePoolConfig(ctx, nodePoolUpdateConfigRequest)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("node pool config update (either version/labels/taints/locations/image type/network tag/linux node config or all) failed: %s", err)
+			return ctrl.Result{}, fmt.Errorf("node pool config update (either version/labels/taints/locations/image type/network tag/linux node config or all) failed: %w", err)
 		}
 		log.Info("Node pool config updating in progress")
 		s.scope.GCPManagedMachinePool.Status.Ready = true


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Controller logs show an error during reconciliation if GCP-controlled automatic updates are currently running on node pools. This is because the error received from Google's API cannot be unwrapped, even if there is logic in the controller code to check for this failure. Same behavior occurs when deleting a cluster but, in this case, there's no existing logic to handle this API response.

This PR returns the error in an *unwrappable* format for update operations and adds the same error validation for deletions.

**Which issue(s) this PR fixes**:
Fixes #1363 

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix controller error on GKE node pool updates
```
