### PR TITLE
Enable dual stack

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -240,6 +240,22 @@ type SubnetSpec struct {
 	// +kubebuilder:default=PRIVATE_RFC_1918
 	// +optional
 	Purpose *string `json:"purpose,omitempty"`
+
+	// StackType: The stack type for the subnet. If set to IPV4_ONLY, new VMs in
+	// the subnet are assigned IPv4 addresses only. If set to IPV4_IPV6, new VMs in
+	// the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
+	// IPV4_ONLY is used. This field can be both set at resource creation time and
+	// updated using patch.
+	//
+	// Possible values:
+	//   "IPV4_IPV6" - New VMs in this subnet can have both IPv4 and IPv6
+	// addresses.
+	//   "IPV4_ONLY" - New VMs in this subnet will only be assigned IPv4 addresses.
+	//   "IPV6_ONLY" - New VMs in this subnet will only be assigned IPv6 addresses.
+	// +kubebuilder:validation:Enum=IPV4_ONLY;IPV4_IPV6;IPV6_ONLY
+	// +kubebuilder:default=IPV4_ONLY
+	// +optional
+	StackType string `json:"stackType,omitempty"`
 }
 
 // String returns a string representation of the subnet.

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -263,6 +263,7 @@ func (s *ClusterScope) SubnetSpecs() []*compute.Subnetwork {
 			Network:               s.NetworkLink(),
 			Purpose:               ptr.Deref(subnetwork.Purpose, "PRIVATE_RFC_1918"),
 			Role:                  "ACTIVE",
+			StackType:             subnetwork.StackType,
 		})
 	}
 

--- a/cloud/scope/managedcluster.go
+++ b/cloud/scope/managedcluster.go
@@ -247,6 +247,7 @@ func (s *ManagedClusterScope) SubnetSpecs() []*compute.Subnetwork {
 			Network:               s.NetworkLink(),
 			Purpose:               ptr.Deref(subnetwork.Purpose, "PRIVATE_RFC_1918"),
 			Role:                  "ACTIVE",
+			StackType:             subnetwork.StackType,
 		})
 	}
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -248,6 +248,25 @@ spec:
                             SecondaryCidrBlocks defines secondary CIDR ranges,
                             from which secondary IP ranges of a VM may be allocated
                           type: object
+                        stackType:
+                          default: IPV4_ONLY
+                          description: |-
+                            StackType: The stack type for the subnet. If set to IPV4_ONLY, new VMs in
+                            the subnet are assigned IPv4 addresses only. If set to IPV4_IPV6, new VMs in
+                            the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
+                            IPV4_ONLY is used. This field can be both set at resource creation time and
+                            updated using patch.
+
+                            Possible values:
+                              "IPV4_IPV6" - New VMs in this subnet can have both IPv4 and IPv6
+                            addresses.
+                              "IPV4_ONLY" - New VMs in this subnet will only be assigned IPv4 addresses.
+                              "IPV6_ONLY" - New VMs in this subnet will only be assigned IPv6 addresses.
+                          enum:
+                          - IPV4_ONLY
+                          - IPV4_IPV6
+                          - IPV6_ONLY
+                          type: string
                       type: object
                     type: array
                 type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -265,6 +265,25 @@ spec:
                                     SecondaryCidrBlocks defines secondary CIDR ranges,
                                     from which secondary IP ranges of a VM may be allocated
                                   type: object
+                                stackType:
+                                  default: IPV4_ONLY
+                                  description: |-
+                                    StackType: The stack type for the subnet. If set to IPV4_ONLY, new VMs in
+                                    the subnet are assigned IPv4 addresses only. If set to IPV4_IPV6, new VMs in
+                                    the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
+                                    IPV4_ONLY is used. This field can be both set at resource creation time and
+                                    updated using patch.
+
+                                    Possible values:
+                                      "IPV4_IPV6" - New VMs in this subnet can have both IPv4 and IPv6
+                                    addresses.
+                                      "IPV4_ONLY" - New VMs in this subnet will only be assigned IPv4 addresses.
+                                      "IPV6_ONLY" - New VMs in this subnet will only be assigned IPv6 addresses.
+                                  enum:
+                                  - IPV4_ONLY
+                                  - IPV4_IPV6
+                                  - IPV6_ONLY
+                                  type: string
                               type: object
                             type: array
                         type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -244,6 +244,25 @@ spec:
                             SecondaryCidrBlocks defines secondary CIDR ranges,
                             from which secondary IP ranges of a VM may be allocated
                           type: object
+                        stackType:
+                          default: IPV4_ONLY
+                          description: |-
+                            StackType: The stack type for the subnet. If set to IPV4_ONLY, new VMs in
+                            the subnet are assigned IPv4 addresses only. If set to IPV4_IPV6, new VMs in
+                            the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
+                            IPV4_ONLY is used. This field can be both set at resource creation time and
+                            updated using patch.
+
+                            Possible values:
+                              "IPV4_IPV6" - New VMs in this subnet can have both IPv4 and IPv6
+                            addresses.
+                              "IPV4_ONLY" - New VMs in this subnet will only be assigned IPv4 addresses.
+                              "IPV6_ONLY" - New VMs in this subnet will only be assigned IPv6 addresses.
+                          enum:
+                          - IPV4_ONLY
+                          - IPV4_IPV6
+                          - IPV6_ONLY
+                          type: string
                       type: object
                     type: array
                 type: object


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind api-change
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
Adding the ability to enable dual stacks.
    
  Subnets are one of the resources that control the ability to use a dual stack (IPV4
  and IPV6). These are required to be set on resource creation, and they cannot be
  altered post creation.
    
  The user has the option to set the stack type for each subnet (IPV4_ONLY, IPV4_IPV6, or
  IPV6_ONLY). The default will be IPV4_ONLY.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CORS-3762

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Adding the ability to enable dual stacks.
    
Subnets are one of the resources that control the ability to use a dual stack (IPV4 and IPV6). These are required to be set on resource creation, and they cannot be altered post creation.
    
The user has the option to set the stack type for each subnet (IPV4_ONLY, IPV4_IPV6, or IPV6_ONLY). The default will be IPV4_ONLY.

When creating compute.Subnetwork structs, set the StackType to the same value as the StackType in the SubnetSpecs.
```
