### PR TITLE
chore: don't use Requeue in controller-runtime

### DIFF
--- a/controllers/gcpcluster_controller_test.go
+++ b/controllers/gcpcluster_controller_test.go
@@ -55,7 +55,6 @@ var _ = Describe("GCPClusterReconciler", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeZero())
-			Expect(result.Requeue).To(BeFalse())
 		})
 	})
 })

--- a/controllers/gcpmachine_controller.go
+++ b/controllers/gcpmachine_controller.go
@@ -245,7 +245,7 @@ func (r *GCPMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 	default:
 		machineScope.SetFailureReason("UpdateError")
 		machineScope.SetFailureMessage(errors.Errorf("GCPMachine instance state %s is unexpected", instanceState))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: reconciler.DefaultRetryTime}, nil
 	}
 }
 

--- a/controllers/gcpmachine_controller_test.go
+++ b/controllers/gcpmachine_controller_test.go
@@ -47,7 +47,6 @@ var _ = Describe("GCPMachineReconciler", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeZero())
-			Expect(result.Requeue).To(BeFalse())
 		})
 	})
 })

--- a/exp/controllers/gcpmanagedcontrolplane_controller.go
+++ b/exp/controllers/gcpmanagedcontrolplane_controller.go
@@ -96,7 +96,7 @@ func (r *GCPManagedControlPlaneReconciler) Reconcile(ctx context.Context, req ct
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, fmt.Errorf("getting GCPManagedControlPlane: %w", err)
 	}
 
 	// Get the cluster
@@ -181,10 +181,6 @@ func (r *GCPManagedControlPlaneReconciler) reconcile(ctx context.Context, manage
 			log.V(4).Info("Reconciler requested requeueAfter", "reconciler", name, "after", res.RequeueAfter)
 			return res, nil
 		}
-		if res.Requeue {
-			log.V(4).Info("Reconciler requested requeue", "reconciler", name)
-			return res, nil
-		}
 	}
 
 	return ctrl.Result{}, nil
@@ -207,10 +203,6 @@ func (r *GCPManagedControlPlaneReconciler) reconcileDelete(ctx context.Context, 
 		}
 		if res.RequeueAfter > 0 {
 			log.V(4).Info("Reconciler requested requeueAfter", "reconciler", name, "after", res.RequeueAfter)
-			return res, nil
-		}
-		if res.Requeue {
-			log.V(4).Info("Reconciler requested requeue", "reconciler", name)
 			return res, nil
 		}
 	}

--- a/exp/controllers/gcpmanagedmachinepool_controller.go
+++ b/exp/controllers/gcpmanagedmachinepool_controller.go
@@ -237,7 +237,7 @@ func (r *GCPManagedMachinePoolReconciler) Reconcile(ctx context.Context, req ctr
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, fmt.Errorf("getting GCPManagedMachinePool: %w", err)
 	}
 
 	// Get the machine pool
@@ -354,10 +354,6 @@ func (r *GCPManagedMachinePoolReconciler) reconcile(ctx context.Context, managed
 			log.V(4).Info("Reconciler requested requeueAfter", "reconciler", name, "after", res.RequeueAfter)
 			return res, nil
 		}
-		if res.Requeue {
-			log.V(4).Info("Reconciler requested requeue", "reconciler", name)
-			return res, nil
-		}
 	}
 
 	return ctrl.Result{}, nil
@@ -388,10 +384,6 @@ func (r *GCPManagedMachinePoolReconciler) reconcileDelete(ctx context.Context, m
 		}
 		if res.RequeueAfter > 0 {
 			log.V(4).Info("Reconciler requested requeueAfter", "reconciler", name, "after", res.RequeueAfter)
-			return res, nil
-		}
-		if res.Requeue {
-			log.V(4).Info("Reconciler requested requeue", "reconciler", name)
 			return res, nil
 		}
 	}


### PR DESCRIPTION
It is deprecated in newer versions of controller-runtime,
because it should not be used.

```release-note

NONE
```