### PR TITLE
Support SEV_SNP instance type configuration

### DIFF
--- a/api/v1beta1/gcpmachine_types.go
+++ b/api/v1beta1/gcpmachine_types.go
@@ -135,11 +135,18 @@ const (
 	ConfidentialComputePolicyEnabled ConfidentialComputePolicy = "Enabled"
 	// ConfidentialComputePolicyDisabled disables confidential compute for the GCP machine.
 	ConfidentialComputePolicyDisabled ConfidentialComputePolicy = "Disabled"
+	// ConfidentialComputePolicySEV sets AMD SEV as the VM instance's confidential computing technology of choice.
+	ConfidentialComputePolicySEV ConfidentialComputePolicy = "AMDEncrytedVirtualization"
+	// ConfidentialComputePolicySEVSNP sets AMD SEV-SNP as the VM instance's confidential computing technology of choice.
+	ConfidentialComputePolicySEVSNP ConfidentialComputePolicy = "AMDEncrytedVirtualizationNestedPaging"
 )
 
-// Confidential VM supports Compute Engine machine types in the following series:
+// Confidential VM Technology support depends on the configured machine types.
 // reference: https://cloud.google.com/compute/confidential-vm/docs/os-and-machine-type#machine-type
-var confidentialComputeSupportedMachineSeries = []string{"n2d", "c2d"}
+var (
+	confidentialMachineSeriesSupportingSev    = []string{"n2d", "c2d", "c3d"}
+	confidentialMachineSeriesSupportingSevsnp = []string{"n2d"}
+)
 
 // HostMaintenancePolicy represents the desired behavior ase of a host maintenance event.
 type HostMaintenancePolicy string
