### PR TITLE
fix: panic on gke cluster deletion

### DIFF
--- a/exp/controllers/gcpmanagedcontrolplane_controller.go
+++ b/exp/controllers/gcpmanagedcontrolplane_controller.go
@@ -215,7 +215,8 @@ func (r *GCPManagedControlPlaneReconciler) reconcileDelete(ctx context.Context, 
 		}
 	}
 
-	if conditions.Get(managedControlPlaneScope.GCPManagedControlPlane, infrav1exp.GKEControlPlaneDeletingCondition).Reason == infrav1exp.GKEControlPlaneDeletedReason {
+	if managedControlPlaneScope.GCPManagedControlPlane != nil &&
+		conditions.Get(managedControlPlaneScope.GCPManagedControlPlane, infrav1exp.GKEControlPlaneDeletingCondition).Reason == infrav1exp.GKEControlPlaneDeletedReason {
 		controllerutil.RemoveFinalizer(managedControlPlaneScope.GCPManagedControlPlane, infrav1exp.ManagedControlPlaneFinalizer)
 	}
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Managed control plane controller panics during cluster deletion because, before removing the finalizer, it tries to get the deleting condition. With this PR, it will now check for nil before fetching the condition. 

**Which issue(s) this PR fixes**:
Fixes #1454 

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
Fix panic on GKE cluster deletion
```
