### PR TITLE
fix: capi-e2e test flavor reference

### DIFF
--- a/test/e2e/capi_test.go
+++ b/test/e2e/capi_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 				BootstrapClusterProxy: bootstrapClusterProxy,
 				ArtifactFolder:        artifactFolder,
 				SkipCleanup:           skipCleanup,
-				Flavor:                ptr.To[string]("topology"),
+				Flavor:                ptr.To[string]("ci-topology"),
 			}
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test


**What this PR does / why we need it**:
fix: capi-e2e test flavor reference, as the name has changed in https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1355

Context:
`
"failed to read "cluster-template-topology.yaml" from provider's repository "infrastructure-gcp": failed to read file "/logs/artifacts/repository/infrastructure-gcp/v1.10.99/cluster-template-topology.yaml" from local release v1.10.99: stat /logs/artifacts/repository/infrastructure-gcp/v1.10.99/cluster-template-topology.yaml: no such file or directory"
`
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-gcp/1459/pull-cluster-api-provider-gcp-capi-e2e/1918628474663211008



