### PR TITLE
Support Intel TDX confidential computing machine configuration

### DIFF
--- a/api/v1beta1/gcpmachine_types.go
+++ b/api/v1beta1/gcpmachine_types.go
@@ -138,6 +138,8 @@ const (
 	ConfidentialComputePolicySEV ConfidentialComputePolicy = "AMDEncrytedVirtualization"
 	// ConfidentialComputePolicySEVSNP sets AMD SEV-SNP as the VM instance's confidential computing technology of choice.
 	ConfidentialComputePolicySEVSNP ConfidentialComputePolicy = "AMDEncrytedVirtualizationNestedPaging"
+	// ConfidentialComputePolicyTDX sets Intel TDX as the VM instance's confidential computing technology of choice.
+	ConfidentialComputePolicyTDX ConfidentialComputePolicy = "IntelTrustedDomainExtensions"
 )
 
 // Confidential VM Technology support depends on the configured machine types.
@@ -145,6 +147,7 @@ const (
 var (
 	confidentialMachineSeriesSupportingSev    = []string{"n2d", "c2d", "c3d"}
 	confidentialMachineSeriesSupportingSevsnp = []string{"n2d"}
+	confidentialMachineSeriesSupportingTdx    = []string{"c3"}
 )
 
 // HostMaintenancePolicy represents the desired behavior ase of a host maintenance event.
@@ -347,9 +350,10 @@ type GCPMachineSpec struct {
 	// If Enabled, confidential computing will be configured and AMD Secure Encrypted Virtualization will be configured by default. That is subject to change over time. If using AMD Secure Encrypted Virtualization is vital, use AMDEncryptedVirtualization explicitly instead.
 	// If AMDEncryptedVirtualization, it will configure AMD Secure Encrypted Virtualization (AMD SEV) as the confidential computing technology.
 	// If AMDEncryptedVirtualizationNestedPaging, it will configure AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP) as the confidential computing technology.
+	// If IntelTrustedDomainExtensions, it will configure Intel TDX as the confidential computing technology.
 	// If enabled (any value other than Disabled) OnHostMaintenance is required to be set to "Terminate".
 	// If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.
-	// +kubebuilder:validation:Enum=Enabled;Disabled;AMDEncrytedVirtualization;AMDEncrytedVirtualizationNestedPaging
+	// +kubebuilder:validation:Enum=Enabled;Disabled;AMDEncrytedVirtualization;AMDEncrytedVirtualizationNestedPaging;IntelTrustedDomainExtensions
 	// +optional
 	ConfidentialCompute *ConfidentialComputePolicy `json:"confidentialCompute,omitempty"`
 

--- a/api/v1beta1/gcpmachine_webhook.go
+++ b/api/v1beta1/gcpmachine_webhook.go
@@ -124,6 +124,10 @@ func validateConfidentialCompute(spec GCPMachineSpec) error {
 			if !slices.Contains(confidentialMachineSeriesSupportingSevsnp, machineSeries) {
 				return fmt.Errorf("ConfidentialCompute %s requires any of the following machine series: %s. %s was found instead", *spec.ConfidentialCompute, strings.Join(confidentialMachineSeriesSupportingSevsnp, ", "), spec.InstanceType)
 			}
+		case ConfidentialComputePolicyTDX:
+			if !slices.Contains(confidentialMachineSeriesSupportingTdx, machineSeries) {
+				return fmt.Errorf("ConfidentialCompute %s requires any of the following machine series: %s. %s was found instead", *spec.ConfidentialCompute, strings.Join(confidentialMachineSeriesSupportingTdx, ", "), spec.InstanceType)
+			}
 		default:
 			return fmt.Errorf("invalid ConfidentialCompute %s", *spec.ConfidentialCompute)
 		}

--- a/api/v1beta1/gcpmachine_webhook_test.go
+++ b/api/v1beta1/gcpmachine_webhook_test.go
@@ -27,6 +27,7 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 	confidentialComputeEnabled := ConfidentialComputePolicyEnabled
 	confidentialComputeSEV := ConfidentialComputePolicySEV
 	confidentialComputeSEVSNP := ConfidentialComputePolicySEVSNP
+	confidentialComputeTDX := ConfidentialComputePolicyTDX
 	confidentialComputeFooBar := ConfidentialComputePolicy("foobar")
 	onHostMaintenanceTerminate := HostMaintenancePolicyTerminate
 	onHostMaintenanceMigrate := HostMaintenancePolicyMigrate
@@ -160,6 +161,28 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 				Spec: GCPMachineSpec{
 					InstanceType:        "n2d-standard-4",
 					ConfidentialCompute: &confidentialComputeFooBar,
+					OnHostMaintenance:   &onHostMaintenanceTerminate,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "GCPMachine with explicit TDX ConfidentialInstanceType and supported machine type - valid",
+			GCPMachine: &GCPMachine{
+				Spec: GCPMachineSpec{
+					InstanceType:        "c3-standard-4",
+					ConfidentialCompute: &confidentialComputeTDX,
+					OnHostMaintenance:   &onHostMaintenanceTerminate,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "GCPMachine with explicit TDX ConfidentialInstanceType and unsupported machine type - invalid",
+			GCPMachine: &GCPMachine{
+				Spec: GCPMachineSpec{
+					InstanceType:        "c3d-standard-4",
+					ConfidentialCompute: &confidentialComputeTDX,
 					OnHostMaintenance:   &onHostMaintenanceTerminate,
 				},
 			},

--- a/api/v1beta1/gcpmachinetemplate_webhook_test.go
+++ b/api/v1beta1/gcpmachinetemplate_webhook_test.go
@@ -27,6 +27,7 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 	confidentialComputeEnabled := ConfidentialComputePolicyEnabled
 	confidentialComputeSEV := ConfidentialComputePolicySEV
 	confidentialComputeSEVSNP := ConfidentialComputePolicySEVSNP
+	confidentialComputeTDX := ConfidentialComputePolicyTDX
 	onHostMaintenanceTerminate := HostMaintenancePolicyTerminate
 	onHostMaintenanceMigrate := HostMaintenancePolicyMigrate
 	tests := []struct {
@@ -191,6 +192,36 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 							InstanceType:        "c2d-standard-4",
 							ConfidentialCompute: &confidentialComputeSEVSNP,
 							OnHostMaintenance:   &onHostMaintenanceMigrate,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "GCPMachine with explicit TDX ConfidentialInstanceType and supported machine type - valid",
+			template: &GCPMachineTemplate{
+				Spec: GCPMachineTemplateSpec{
+					Template: GCPMachineTemplateResource{
+						Spec: GCPMachineSpec{
+							InstanceType:        "c3-standard-4",
+							ConfidentialCompute: &confidentialComputeTDX,
+							OnHostMaintenance:   &onHostMaintenanceTerminate,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "GCPMachine with explicit TDX ConfidentialInstanceType and unsupported machine type - invalid",
+			template: &GCPMachineTemplate{
+				Spec: GCPMachineTemplateSpec{
+					Template: GCPMachineTemplateResource{
+						Spec: GCPMachineSpec{
+							InstanceType:        "c3d-standard-4",
+							ConfidentialCompute: &confidentialComputeTDX,
+							OnHostMaintenance:   &onHostMaintenanceTerminate,
 						},
 					},
 				},

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -454,6 +454,8 @@ func (m *MachineScope) InstanceSpec(log logr.Logger) *compute.Instance {
 			instance.ConfidentialInstanceConfig.ConfidentialInstanceType = "SEV"
 		case infrav1.ConfidentialComputePolicySEVSNP:
 			instance.ConfidentialInstanceConfig.ConfidentialInstanceType = "SEV_SNP"
+		case infrav1.ConfidentialComputePolicyTDX:
+			instance.ConfidentialInstanceConfig.ConfidentialInstanceType = "TDX"
 		default:
 		}
 	}

--- a/cloud/services/compute/instances/reconcile_test.go
+++ b/cloud/services/compute/instances/reconcile_test.go
@@ -648,6 +648,82 @@ func TestService_createOrGetInstance(t *testing.T) {
 			},
 		},
 		{
+			name: "instance does not exist (should create instance) with confidential compute enabled and TDX confidential instance type specified",
+			scope: func() Scope {
+				machineScope.GCPMachine = getFakeGCPMachine()
+				hostMaintenancePolicyTerminate := infrav1.HostMaintenancePolicyTerminate
+				machineScope.GCPMachine.Spec.OnHostMaintenance = &hostMaintenancePolicyTerminate
+				confidentialInstTypeTDX := infrav1.ConfidentialComputePolicyTDX
+				machineScope.GCPMachine.Spec.ConfidentialCompute = &confidentialInstTypeTDX
+				return machineScope
+			},
+			mockInstance: &cloud.MockInstances{
+				ProjectRouter: &cloud.SingleProjectRouter{ID: "proj-id"},
+				Objects:       map[meta.Key]*cloud.MockInstancesObj{},
+			},
+			want: &compute.Instance{
+				Name:         "my-machine",
+				CanIpForward: true,
+				Disks: []*compute.AttachedDisk{
+					{
+						AutoDelete: true,
+						Boot:       true,
+						InitializeParams: &compute.AttachedDiskInitializeParams{
+							DiskType:            "zones/us-central1-c/diskTypes/pd-standard",
+							SourceImage:         "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
+							ResourceManagerTags: map[string]string{},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+				Labels: map[string]string{
+					"capg-role":               "node",
+					"capg-cluster-my-cluster": "owned",
+					"foo":                     "bar",
+				},
+				MachineType: "zones/us-central1-c/machineTypes",
+				Metadata: &compute.Metadata{
+					Items: []*compute.MetadataItems{
+						{
+							Key:   "user-data",
+							Value: ptr.To[string]("Zm9vCg=="),
+						},
+					},
+				},
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{
+						Network: "projects/my-proj/global/networks/default",
+					},
+				},
+				Params: &compute.InstanceParams{
+					ResourceManagerTags: map[string]string{},
+				},
+				SelfLink: "https://www.googleapis.com/compute/v1/projects/proj-id/zones/us-central1-c/instances/my-machine",
+				ConfidentialInstanceConfig: &compute.ConfidentialInstanceConfig{
+					EnableConfidentialCompute: true,
+					ConfidentialInstanceType:  "TDX",
+				},
+				Scheduling: &compute.Scheduling{
+					OnHostMaintenance: strings.ToUpper(string(infrav1.HostMaintenancePolicyTerminate)),
+				},
+				ServiceAccounts: []*compute.ServiceAccount{
+					{
+						Email:  "default",
+						Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
+					},
+				},
+				Tags: &compute.Tags{
+					Items: []string{
+						"my-cluster-node",
+						"my-cluster",
+					},
+				},
+				Zone: "us-central1-c",
+			},
+		},
+		{
 			name: "instance does not exist (should create instance) with MIGRATE OnHostMaintenance",
 			scope: func() Scope {
 				machineScope.GCPMachine = getFakeGCPMachine()

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
@@ -198,6 +198,7 @@ spec:
                   If Enabled, confidential computing will be configured and AMD Secure Encrypted Virtualization will be configured by default. That is subject to change over time. If using AMD Secure Encrypted Virtualization is vital, use AMDEncryptedVirtualization explicitly instead.
                   If AMDEncryptedVirtualization, it will configure AMD Secure Encrypted Virtualization (AMD SEV) as the confidential computing technology.
                   If AMDEncryptedVirtualizationNestedPaging, it will configure AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP) as the confidential computing technology.
+                  If IntelTrustedDomainExtensions, it will configure Intel TDX as the confidential computing technology.
                   If enabled (any value other than Disabled) OnHostMaintenance is required to be set to "Terminate".
                   If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.
                 enum:
@@ -205,6 +206,7 @@ spec:
                 - Disabled
                 - AMDEncrytedVirtualization
                 - AMDEncrytedVirtualizationNestedPaging
+                - IntelTrustedDomainExtensions
                 type: string
               image:
                 description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
@@ -213,6 +213,7 @@ spec:
                           If Enabled, confidential computing will be configured and AMD Secure Encrypted Virtualization will be configured by default. That is subject to change over time. If using AMD Secure Encrypted Virtualization is vital, use AMDEncryptedVirtualization explicitly instead.
                           If AMDEncryptedVirtualization, it will configure AMD Secure Encrypted Virtualization (AMD SEV) as the confidential computing technology.
                           If AMDEncryptedVirtualizationNestedPaging, it will configure AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP) as the confidential computing technology.
+                          If IntelTrustedDomainExtensions, it will configure Intel TDX as the confidential computing technology.
                           If enabled (any value other than Disabled) OnHostMaintenance is required to be set to "Terminate".
                           If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.
                         enum:
@@ -220,6 +221,7 @@ spec:
                         - Disabled
                         - AMDEncrytedVirtualization
                         - AMDEncrytedVirtualizationNestedPaging
+                        - IntelTrustedDomainExtensions
                         type: string
                       image:
                         description: |-


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

In #1410 `confidentialCompute` was extended from `Enabled`/`Disabled` to also supporting explicit AMD SEV and AMD SEV-SNP instance configuration.

TDX is supported in c3 machine types in google cloud [0].

This patch allows users to configure those machines as confidential instances by declaring `confidentialCompute: IntelTrustedDomainExtensions`.

[0] https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#all-confidential-vm-instances

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1425

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support Intel TDX confidential computing instance configuration.
```
