### PR TITLE
test: use unique cluster name to avoid collisions

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Workload cluster creation", func() {
 		namespace           *corev1.Namespace
 		cancelWatches       context.CancelFunc
 		result              *clusterctl.ApplyClusterTemplateAndWaitResult
-		clusterName         string
+		clusterNamePrefix   string
 		clusterctlLogFolder string
 	)
 
@@ -52,7 +52,7 @@ var _ = Describe("Workload cluster creation", func() {
 
 		Expect(e2eConfig.Variables).To(HaveKey(KubernetesVersion))
 
-		clusterName = fmt.Sprintf("capg-e2e-%s", util.RandomString(6))
+		clusterNamePrefix = fmt.Sprintf("capg-e2e-%s", util.RandomString(6))
 
 		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
@@ -80,6 +80,7 @@ var _ = Describe("Workload cluster creation", func() {
 
 	Context("Creating a single control-plane cluster", func() {
 		It("Should create a cluster with 1 worker node and can be scaled", func() {
+			clusterName := fmt.Sprintf("%s-single", clusterNamePrefix)
 			By("Initializes with 1 worker node")
 			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 				ClusterProxy: bootstrapClusterProxy,
@@ -124,6 +125,7 @@ var _ = Describe("Workload cluster creation", func() {
 
 	Context("Creating a highly available control-plane cluster", func() {
 		It("Should create a cluster with 3 control-plane and 2 worker nodes", func() {
+			clusterName := fmt.Sprintf("%s-ha", clusterNamePrefix)
 			By("Creating a high available cluster")
 			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 				ClusterProxy: bootstrapClusterProxy,
@@ -148,6 +150,7 @@ var _ = Describe("Workload cluster creation", func() {
 
 	Context("Creating a single control-plane cluster with per cluster credentials", func() {
 		It("Should create a cluster with 1 worker node", func() {
+			clusterName := fmt.Sprintf("%s-with-creds", clusterNamePrefix)
 			By("Create the credentials secret")
 
 			credsFile := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
@@ -185,6 +188,7 @@ var _ = Describe("Workload cluster creation", func() {
 
 	Context("Creating a control-plane cluster with an internal load balancer", func() {
 		It("Should create a cluster with 1 control-plane and 1 worker node with an internal load balancer", func() {
+			clusterName := fmt.Sprintf("%s-internal-lb", clusterNamePrefix)
 			By("Creating a cluster with internal load balancer")
 			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 				ClusterProxy: bootstrapClusterProxy,
@@ -209,6 +213,7 @@ var _ = Describe("Workload cluster creation", func() {
 
 	Context("Creating a cluster using a cluster class", func() {
 		It("Should create a cluster class and then a cluster based on it", func() {
+			clusterName := fmt.Sprintf("%s-topology", clusterNamePrefix)
 			By("Creating a cluster from a topology")
 			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 				ClusterProxy: bootstrapClusterProxy,


### PR DESCRIPTION
/kind failing-test


**What this PR does / why we need it**:

Use unique cluster names for each test case to prevent name collisions. Reusing cluster resource names creates a situation where the `Cluster` object may be updated by a different cluster flavor, which may imply that the two definitions are not compatible and a webhook will disallow the change. Thanks @damdo for investigating and getting to the bottom of this.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The same change should be applied to GKE test cases. We can do that in the existing PR https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1445, when we're ready to successfully run these tests.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
