### PR TITLE
chore: add Metadata kind to metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,6 +4,7 @@
 #
 # update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
 releaseSeries:
   - major: 0
     minor: 3


### PR DESCRIPTION
Requirement introduced by https://github.com/kubernetes-sigs/cluster-api/pull/12242

/kind cleanup

```release-note
NONE
```
