### PR TITLE
CORS-3841: Update Custom Endpoints

### DIFF
--- a/cloud/scope/clients.go
+++ b/cloud/scope/clients.go
@@ -95,13 +95,13 @@ func newComputeService(ctx context.Context, credentialsRef *infrav1.ObjectRefere
 		return nil, fmt.Errorf("getting default gcp client options: %w", err)
 	}
 
-	if endpoints != nil && endpoints.ComputeServiceEndpoint != "" {
-		opts = append(opts, option.WithEndpoint(endpoints.ComputeServiceEndpoint))
-	}
-
 	computeSvc, err := compute.NewService(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating new compute service instance: %w", err)
+	}
+
+	if endpoints.ComputeServiceEndpoint != "" {
+		computeSvc.BasePath = endpoints.ComputeServiceEndpoint
 	}
 
 	return computeSvc, nil


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind feature

**What this PR does / why we need it**:

When this was originally completed, the option.WithEndpoint Google cloud option was used. This is the offically accepted way that is recommended by Google. However, it was discovered that when an endpoint formatted as https://someendpoint... is used, the client was producing 404 errors. If this same endpoint was used but set with BasePath = endpoint the correct endpoint was used and traffic was observed going to the endpoint.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
cloud/scope/clients : (Update) : When this was originally completed, the option.WithEndpoint Google cloud option was used. This is the offically accepted way that is recommended by Google. However, it was discovered that when an endpoint formatted as https://someendpoint... is used, the client was producing 404 errors. If this same endpoint was used but set with BasePath = endpoint the correct endpoint was used and traffic was observed going to the endpoint.
```
