### PR TITLE
chore: support registry and tag overrides in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ CERT_MANAGER_VER := v1.14.4
 # Define Docker related variables. Releases should modify and double check these vars.
 export GCP_PROJECT ?= $(shell gcloud config get-value project)
 REGISTRY ?= gcr.io/$(GCP_PROJECT)
-STAGING_REGISTRY := gcr.io/k8s-staging-cluster-api-gcp
-PROD_REGISTRY := registry.k8s.io/cluster-api-gcp
+STAGING_REGISTRY ?= gcr.io/k8s-staging-cluster-api-gcp
+PROD_REGISTRY ?= registry.k8s.io/cluster-api-gcp
 IMAGE_NAME ?= cluster-api-gcp-controller
 STAGING_BUCKET ?= k8s-staging-cluster-api-gcp
 BUCKET ?= $(STAGING_BUCKET)
@@ -407,7 +407,7 @@ set-manifest-pull-policy:
 ## Release
 ## --------------------------------------
 
-RELEASE_TAG := $(shell git describe --abbrev=0 2>/dev/null)
+RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
 RELEASE_DIR := out
 
 $(RELEASE_DIR):


### PR DESCRIPTION

/kind cleanup

**What this PR does / why we need it**:

This change adds support for `STAGING_REGISTRY`/`PROD_REGISTRY` and `RELEASE_TAG` overrides in the `Makefile`. The current configuration does not allow setting a different value for these parameters via environment variables. This is a limitation in, for example, an air-gapped environment where a user may want to create their own release of the provider and reference an image stored in a custom registry.

It should not affect any existing use cases as the default value is unchanged.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
