### PR TITLE
chore: unify calling of apidiff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -576,10 +576,11 @@ clean-release: ## Remove the release folder
 	rm -rf $(RELEASE_DIR)
 
 .PHONY: apidiff
-apidiff: $(GO_APIDIFF) ## Check for API differences.
+apidiff: APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
+apidiff: $(GO_APIDIFF) ## Check for API differences
 	@$(call checkdiff) > /dev/null
 	@if ($(call checkdiff) | grep "api/"); then \
-		$(GO_APIDIFF) $(shell git rev-parse origin/main) --print-compatible; \
+		$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible; \
 	else \
 		echo "No changes to 'api/'. Nothing to do."; \
 	fi

--- a/scripts/ci-apidiff.sh
+++ b/scripts/ci-apidiff.sh
@@ -20,9 +20,7 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-APIDIFF="${REPO_ROOT}/hack/tools/bin/go-apidiff"
+cd "${REPO_ROOT}"
 
-cd "${REPO_ROOT}" && make "${APIDIFF##*/}"
 echo "*** Running go-apidiff ***"
-
-${APIDIFF} "${PULL_BASE_SHA}" --print-compatible
+APIDIFF_OLD_COMMIT="${PULL_BASE_SHA}" make apidiff


### PR DESCRIPTION
Following what is done in cluster-api-provider-aws, we always use the Makefile apidiff target.

This means we ignore api diffs if the API is not changing.

```release-note

NONE
```
