### PR TITLE
confidentialCompute: Fix "Encryted" typo

### DIFF
--- a/api/v1beta1/gcpmachine_types.go
+++ b/api/v1beta1/gcpmachine_types.go
@@ -135,9 +135,9 @@ const (
 	// ConfidentialComputePolicyDisabled disables confidential compute for the GCP machine.
 	ConfidentialComputePolicyDisabled ConfidentialComputePolicy = "Disabled"
 	// ConfidentialComputePolicySEV sets AMD SEV as the VM instance's confidential computing technology of choice.
-	ConfidentialComputePolicySEV ConfidentialComputePolicy = "AMDEncrytedVirtualization"
+	ConfidentialComputePolicySEV ConfidentialComputePolicy = "AMDEncryptedVirtualization"
 	// ConfidentialComputePolicySEVSNP sets AMD SEV-SNP as the VM instance's confidential computing technology of choice.
-	ConfidentialComputePolicySEVSNP ConfidentialComputePolicy = "AMDEncrytedVirtualizationNestedPaging"
+	ConfidentialComputePolicySEVSNP ConfidentialComputePolicy = "AMDEncryptedVirtualizationNestedPaging"
 	// ConfidentialComputePolicyTDX sets Intel TDX as the VM instance's confidential computing technology of choice.
 	ConfidentialComputePolicyTDX ConfidentialComputePolicy = "IntelTrustedDomainExtensions"
 )
@@ -353,7 +353,7 @@ type GCPMachineSpec struct {
 	// If IntelTrustedDomainExtensions, it will configure Intel TDX as the confidential computing technology.
 	// If enabled (any value other than Disabled) OnHostMaintenance is required to be set to "Terminate".
 	// If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.
-	// +kubebuilder:validation:Enum=Enabled;Disabled;AMDEncrytedVirtualization;AMDEncrytedVirtualizationNestedPaging;IntelTrustedDomainExtensions
+	// +kubebuilder:validation:Enum=Enabled;Disabled;AMDEncryptedVirtualization;AMDEncryptedVirtualizationNestedPaging;IntelTrustedDomainExtensions
 	// +optional
 	ConfidentialCompute *ConfidentialComputePolicy `json:"confidentialCompute,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
@@ -204,8 +204,8 @@ spec:
                 enum:
                 - Enabled
                 - Disabled
-                - AMDEncrytedVirtualization
-                - AMDEncrytedVirtualizationNestedPaging
+                - AMDEncryptedVirtualization
+                - AMDEncryptedVirtualizationNestedPaging
                 - IntelTrustedDomainExtensions
                 type: string
               image:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
@@ -219,8 +219,8 @@ spec:
                         enum:
                         - Enabled
                         - Disabled
-                        - AMDEncrytedVirtualization
-                        - AMDEncrytedVirtualizationNestedPaging
+                        - AMDEncryptedVirtualization
+                        - AMDEncryptedVirtualizationNestedPaging
                         - IntelTrustedDomainExtensions
                         type: string
                       image:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
I introduced a typo in the AMD SEV/SEV-SNP confidentialCompute values. It stated "Encryted" instead of "Encrypted".
This patch fixes the typos.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Typo introduced in #1410 @damdo, @JoelSpeed

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
