### PR TITLE
fix: make sure machine pools are deleted before gke cluster

### DIFF
--- a/exp/controllers/gcpmanagedcluster_controller.go
+++ b/exp/controllers/gcpmanagedcluster_controller.go
@@ -228,6 +228,17 @@ func (r *GCPManagedClusterReconciler) reconcileDelete(ctx context.Context, clust
 	log := log.FromContext(ctx).WithValues("controller", "gcpmanagedcluster", "action", "delete")
 	log.Info("Reconciling Delete GCPManagedCluster")
 
+	numDependencies, err := r.dependencyCount(ctx, clusterScope)
+	if err != nil {
+		log.Error(err, "error getting cluster dependencies", "namespace", clusterScope.GCPManagedCluster.Namespace, "name", clusterScope.GCPManagedCluster.Name)
+		return ctrl.Result{}, err
+	}
+	if numDependencies > 0 {
+		log.V(4).Info("GKE cluster still has dependencies - requeue needed", "dependencyCount", numDependencies)
+		return ctrl.Result{RequeueAfter: reconciler.DefaultRetryTime}, nil
+	}
+	log.V(4).Info("GKE cluster has no dependencies")
+
 	if clusterScope.GCPManagedControlPlane != nil {
 		log.Info("GCPManagedControlPlane not deleted yet, retry later")
 		return ctrl.Result{RequeueAfter: reconciler.DefaultRetryTime}, nil
@@ -294,4 +305,23 @@ func (r *GCPManagedClusterReconciler) managedControlPlaneMapper() handler.MapFun
 			},
 		}
 	}
+}
+
+func (r *GCPManagedClusterReconciler) dependencyCount(ctx context.Context, clusterScope *scope.ManagedClusterScope) (int, error) {
+	log := log.FromContext(ctx)
+
+	clusterName, clusterNamespace := clusterScope.GCPManagedCluster.Name, clusterScope.GCPManagedCluster.Namespace
+	log.Info("looking for GKE cluster dependencies", "cluster", klog.KRef(clusterNamespace, clusterName))
+
+	listOptions := []client.ListOption{
+		client.InNamespace(clusterNamespace),
+		client.MatchingLabels(map[string]string{clusterv1.ClusterNameLabel: clusterName}),
+	}
+
+	managedMachinePools := &infrav1exp.GCPManagedMachinePoolList{}
+	if err := r.Client.List(ctx, managedMachinePools, listOptions...); err != nil {
+		return 0, fmt.Errorf("failed to list managed machine pools for cluster %s/%s: %w", clusterNamespace, clusterName, err)
+	}
+
+	return len(managedMachinePools.Items), nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

During cluster deletion, a `GCPManagedCluster` may be deleted before its associated `GCPManagedMachinePool`/s which actually needs the cluster resource to exist to delete successfully:

```
E0321 10:41:55.730846       1 controller.go:324] "Reconciler error" err="GCPManagedCluster.infrastructure.cluster.x-k8s.io \"cluster-gke\" not found" controller="gcpmanagedmachinepool" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="GCPManagedMachinePool" GCPManagedMachinePool="default/cluster-gke-mp-0" namespace="default" name="cluster-gke-mp-0" reconcileID="5e38a1b8-a006-4c22-973b-a7ebe1ca8c06"
E0321 10:42:05.971755       1 gcpmanagedmachinepool_controller.go:270] "Failed to retrieve GCPManagedCluster from the API Server" err="GCPManagedCluster.infrastructure.cluster.x-k8s.io \"cluster-gke\" not found" controller="gcpmanagedmachinepool" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="GCPManagedMachinePool" GCPManagedMachinePool="default/cluster-gke-mp-0" namespace="default" name="cluster-gke-mp-0" reconcileID="becd4efd-9abf-4dda-a3fb-ec1e1cfd6d95"
```

This happens intermittently and it's hard to reproduce, but there needs to be logic that waits for the machine pools to be removed before continuing with deleting the cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This is similar to [this](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5365) CAPA issue.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
Wait for machine pools to be deleted before deleting gke cluster
```
