### PR TITLE
Provide a MinPortsPerVM for Nat Router

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -147,6 +147,16 @@ type NetworkSpec struct {
 	// +kubebuilder:default:=1460
 	// +optional
 	Mtu int64 `json:"mtu,omitempty"`
+
+	// MinPortsPerVM: Minimum number of ports allocated to a VM from this NAT
+	// config. If not set, a default number of ports is allocated to a VM. This is
+	// rounded up to the nearest power of 2. For example, if the value of this
+	// field is 50, at least 64 ports are allocated to a VM.
+	// +kubebuilder:validation:Minimum:=2
+	// +kubebuilder:validation:Maximum:=65536
+	// +kubebuilder:default:=64
+	// +optional
+	MinPortsPerVM int64 `json:"minPortsPerVm,omitempty"`
 }
 
 // LoadBalancerType defines the Load Balancer that should be created.

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -237,6 +237,7 @@ func (s *ClusterScope) NatRouterSpec() *compute.Router {
 				Name:                          fmt.Sprintf("%s-%s", networkSpec.Name, "nat"),
 				NatIpAllocateOption:           "AUTO_ONLY",
 				SourceSubnetworkIpRangesToNat: "ALL_SUBNETWORKS_ALL_IP_RANGES",
+				MinPortsPerVm:                 s.GCPCluster.Spec.Network.MinPortsPerVM,
 			},
 		},
 	}

--- a/cloud/scope/managedcluster.go
+++ b/cloud/scope/managedcluster.go
@@ -221,6 +221,7 @@ func (s *ManagedClusterScope) NatRouterSpec() *compute.Router {
 				Name:                          fmt.Sprintf("%s-%s", networkSpec.Name, "nat"),
 				NatIpAllocateOption:           "AUTO_ONLY",
 				SourceSubnetworkIpRangesToNat: "ALL_SUBNETWORKS_ALL_IP_RANGES",
+				MinPortsPerVm:                 s.GCPManagedCluster.Spec.Network.MinPortsPerVM,
 			},
 		},
 	}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -188,6 +188,17 @@ spec:
                       (useful for changing apiserver port)
                     format: int32
                     type: integer
+                  minPortsPerVm:
+                    default: 64
+                    description: |-
+                      MinPortsPerVM: Minimum number of ports allocated to a VM from this NAT
+                      config. If not set, a default number of ports is allocated to a VM. This is
+                      rounded up to the nearest power of 2. For example, if the value of this
+                      field is 50, at least 64 ports are allocated to a VM.
+                    format: int64
+                    maximum: 65536
+                    minimum: 2
+                    type: integer
                   mtu:
                     default: 1460
                     description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -207,6 +207,17 @@ spec:
                               backend (useful for changing apiserver port)
                             format: int32
                             type: integer
+                          minPortsPerVm:
+                            default: 64
+                            description: |-
+                              MinPortsPerVM: Minimum number of ports allocated to a VM from this NAT
+                              config. If not set, a default number of ports is allocated to a VM. This is
+                              rounded up to the nearest power of 2. For example, if the value of this
+                              field is 50, at least 64 ports are allocated to a VM.
+                            format: int64
+                            maximum: 65536
+                            minimum: 2
+                            type: integer
                           mtu:
                             default: 1460
                             description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -184,6 +184,17 @@ spec:
                       (useful for changing apiserver port)
                     format: int32
                     type: integer
+                  minPortsPerVm:
+                    default: 64
+                    description: |-
+                      MinPortsPerVM: Minimum number of ports allocated to a VM from this NAT
+                      config. If not set, a default number of ports is allocated to a VM. This is
+                      rounded up to the nearest power of 2. For example, if the value of this
+                      field is 50, at least 64 ports are allocated to a VM.
+                    format: int64
+                    maximum: 65536
+                    minimum: 2
+                    type: integer
                   mtu:
                     default: 1460
                     description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
@@ -178,6 +178,17 @@ spec:
                               backend (useful for changing apiserver port)
                             format: int32
                             type: integer
+                          minPortsPerVm:
+                            default: 64
+                            description: |-
+                              MinPortsPerVM: Minimum number of ports allocated to a VM from this NAT
+                              config. If not set, a default number of ports is allocated to a VM. This is
+                              rounded up to the nearest power of 2. For example, if the value of this
+                              field is 50, at least 64 ports are allocated to a VM.
+                            format: int64
+                            maximum: 65536
+                            minimum: 2
+                            type: integer
                           mtu:
                             default: 1460
                             description: |-


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->
/kind feature

**What this PR does / why we need it**

** This is a regression for the openshift installer.

Instead of filling this value in, the default will be 64 (so that this is backwards compatible), otherwise the user can provide this information in the cluster spec.

** MinPortsPerVM: Minimum number of ports allocated to a VM from this NAT config. If not set, a default number of ports is allocated to a VM. This is rounded up to the nearest power of 2. For example, if the value of this field is 50, at least 64 ports are allocated to a VM.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://issues.redhat.com/browse/OCPBUGS-61876

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
MinPortsPerVM is the minimum number of ports allocated to a VM from this NAT config. If not set, a default number of ports is allocated to a VM. This is rounded up to the nearest power of 2. For example, if the value of this field is 50, at least 64 ports are allocated to a VM. 
```
