### PR TITLE
Add support for creating an internal load balancer using the predefined IP from the control plane endpoint

### DIFF
--- a/cloud/services/compute/loadbalancers/reconcile.go
+++ b/cloud/services/compute/loadbalancers/reconcile.go
@@ -525,6 +525,9 @@ func (s *Service) createOrGetInternalAddress(ctx context.Context, lbname string)
 		log.Error(err, "Error getting subnet for Internal Load Balancer")
 		return nil, err
 	}
+	if s.scope.ControlPlaneEndpoint().Host != "" {
+		addrSpec.Address = s.scope.ControlPlaneEndpoint().Host
+	}
 	addrSpec.Subnetwork = subnet.SelfLink
 	addrSpec.Purpose = "GCE_ENDPOINT"
 	log.V(2).Info("Looking for internal address", "name", addrSpec.Name)


### PR DESCRIPTION

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
When deploying a cluster, it is useful to know the static IP of the API server before the internal passthrough load balancer is created, especially for integration with certain third-party tools. This setup is similar to how private IPs are handled in other CAPI providers (such as CAPZ), where users can predefine the private IP of the load balancer.

**Which issue(s) this PR fixes**:
Fixes #1474

**Release note**:

```release-note
Add an option to create a predefined static IP address for an internal passthrough load balancer.
```
