### PR TITLE
option to enable global access for internal passthrough load balancers

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -357,6 +357,17 @@ type ObjectReference struct {
 	Name string `json:"name"`
 }
 
+// InternalAccess defines the access for the Internal Passthrough Load Balancer.
+type InternalAccess string
+
+const (
+	// InternalAccessRegional restricts traffic to clients within the same region as the internal load balancer.
+	InternalAccessRegional = InternalAccess("Regional")
+
+	// InternalAccessGlobal allows traffic from any region to access the internal load balancer.
+	InternalAccessGlobal = InternalAccess("Global")
+)
+
 // LoadBalancer specifies the configuration of a LoadBalancer.
 type LoadBalancer struct {
 	// Name is the name of the Load Balancer. If not set a default name
@@ -371,4 +382,17 @@ type LoadBalancer struct {
 	// required for the Load Balancer, if not defined the first configured subnet will be
 	// used.
 	Subnet *string `json:"subnet,omitempty"`
+
+	// InternalAccess defines the access for the Internal Passthrough Load Balancer.
+	// It determines whether the load balancer allows global access,
+	// or restricts traffic to clients within the same region as the load balancer.
+	// If unspecified, the value defaults to "Regional".
+	//
+	// Possible values:
+	//   "Regional" - Only clients in the same region as the load balancer can access it.
+	//   "Global" - Clients from any region can access the load balancer.
+	// +kubebuilder:validation:Enum=Regional;Global
+	// +kubebuilder:default=Regional
+	// +optional
+	InternalAccess InternalAccess `json:"internalAccess,omitempty"`
 }

--- a/cloud/services/compute/loadbalancers/reconcile.go
+++ b/cloud/services/compute/loadbalancers/reconcile.go
@@ -601,6 +601,10 @@ func (s *Service) createOrGetRegionalForwardingRule(ctx context.Context, lbname 
 	spec.LoadBalancingScheme = string(loadBalanceTrafficInternal)
 	spec.Region = s.scope.Region()
 	spec.BackendService = backendSvc.SelfLink
+	lbSpec := s.scope.LoadBalancer()
+	if lbSpec.InternalLoadBalancer != nil && lbSpec.InternalLoadBalancer.InternalAccess == infrav1.InternalAccessGlobal {
+		spec.AllowGlobalAccess = true
+	}
 	// Ports is used instead or PortRange for passthrough Load Balancer
 	// Configure ports for k8s API to match the external API which is the first port of range
 	var ports []string

--- a/cloud/services/compute/loadbalancers/reconcile_test.go
+++ b/cloud/services/compute/loadbalancers/reconcile_test.go
@@ -818,6 +818,7 @@ func TestService_createOrGetRegionalForwardingRule(t *testing.T) {
 				Region:              "us-central1",
 				Name:                "my-cluster-api-internal",
 				SelfLink:            "https://www.googleapis.com/compute/v1/projects/proj-id/regions/us-central1/forwardingRules/my-cluster-api-internal",
+				AllowGlobalAccess:   false,
 			},
 		},
 	}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -122,6 +122,21 @@ spec:
                     description: InternalLoadBalancer is the configuration for an
                       Internal Passthrough Network Load Balancer.
                     properties:
+                      internalAccess:
+                        default: Regional
+                        description: |-
+                          InternalAccess defines the access for the Internal Passthrough Load Balancer.
+                          It determines whether the load balancer allows global access,
+                          or restricts traffic to clients within the same region as the load balancer.
+                          If unspecified, the value defaults to "Regional".
+
+                          Possible values:
+                            "Regional" - Only clients in the same region as the load balancer can access it.
+                            "Global" - Clients from any region can access the load balancer.
+                        enum:
+                        - Regional
+                        - Global
+                        type: string
                       name:
                         description: |-
                           Name is the name of the Load Balancer. If not set a default name

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -138,6 +138,21 @@ spec:
                             description: InternalLoadBalancer is the configuration
                               for an Internal Passthrough Network Load Balancer.
                             properties:
+                              internalAccess:
+                                default: Regional
+                                description: |-
+                                  InternalAccess defines the access for the Internal Passthrough Load Balancer.
+                                  It determines whether the load balancer allows global access,
+                                  or restricts traffic to clients within the same region as the load balancer.
+                                  If unspecified, the value defaults to "Regional".
+
+                                  Possible values:
+                                    "Regional" - Only clients in the same region as the load balancer can access it.
+                                    "Global" - Clients from any region can access the load balancer.
+                                enum:
+                                - Regional
+                                - Global
+                                type: string
                               name:
                                 description: |-
                                   Name is the name of the Load Balancer. If not set a default name

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -117,6 +117,21 @@ spec:
                     description: InternalLoadBalancer is the configuration for an
                       Internal Passthrough Network Load Balancer.
                     properties:
+                      internalAccess:
+                        default: Regional
+                        description: |-
+                          InternalAccess defines the access for the Internal Passthrough Load Balancer.
+                          It determines whether the load balancer allows global access,
+                          or restricts traffic to clients within the same region as the load balancer.
+                          If unspecified, the value defaults to "Regional".
+
+                          Possible values:
+                            "Regional" - Only clients in the same region as the load balancer can access it.
+                            "Global" - Clients from any region can access the load balancer.
+                        enum:
+                        - Regional
+                        - Global
+                        type: string
                       name:
                         description: |-
                           Name is the name of the Load Balancer. If not set a default name


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
When Cluster API (CAPI) is deployed in a different region or outside of the Google Cloud Platform (GCP), reconciliation fails because CAPI cannot reach the control plane API. Enabling the global access option on the internal passthrough load balancer would resolve this issue.

**Which issue(s) this PR fixes** 
Fixes #1468

**Release note**:
```release-note
Option for enabling global access for internal passthrough load balancer.
```
