### PR TITLE
chore: make apidiff test more robust and informative

### DIFF
--- a/hack/verify-apidiff
+++ b/hack/verify-apidiff
@@ -33,9 +33,14 @@ apidiffs=$(go run github.com/joelanford/go-apidiff@v0.8.3 ${APIDIFF_OLD_COMMIT} 
 filtered=$(echo "$apidiffs" | grep -E 'cluster-api-provider-gcp/(api/|exp/api/)' || true)
 
 if [[ -n "$filtered" ]]; then
-  echo "API differences found in api/ or exp/api/:"
+  echo "API differences found in api/ or exp/api/ packages."
+  echo ""
+  echo "Full set of differences found by go-apidiff:"
   echo "$apidiffs"
   exit 1
 else
-  echo "No differences found in api/ or exp/api/ packages"
+  echo "No differences found in api/ or exp/api/ packages."
+  echo ""
+  echo "Full set of differences found by go-apidiff:"
+  echo "$apidiffs"
 fi

--- a/scripts/ci-apidiff.sh
+++ b/scripts/ci-apidiff.sh
@@ -22,4 +22,4 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 cd "${REPO_ROOT}"
 
-APIDIFF_OLD_COMMIT="${PULL_BASE_SHA}" make apidiff
+APIDIFF_OLD_COMMIT="${PULL_BASE_SHA}" exec make apidiff


### PR DESCRIPTION
* Use exec so that if the prow job is killed, the script is killed too
* Print full apidiff output in both success and failure cases

```release-note

NONE
```