@@ -336,10 +343,14 @@ type GCPMachineSpec struct {
 	// +optional
 	OnHostMaintenance *HostMaintenancePolicy `json:"onHostMaintenance,omitempty"`
 
-	// ConfidentialCompute Defines whether the instance should have confidential compute enabled.
-	// If enabled OnHostMaintenance is required to be set to "Terminate".
+	// ConfidentialCompute Defines whether the instance should have confidential compute enabled or not, and the confidential computing technology of choice.
+	// If Disabled, the machine will not be configured to be a confidential computing instance.
+	// If Enabled, confidential computing will be configured and AMD Secure Encrypted Virtualization will be configured by default. That is subject to change over time. If using AMD Secure Encrypted Virtualization is vital, use AMDEncryptedVirtualization explicitly instead.
+	// If AMDEncryptedVirtualization, it will configure AMD Secure Encrypted Virtualization (AMD SEV) as the confidential computing technology.
+	// If AMDEncryptedVirtualizationNestedPaging, it will configure AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP) as the confidential computing technology.
+	// If enabled (any value other than Disabled) OnHostMaintenance is required to be set to "Terminate".
 	// If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.
-	// +kubebuilder:validation:Enum=Enabled;Disabled
+	// +kubebuilder:validation:Enum=Enabled;Disabled;AMDEncrytedVirtualization;AMDEncrytedVirtualizationNestedPaging
 	// +optional
 	ConfidentialCompute *ConfidentialComputePolicy `json:"confidentialCompute,omitempty"`
 

--- a/api/v1beta1/gcpmachine_webhook.go
+++ b/api/v1beta1/gcpmachine_webhook.go
@@ -109,14 +109,23 @@ func (m *GCPMachine) Default() {
 }
 
 func validateConfidentialCompute(spec GCPMachineSpec) error {
-	if spec.ConfidentialCompute != nil && *spec.ConfidentialCompute == ConfidentialComputePolicyEnabled {
+	if spec.ConfidentialCompute != nil && *spec.ConfidentialCompute != ConfidentialComputePolicyDisabled {
 		if spec.OnHostMaintenance == nil || *spec.OnHostMaintenance == HostMaintenancePolicyMigrate {
 			return fmt.Errorf("ConfidentialCompute require OnHostMaintenance to be set to %s, the current value is: %s", HostMaintenancePolicyTerminate, HostMaintenancePolicyMigrate)
 		}
 
 		machineSeries := strings.Split(spec.InstanceType, "-")[0]
-		if !slices.Contains(confidentialComputeSupportedMachineSeries, machineSeries) {
-			return fmt.Errorf("ConfidentialCompute require instance type in the following series: %s", confidentialComputeSupportedMachineSeries)
+		switch *spec.ConfidentialCompute {
+		case ConfidentialComputePolicyEnabled, ConfidentialComputePolicySEV:
+			if !slices.Contains(confidentialMachineSeriesSupportingSev, machineSeries) {
+				return fmt.Errorf("ConfidentialCompute %s requires any of the following machine series: %s. %s was found instead", *spec.ConfidentialCompute, strings.Join(confidentialMachineSeriesSupportingSev, ", "), spec.InstanceType)
+			}
+		case ConfidentialComputePolicySEVSNP:
+			if !slices.Contains(confidentialMachineSeriesSupportingSevsnp, machineSeries) {
+				return fmt.Errorf("ConfidentialCompute %s requires any of the following machine series: %s. %s was found instead", *spec.ConfidentialCompute, strings.Join(confidentialMachineSeriesSupportingSevsnp, ", "), spec.InstanceType)
+			}
+		default:
+			return fmt.Errorf("invalid ConfidentialCompute %s", *spec.ConfidentialCompute)
 		}
 	}
 	return nil

--- a/api/v1beta1/gcpmachine_webhook_test.go
+++ b/api/v1beta1/gcpmachine_webhook_test.go
@@ -25,6 +25,9 @@ import (
 func TestGCPMachine_ValidateCreate(t *testing.T) {
 	g := NewWithT(t)
 	confidentialComputeEnabled := ConfidentialComputePolicyEnabled
+	confidentialComputeSEV := ConfidentialComputePolicySEV
+	confidentialComputeSEVSNP := ConfidentialComputePolicySEVSNP
+	confidentialComputeFooBar := ConfidentialComputePolicy("foobar")
 	onHostMaintenanceTerminate := HostMaintenancePolicyTerminate
 	onHostMaintenanceMigrate := HostMaintenancePolicyMigrate
 	tests := []struct {
@@ -80,6 +83,83 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 				Spec: GCPMachineSpec{
 					InstanceType:        "e2-standard-4",
 					ConfidentialCompute: &confidentialComputeEnabled,
+					OnHostMaintenance:   &onHostMaintenanceTerminate,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "GCPMachine with ConfidentialCompute AMDEncryptedVirtualization and supported instance type - valid",
+			GCPMachine: &GCPMachine{
+				Spec: GCPMachineSpec{
+					InstanceType:        "c3d-standard-4",
+					ConfidentialCompute: &confidentialComputeSEV,
+					OnHostMaintenance:   &onHostMaintenanceTerminate,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "GCPMachine with ConfidentialCompute AMDEncryptedVirtualization and unsupported instance type - invalid",
+			GCPMachine: &GCPMachine{
+				Spec: GCPMachineSpec{
+					InstanceType:        "e2-standard-4",
+					ConfidentialCompute: &confidentialComputeSEV,
+					OnHostMaintenance:   &onHostMaintenanceTerminate,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "GCPMachine with ConfidentialCompute AMDEncryptedVirtualization and OnHostMaintenance Migrate - invalid",
+			GCPMachine: &GCPMachine{
+				Spec: GCPMachineSpec{
+					InstanceType:        "c2d-standard-4",
+					ConfidentialCompute: &confidentialComputeSEV,
+					OnHostMaintenance:   &onHostMaintenanceMigrate,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "GCPMachine with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and supported instance type - valid",
+			GCPMachine: &GCPMachine{
+				Spec: GCPMachineSpec{
+					InstanceType:        "n2d-standard-4",
+					ConfidentialCompute: &confidentialComputeSEVSNP,
+					OnHostMaintenance:   &onHostMaintenanceTerminate,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "GCPMachine with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and unsupported instance type - invalid",
+			GCPMachine: &GCPMachine{
+				Spec: GCPMachineSpec{
+					InstanceType:        "e2-standard-4",
+					ConfidentialCompute: &confidentialComputeSEVSNP,
+					OnHostMaintenance:   &onHostMaintenanceTerminate,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "GCPMachine with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and OnHostMaintenance Migrate - invalid",
+			GCPMachine: &GCPMachine{
+				Spec: GCPMachineSpec{
+					InstanceType:        "n2d-standard-4",
+					ConfidentialCompute: &confidentialComputeSEVSNP,
+					OnHostMaintenance:   &onHostMaintenanceMigrate,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "GCPMachine with ConfidentialCompute foobar - invalid",
+			GCPMachine: &GCPMachine{
+				Spec: GCPMachineSpec{
+					InstanceType:        "n2d-standard-4",
+					ConfidentialCompute: &confidentialComputeFooBar,
 					OnHostMaintenance:   &onHostMaintenanceTerminate,
 				},
 			},

--- a/api/v1beta1/gcpmachinetemplate_webhook_test.go
+++ b/api/v1beta1/gcpmachinetemplate_webhook_test.go
@@ -25,6 +25,8 @@ import (
 func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 	g := NewWithT(t)
 	confidentialComputeEnabled := ConfidentialComputePolicyEnabled
+	confidentialComputeSEV := ConfidentialComputePolicySEV
+	confidentialComputeSEVSNP := ConfidentialComputePolicySEVSNP
 	onHostMaintenanceTerminate := HostMaintenancePolicyTerminate
 	onHostMaintenanceMigrate := HostMaintenancePolicyMigrate
 	tests := []struct {
@@ -99,6 +101,96 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 							InstanceType:        "e2-standard-4",
 							ConfidentialCompute: &confidentialComputeEnabled,
 							OnHostMaintenance:   &onHostMaintenanceTerminate,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "GCPMachineTemplate with ConfidentialCompute AMDEncryptedVirtualization and unsupported instance type - invalid",
+			template: &GCPMachineTemplate{
+				Spec: GCPMachineTemplateSpec{
+					Template: GCPMachineTemplateResource{
+						Spec: GCPMachineSpec{
+							InstanceType:        "e2-standard-4",
+							ConfidentialCompute: &confidentialComputeSEV,
+							OnHostMaintenance:   &onHostMaintenanceTerminate,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "GCPMachineTemplate with ConfidentialCompute AMDEncryptedVirtualization and supported instance type - valid",
+			template: &GCPMachineTemplate{
+				Spec: GCPMachineTemplateSpec{
+					Template: GCPMachineTemplateResource{
+						Spec: GCPMachineSpec{
+							InstanceType:        "c2d-standard-4",
+							ConfidentialCompute: &confidentialComputeSEV,
+							OnHostMaintenance:   &onHostMaintenanceTerminate,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "GCPMachineTemplate with ConfidentialCompute AMDEncryptedVirtualization and OnHostMaintenance Migrate - invalid",
+			template: &GCPMachineTemplate{
+				Spec: GCPMachineTemplateSpec{
+					Template: GCPMachineTemplateResource{
+						Spec: GCPMachineSpec{
+							InstanceType:        "c2d-standard-4",
+							ConfidentialCompute: &confidentialComputeSEV,
+							OnHostMaintenance:   &onHostMaintenanceMigrate,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "GCPMachineTemplate with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and unsupported instance type - invalid",
+			template: &GCPMachineTemplate{
+				Spec: GCPMachineTemplateSpec{
+					Template: GCPMachineTemplateResource{
+						Spec: GCPMachineSpec{
+							InstanceType:        "c2d-standard-4",
+							ConfidentialCompute: &confidentialComputeSEVSNP,
+							OnHostMaintenance:   &onHostMaintenanceTerminate,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "GCPMachineTemplate with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and supported instance type - valid",
+			template: &GCPMachineTemplate{
+				Spec: GCPMachineTemplateSpec{
+					Template: GCPMachineTemplateResource{
+						Spec: GCPMachineSpec{
+							InstanceType:        "n2d-standard-4",
+							ConfidentialCompute: &confidentialComputeSEVSNP,
+							OnHostMaintenance:   &onHostMaintenanceTerminate,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "GCPMachineTemplate with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and OnHostMaintenance Migrate - invalid",
+			template: &GCPMachineTemplate{
+				Spec: GCPMachineTemplateSpec{
+					Template: GCPMachineTemplateResource{
+						Spec: GCPMachineSpec{
+							InstanceType:        "c2d-standard-4",
+							ConfidentialCompute: &confidentialComputeSEVSNP,
+							OnHostMaintenance:   &onHostMaintenanceMigrate,
 						},
 					},
 				},

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -446,9 +446,16 @@ func (m *MachineScope) InstanceSpec(log logr.Logger) *compute.Instance {
 		instance.Scheduling.OnHostMaintenance = strings.ToUpper(string(*m.GCPMachine.Spec.OnHostMaintenance))
 	}
 	if m.GCPMachine.Spec.ConfidentialCompute != nil {
-		enabled := *m.GCPMachine.Spec.ConfidentialCompute == infrav1.ConfidentialComputePolicyEnabled
+		enabled := *m.GCPMachine.Spec.ConfidentialCompute != infrav1.ConfidentialComputePolicyDisabled
 		instance.ConfidentialInstanceConfig = &compute.ConfidentialInstanceConfig{
 			EnableConfidentialCompute: enabled,
+		}
+		switch *m.GCPMachine.Spec.ConfidentialCompute {
+		case infrav1.ConfidentialComputePolicySEV:
+			instance.ConfidentialInstanceConfig.ConfidentialInstanceType = "SEV"
+		case infrav1.ConfidentialComputePolicySEVSNP:
+			instance.ConfidentialInstanceConfig.ConfidentialInstanceType = "SEV_SNP"
+		default:
 		}
 	}
 

--- a/cloud/services/compute/instances/reconcile_test.go
+++ b/cloud/services/compute/instances/reconcile_test.go
@@ -496,6 +496,158 @@ func TestService_createOrGetInstance(t *testing.T) {
 			},
 		},
 		{
+			name: "instance does not exist (should create instance) with confidential compute AMDEncryptedVirtualization",
+			scope: func() Scope {
+				machineScope.GCPMachine = getFakeGCPMachine()
+				hostMaintenancePolicyTerminate := infrav1.HostMaintenancePolicyTerminate
+				machineScope.GCPMachine.Spec.OnHostMaintenance = &hostMaintenancePolicyTerminate
+				confidentialComputeSEV := infrav1.ConfidentialComputePolicySEV
+				machineScope.GCPMachine.Spec.ConfidentialCompute = &confidentialComputeSEV
+				return machineScope
+			},
+			mockInstance: &cloud.MockInstances{
+				ProjectRouter: &cloud.SingleProjectRouter{ID: "proj-id"},
+				Objects:       map[meta.Key]*cloud.MockInstancesObj{},
+			},
+			want: &compute.Instance{
+				Name:         "my-machine",
+				CanIpForward: true,
+				Disks: []*compute.AttachedDisk{
+					{
+						AutoDelete: true,
+						Boot:       true,
+						InitializeParams: &compute.AttachedDiskInitializeParams{
+							DiskType:            "zones/us-central1-c/diskTypes/pd-standard",
+							SourceImage:         "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
+							ResourceManagerTags: map[string]string{},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+				Labels: map[string]string{
+					"capg-role":               "node",
+					"capg-cluster-my-cluster": "owned",
+					"foo":                     "bar",
+				},
+				MachineType: "zones/us-central1-c/machineTypes",
+				Metadata: &compute.Metadata{
+					Items: []*compute.MetadataItems{
+						{
+							Key:   "user-data",
+							Value: ptr.To[string]("Zm9vCg=="),
+						},
+					},
+				},
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{
+						Network: "projects/my-proj/global/networks/default",
+					},
+				},
+				Params: &compute.InstanceParams{
+					ResourceManagerTags: map[string]string{},
+				},
+				SelfLink: "https://www.googleapis.com/compute/v1/projects/proj-id/zones/us-central1-c/instances/my-machine",
+				ConfidentialInstanceConfig: &compute.ConfidentialInstanceConfig{
+					EnableConfidentialCompute: true,
+					ConfidentialInstanceType:  "SEV",
+				},
+				Scheduling: &compute.Scheduling{
+					OnHostMaintenance: strings.ToUpper(string(infrav1.HostMaintenancePolicyTerminate)),
+				},
+				ServiceAccounts: []*compute.ServiceAccount{
+					{
+						Email:  "default",
+						Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
+					},
+				},
+				Tags: &compute.Tags{
+					Items: []string{
+						"my-cluster-node",
+						"my-cluster",
+					},
+				},
+				Zone: "us-central1-c",
+			},
+		},
+		{
+			name: "instance does not exist (should create instance) with confidential compute AMDEncryptedVirtualizationNestedPaging",
+			scope: func() Scope {
+				machineScope.GCPMachine = getFakeGCPMachine()
+				hostMaintenancePolicyTerminate := infrav1.HostMaintenancePolicyTerminate
+				machineScope.GCPMachine.Spec.OnHostMaintenance = &hostMaintenancePolicyTerminate
+				confidentialComputeSEVSNP := infrav1.ConfidentialComputePolicySEVSNP
+				machineScope.GCPMachine.Spec.ConfidentialCompute = &confidentialComputeSEVSNP
+				return machineScope
+			},
+			mockInstance: &cloud.MockInstances{
+				ProjectRouter: &cloud.SingleProjectRouter{ID: "proj-id"},
+				Objects:       map[meta.Key]*cloud.MockInstancesObj{},
+			},
+			want: &compute.Instance{
+				Name:         "my-machine",
+				CanIpForward: true,
+				Disks: []*compute.AttachedDisk{
+					{
+						AutoDelete: true,
+						Boot:       true,
+						InitializeParams: &compute.AttachedDiskInitializeParams{
+							DiskType:            "zones/us-central1-c/diskTypes/pd-standard",
+							SourceImage:         "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
+							ResourceManagerTags: map[string]string{},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+				Labels: map[string]string{
+					"capg-role":               "node",
+					"capg-cluster-my-cluster": "owned",
+					"foo":                     "bar",
+				},
+				MachineType: "zones/us-central1-c/machineTypes",
+				Metadata: &compute.Metadata{
+					Items: []*compute.MetadataItems{
+						{
+							Key:   "user-data",
+							Value: ptr.To[string]("Zm9vCg=="),
+						},
+					},
+				},
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{
+						Network: "projects/my-proj/global/networks/default",
+					},
+				},
+				Params: &compute.InstanceParams{
+					ResourceManagerTags: map[string]string{},
+				},
+				SelfLink: "https://www.googleapis.com/compute/v1/projects/proj-id/zones/us-central1-c/instances/my-machine",
+				ConfidentialInstanceConfig: &compute.ConfidentialInstanceConfig{
+					EnableConfidentialCompute: true,
+					ConfidentialInstanceType:  "SEV_SNP",
+				},
+				Scheduling: &compute.Scheduling{
+					OnHostMaintenance: strings.ToUpper(string(infrav1.HostMaintenancePolicyTerminate)),
+				},
+				ServiceAccounts: []*compute.ServiceAccount{
+					{
+						Email:  "default",
+						Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
+					},
+				},
+				Tags: &compute.Tags{
+					Items: []string{
+						"my-cluster-node",
+						"my-cluster",
+					},
+				},
+				Zone: "us-central1-c",
+			},
+		},
+		{
 			name: "instance does not exist (should create instance) with MIGRATE OnHostMaintenance",
 			scope: func() Scope {
 				machineScope.GCPMachine = getFakeGCPMachine()

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
@@ -193,12 +193,18 @@ spec:
                 type: array
               confidentialCompute:
                 description: |-
-                  ConfidentialCompute Defines whether the instance should have confidential compute enabled.
-                  If enabled OnHostMaintenance is required to be set to "Terminate".
+                  ConfidentialCompute Defines whether the instance should have confidential compute enabled or not, and the confidential computing technology of choice.
+                  If Disabled, the machine will not be configured to be a confidential computing instance.
+                  If Enabled, confidential computing will be configured and AMD Secure Encrypted Virtualization will be configured by default. That is subject to change over time. If using AMD Secure Encrypted Virtualization is vital, use AMDEncryptedVirtualization explicitly instead.
+                  If AMDEncryptedVirtualization, it will configure AMD Secure Encrypted Virtualization (AMD SEV) as the confidential computing technology.
+                  If AMDEncryptedVirtualizationNestedPaging, it will configure AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP) as the confidential computing technology.
+                  If enabled (any value other than Disabled) OnHostMaintenance is required to be set to "Terminate".
                   If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.
                 enum:
                 - Enabled
                 - Disabled
+                - AMDEncrytedVirtualization
+                - AMDEncrytedVirtualizationNestedPaging
                 type: string
               image:
                 description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
@@ -208,12 +208,18 @@ spec:
                         type: array
                       confidentialCompute:
                         description: |-
-                          ConfidentialCompute Defines whether the instance should have confidential compute enabled.
-                          If enabled OnHostMaintenance is required to be set to "Terminate".
+                          ConfidentialCompute Defines whether the instance should have confidential compute enabled or not, and the confidential computing technology of choice.
+                          If Disabled, the machine will not be configured to be a confidential computing instance.
+                          If Enabled, confidential computing will be configured and AMD Secure Encrypted Virtualization will be configured by default. That is subject to change over time. If using AMD Secure Encrypted Virtualization is vital, use AMDEncryptedVirtualization explicitly instead.
+                          If AMDEncryptedVirtualization, it will configure AMD Secure Encrypted Virtualization (AMD SEV) as the confidential computing technology.
+                          If AMDEncryptedVirtualizationNestedPaging, it will configure AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP) as the confidential computing technology.
+                          If enabled (any value other than Disabled) OnHostMaintenance is required to be set to "Terminate".
                           If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.
                         enum:
                         - Enabled
                         - Disabled
+                        - AMDEncrytedVirtualization
+                        - AMDEncrytedVirtualizationNestedPaging
                         type: string
                       image:
                         description: |-


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Only SEV machines could be configured by using the former
confidentialCompute Enabled/Disabled. GCP allows now to also configure
the confidential instance type as well by using the appropriate
parameter, see [0].

This commit introduces confidentialInstanceType, which lets users choose
between sev or sev-snp as their confidential computing technology of
choice.

Meanwhile, add c3d as a machine that supports AMD SEV.

[0] https://cloud.google.com/confidential-computing/confidential-vm/docs/create-a-confidential-vm-instance#rest

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/1402

**Special notes for your reviewer**:
`confidentialInstanceType` overrides `confidentialCompute`. This was due to these reasons:
- Backwards compatibility.
- Imitating the gcp compute API behavior.
 
_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add confidentialInstanceType to the API
```