### PR TITLE
feat: implement proper context in scope methods

### DIFF
--- a/cloud/interfaces.go
+++ b/cloud/interfaces.go
@@ -90,7 +90,7 @@ type MachineGetter interface {
 	ControlPlaneGroupName() string
 	GetInstanceID() *string
 	GetProviderID() string
-	GetBootstrapData() (string, error)
+	GetBootstrapData(ctx context.Context) (string, error)
 	GetInstanceStatus() *infrav1.InstanceStatus
 }
 

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -421,11 +421,11 @@ func (s *ClusterScope) TargetTCPProxySpec() *compute.TargetTcpProxy {
 // ANCHOR_END: ClusterControlPlaneSpec
 
 // PatchObject persists the cluster configuration and status.
-func (s *ClusterScope) PatchObject() error {
-	return s.patchHelper.Patch(context.TODO(), s.GCPCluster)
+func (s *ClusterScope) PatchObject(ctx context.Context) error {
+	return s.patchHelper.Patch(ctx, s.GCPCluster)
 }
 
 // Close closes the current scope persisting the cluster configuration and status.
-func (s *ClusterScope) Close() error {
-	return s.PatchObject()
+func (s *ClusterScope) Close(ctx context.Context) error {
+	return s.PatchObject(ctx)
 }

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -389,11 +389,11 @@ func (s *ClusterScope) TargetTCPProxySpec() *compute.TargetTcpProxy {
 // ANCHOR_END: ClusterControlPlaneSpec
 
 // PatchObject persists the cluster configuration and status.
-func (s *ClusterScope) PatchObject() error {
-	return s.patchHelper.Patch(context.TODO(), s.GCPCluster)
+func (s *ClusterScope) PatchObject(ctx context.Context) error {
+	return s.patchHelper.Patch(ctx, s.GCPCluster)
 }
 
 // Close closes the current scope persisting the cluster configuration and status.
-func (s *ClusterScope) Close() error {
-	return s.PatchObject()
+func (s *ClusterScope) Close(ctx context.Context) error {
+	return s.PatchObject(ctx)
 }

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -229,7 +229,7 @@ func (m *MachineScope) SetAddresses(addressList []corev1.NodeAddress) {
 // ANCHOR: MachineInstanceSpec
 
 // InstanceImageSpec returns compute instance image attched-disk spec.
-func (m *MachineScope) InstanceImageSpec() *compute.AttachedDisk {
+func (m *MachineScope) InstanceImageSpec(ctx context.Context) *compute.AttachedDisk {
 	version := m.Machine.Spec.Version
 	image := "capi-ubuntu-1804-k8s-" + strings.ReplaceAll(semver.MajorMinor(version), ".", "-")
 	sourceImage := path.Join("projects", m.ClusterGetter.Project(), "global", "images", "family", image)
@@ -250,7 +250,7 @@ func (m *MachineScope) InstanceImageSpec() *compute.AttachedDisk {
 		InitializeParams: &compute.AttachedDiskInitializeParams{
 			DiskSizeGb:          m.GCPMachine.Spec.RootDeviceSize,
 			DiskType:            path.Join("zones", m.Zone(), "diskTypes", string(diskType)),
-			ResourceManagerTags: shared.ResourceTagConvert(context.TODO(), m.GCPMachine.Spec.ResourceManagerTags),
+			ResourceManagerTags: shared.ResourceTagConvert(ctx, m.GCPMachine.Spec.ResourceManagerTags),
 			SourceImage:         sourceImage,
 			Labels:              m.ClusterGetter.AdditionalLabels().AddLabels(m.GCPMachine.Spec.AdditionalLabels),
 		},
@@ -412,9 +412,7 @@ func instanceGuestAcceleratorsSpec(guestAccelerators []infrav1.Accelerator) []*c
 }
 
 // InstanceSpec returns instance spec.
-func (m *MachineScope) InstanceSpec(log logr.Logger) *compute.Instance {
-	ctx := context.TODO()
-
+func (m *MachineScope) InstanceSpec(ctx context.Context, log logr.Logger) *compute.Instance {
 	instance := &compute.Instance{
 		Name:        m.Name(),
 		Zone:        m.Zone(),
@@ -427,7 +425,7 @@ func (m *MachineScope) InstanceSpec(log logr.Logger) *compute.Instance {
 			),
 		},
 		Params: &compute.InstanceParams{
-			ResourceManagerTags: shared.ResourceTagConvert(context.TODO(), m.ResourceManagerTags()),
+			ResourceManagerTags: shared.ResourceTagConvert(ctx, m.ResourceManagerTags()),
 		},
 		Labels: infrav1.Build(infrav1.BuildParams{
 			ClusterName: m.ClusterGetter.Name(),
@@ -500,7 +498,7 @@ func (m *MachineScope) InstanceSpec(log logr.Logger) *compute.Instance {
 		}
 	}
 
-	instance.Disks = append(instance.Disks, m.InstanceImageSpec())
+	instance.Disks = append(instance.Disks, m.InstanceImageSpec(ctx))
 	instance.Disks = append(instance.Disks, instanceAdditionalDiskSpec(ctx, m.GCPMachine.Spec.AdditionalDisks, m.GCPMachine.Spec.RootDiskEncryptionKey, m.Zone(), m.ResourceManagerTags())...)
 
 	instance.Metadata = InstanceAdditionalMetadataSpec(m.GCPMachine.Spec.AdditionalMetadata)
@@ -542,13 +540,13 @@ func GetBootstrapData(ctx context.Context, client client.Client, parent client.O
 }
 
 // PatchObject persists the cluster configuration and status.
-func (m *MachineScope) PatchObject() error {
-	return m.patchHelper.Patch(context.TODO(), m.GCPMachine)
+func (m *MachineScope) PatchObject(ctx context.Context) error {
+	return m.patchHelper.Patch(ctx, m.GCPMachine)
 }
 
 // Close closes the current scope persisting the cluster configuration and status.
-func (m *MachineScope) Close() error {
-	return m.PatchObject()
+func (m *MachineScope) Close(ctx context.Context) error {
+	return m.PatchObject(ctx)
 }
 
 // ResourceManagerTags merges ResourceManagerTags from the scope's GCPCluster and GCPMachine. If the same key is present in both,

--- a/cloud/scope/managedcluster.go
+++ b/cloud/scope/managedcluster.go
@@ -327,11 +327,11 @@ func (s *ManagedClusterScope) FirewallRulesSpec() []*compute.Firewall {
 // ANCHOR_END: ClusterFirewallSpec
 
 // PatchObject persists the cluster configuration and status.
-func (s *ManagedClusterScope) PatchObject() error {
-	return s.patchHelper.Patch(context.TODO(), s.GCPManagedCluster)
+func (s *ManagedClusterScope) PatchObject(ctx context.Context) error {
+	return s.patchHelper.Patch(ctx, s.GCPManagedCluster)
 }
 
 // Close closes the current scope persisting the cluster configuration and status.
-func (s *ManagedClusterScope) Close() error {
-	return s.PatchObject()
+func (s *ManagedClusterScope) Close(ctx context.Context) error {
+	return s.PatchObject(ctx)
 }

--- a/cloud/scope/managedcluster.go
+++ b/cloud/scope/managedcluster.go
@@ -289,11 +289,11 @@ func (s *ManagedClusterScope) FirewallRulesSpec() []*compute.Firewall {
 // ANCHOR_END: ClusterFirewallSpec
 
 // PatchObject persists the cluster configuration and status.
-func (s *ManagedClusterScope) PatchObject() error {
-	return s.patchHelper.Patch(context.TODO(), s.GCPManagedCluster)
+func (s *ManagedClusterScope) PatchObject(ctx context.Context) error {
+	return s.patchHelper.Patch(ctx, s.GCPManagedCluster)
 }
 
 // Close closes the current scope persisting the cluster configuration and status.
-func (s *ManagedClusterScope) Close() error {
-	return s.PatchObject()
+func (s *ManagedClusterScope) Close(ctx context.Context) error {
+	return s.PatchObject(ctx)
 }

--- a/cloud/scope/managedcontrolplane.go
+++ b/cloud/scope/managedcontrolplane.go
@@ -128,9 +128,9 @@ type ManagedControlPlaneScope struct {
 }
 
 // PatchObject persists the managed control plane configuration and status.
-func (s *ManagedControlPlaneScope) PatchObject() error {
+func (s *ManagedControlPlaneScope) PatchObject(ctx context.Context) error {
 	return s.patchHelper.Patch(
-		context.TODO(),
+		ctx,
 		s.GCPManagedControlPlane,
 		v1beta1patch.WithOwnedConditions{Conditions: []clusterv1beta1.ConditionType{
 			infrav1exp.GKEControlPlaneReadyCondition,
@@ -141,11 +141,11 @@ func (s *ManagedControlPlaneScope) PatchObject() error {
 }
 
 // Close closes the current scope persisting the managed control plane configuration and status.
-func (s *ManagedControlPlaneScope) Close() error {
+func (s *ManagedControlPlaneScope) Close(ctx context.Context) error {
 	s.mcClient.Close()
 	s.tagBindingsClient.Close()
 	s.credentialsClient.Close()
-	return s.PatchObject()
+	return s.PatchObject(ctx)
 }
 
 // ConditionSetter return a condition setter (which is GCPManagedControlPlane itself).

--- a/cloud/scope/managedmachinepool.go
+++ b/cloud/scope/managedmachinepool.go
@@ -117,9 +117,9 @@ type ManagedMachinePoolScope struct {
 }
 
 // PatchObject persists the managed control plane configuration and status.
-func (s *ManagedMachinePoolScope) PatchObject() error {
+func (s *ManagedMachinePoolScope) PatchObject(ctx context.Context) error {
 	return s.patchHelper.Patch(
-		context.TODO(),
+		ctx,
 		s.GCPManagedMachinePool,
 		v1beta1patch.WithOwnedConditions{Conditions: []clusterv1beta1.ConditionType{
 			infrav1exp.GKEMachinePoolReadyCondition,
@@ -130,10 +130,10 @@ func (s *ManagedMachinePoolScope) PatchObject() error {
 }
 
 // Close closes the current scope persisting the managed control plane configuration and status.
-func (s *ManagedMachinePoolScope) Close() error {
+func (s *ManagedMachinePoolScope) Close(ctx context.Context) error {
 	s.mcClient.Close()
 	s.migClient.Close()
-	return s.PatchObject()
+	return s.PatchObject(ctx)
 }
 
 // ConditionSetter return a condition setter (which is GCPManagedMachinePool itself).

--- a/cloud/services/compute/instances/reconcile.go
+++ b/cloud/services/compute/instances/reconcile.go
@@ -101,7 +101,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 func (s *Service) Delete(ctx context.Context) error {
 	log := log.FromContext(ctx)
 	log.Info("Deleting instance resources")
-	instanceSpec := s.scope.InstanceSpec(log)
+	instanceSpec := s.scope.InstanceSpec(ctx, log)
 	instanceName := instanceSpec.Name
 	instanceKey := meta.ZonalKey(instanceName, s.scope.Zone())
 	log.V(2).Info("Looking for instance before deleting", "name", instanceName, "zone", s.scope.Zone())
@@ -128,13 +128,13 @@ func (s *Service) Delete(ctx context.Context) error {
 func (s *Service) createOrGetInstance(ctx context.Context) (*compute.Instance, error) {
 	log := log.FromContext(ctx)
 	log.V(2).Info("Getting bootstrap data for machine")
-	bootstrapData, err := s.scope.GetBootstrapData()
+	bootstrapData, err := s.scope.GetBootstrapData(ctx)
 	if err != nil {
 		log.Error(err, "Error getting bootstrap data for machine")
 		return nil, errors.Wrap(err, "failed to retrieve bootstrap data")
 	}
 
-	instanceSpec := s.scope.InstanceSpec(log)
+	instanceSpec := s.scope.InstanceSpec(ctx, log)
 	instanceName := instanceSpec.Name
 	instanceKey := meta.ZonalKey(instanceName, s.scope.Zone())
 	instanceSpec.Metadata.Items = append(instanceSpec.Metadata.Items, &compute.MetadataItems{

--- a/cloud/services/compute/instances/reconcile.go
+++ b/cloud/services/compute/instances/reconcile.go
@@ -103,7 +103,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 func (s *Service) Delete(ctx context.Context) error {
 	log := log.FromContext(ctx)
 	log.Info("Deleting instance resources")
-	instanceSpec := s.scope.InstanceSpec(log)
+	instanceSpec := s.scope.InstanceSpec(ctx, log)
 	instanceName := instanceSpec.Name
 	instanceKey := meta.ZonalKey(instanceName, s.scope.Zone())
 	log.V(2).Info("Looking for instance before deleting", "name", instanceName, "zone", s.scope.Zone())
@@ -136,7 +136,7 @@ func (s *Service) createOrGetInstance(ctx context.Context) (*compute.Instance, e
 		return nil, errors.Wrap(err, "failed to retrieve bootstrap data")
 	}
 
-	instanceSpec := s.scope.InstanceSpec(log)
+	instanceSpec := s.scope.InstanceSpec(ctx, log)
 	instanceName := instanceSpec.Name
 	instanceKey := meta.ZonalKey(instanceName, s.scope.Zone())
 	instanceSpec.Metadata.Items = append(instanceSpec.Metadata.Items, &compute.MetadataItems{

--- a/cloud/services/compute/instances/service.go
+++ b/cloud/services/compute/instances/service.go
@@ -44,7 +44,7 @@ type instancegroupsInterface interface {
 // Scope is an interfaces that hold used methods.
 type Scope interface {
 	cloud.Machine
-	InstanceSpec(log logr.Logger) *compute.Instance
+	InstanceSpec(ctx context.Context, log logr.Logger) *compute.Instance
 }
 
 // Service implements instances reconciler.

--- a/cloud/services/compute/instances/service.go
+++ b/cloud/services/compute/instances/service.go
@@ -43,7 +43,7 @@ type instancegroupsInterface interface {
 // Scope is an interfaces that hold used methods.
 type Scope interface {
 	cloud.Machine
-	InstanceSpec(log logr.Logger) *compute.Instance
+	InstanceSpec(ctx context.Context, log logr.Logger) *compute.Instance
 }
 
 // Service implements instances reconciler.

--- a/controllers/gcpcluster_controller.go
+++ b/controllers/gcpcluster_controller.go
@@ -146,7 +146,7 @@ func (r *GCPClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// Always close the scope when exiting this function so we can persist any GCPMachine changes.
 	defer func() {
-		if err := clusterScope.Close(); err != nil && reterr == nil {
+		if err := clusterScope.Close(ctx); err != nil && reterr == nil {
 			reterr = err
 		}
 	}()
@@ -165,7 +165,7 @@ func (r *GCPClusterReconciler) reconcile(ctx context.Context, clusterScope *scop
 	log.Info("Reconciling GCPCluster")
 
 	controllerutil.AddFinalizer(clusterScope.GCPCluster, infrav1.ClusterFinalizer)
-	if err := clusterScope.PatchObject(); err != nil {
+	if err := clusterScope.PatchObject(ctx); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/gcpmachine_controller.go
+++ b/controllers/gcpmachine_controller.go
@@ -201,7 +201,7 @@ func (r *GCPMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// Always close the scope when exiting this function so we can persist any GCPMachine changes.
 	defer func() {
-		if err := machineScope.Close(); err != nil && reterr == nil {
+		if err := machineScope.Close(ctx); err != nil && reterr == nil {
 			reterr = err
 		}
 	}()
@@ -220,7 +220,7 @@ func (r *GCPMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 	log.Info("Reconciling GCPMachine")
 
 	controllerutil.AddFinalizer(machineScope.GCPMachine, infrav1.MachineFinalizer)
-	if err := machineScope.PatchObject(); err != nil {
+	if err := machineScope.PatchObject(ctx); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/exp/controllers/gcpmanagedcluster_controller.go
+++ b/exp/controllers/gcpmanagedcluster_controller.go
@@ -125,7 +125,7 @@ func (r *GCPManagedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Always close the scope when exiting this function so we can persist any GCPMachine changes.
 	defer func() {
-		if err := clusterScope.Close(); err != nil && reterr == nil {
+		if err := clusterScope.Close(ctx); err != nil && reterr == nil {
 			reterr = err
 		}
 	}()
@@ -173,7 +173,7 @@ func (r *GCPManagedClusterReconciler) reconcile(ctx context.Context, clusterScop
 	log.Info("Reconciling GCPManagedCluster")
 
 	controllerutil.AddFinalizer(clusterScope.GCPManagedCluster, infrav1exp.ClusterFinalizer)
-	if err := clusterScope.PatchObject(); err != nil {
+	if err := clusterScope.PatchObject(ctx); err != nil {
 		return err
 	}
 

--- a/exp/controllers/gcpmanagedcontrolplane_controller.go
+++ b/exp/controllers/gcpmanagedcontrolplane_controller.go
@@ -137,7 +137,7 @@ func (r *GCPManagedControlPlaneReconciler) Reconcile(ctx context.Context, req ct
 
 	// Always close the scope when exiting this function so we can persist any GCPMachine changes.
 	defer func() {
-		if err := managedControlPlaneScope.Close(); err != nil && reterr == nil {
+		if err := managedControlPlaneScope.Close(ctx); err != nil && reterr == nil {
 			reterr = err
 		}
 	}()
@@ -156,7 +156,7 @@ func (r *GCPManagedControlPlaneReconciler) reconcile(ctx context.Context, manage
 	log.Info("Reconciling GCPManagedControlPlane")
 
 	controllerutil.AddFinalizer(managedControlPlaneScope.GCPManagedControlPlane, infrav1exp.ManagedControlPlaneFinalizer)
-	if err := managedControlPlaneScope.PatchObject(); err != nil {
+	if err := managedControlPlaneScope.PatchObject(ctx); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/exp/controllers/gcpmanagedmachinepool_controller.go
+++ b/exp/controllers/gcpmanagedmachinepool_controller.go
@@ -305,7 +305,7 @@ func (r *GCPManagedMachinePoolReconciler) Reconcile(ctx context.Context, req ctr
 
 	// Always close the scope when exiting this function so we can persist any GCPMachine changes.
 	defer func() {
-		if err := managedMachinePoolScope.Close(); err != nil && reterr == nil {
+		if err := managedMachinePoolScope.Close(ctx); err != nil && reterr == nil {
 			log.Error(err, "Failed to patch GCPManagedMachinePool object", "GCPManagedMachinePool", managedMachinePoolScope.GCPManagedMachinePool.Name)
 			reterr = err
 		}
@@ -326,7 +326,7 @@ func (r *GCPManagedMachinePoolReconciler) reconcile(ctx context.Context, managed
 
 	controllerutil.AddFinalizer(managedMachinePoolScope.GCPManagedMachinePool, infrav1exp.ManagedMachinePoolFinalizer)
 	managedMachinePoolScope.SetInfrastructureMachineKind()
-	if err := managedMachinePoolScope.PatchObject(); err != nil {
+	if err := managedMachinePoolScope.PatchObject(ctx); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/exp/controllers/gcpmanagedmachinepool_controller.go
+++ b/exp/controllers/gcpmanagedmachinepool_controller.go
@@ -278,7 +278,7 @@ func (r *GCPManagedMachinePoolReconciler) Reconcile(ctx context.Context, req ctr
 
 	// Always close the scope when exiting this function so we can persist any GCPMachine changes.
 	defer func() {
-		if err := managedMachinePoolScope.Close(); err != nil && reterr == nil {
+		if err := managedMachinePoolScope.Close(ctx); err != nil && reterr == nil {
 			log.Error(err, "Failed to patch GCPManagedMachinePool object", "GCPManagedMachinePool", managedMachinePoolScope.GCPManagedMachinePool.Name)
 			reterr = err
 		}
@@ -299,7 +299,7 @@ func (r *GCPManagedMachinePoolReconciler) reconcile(ctx context.Context, managed
 
 	controllerutil.AddFinalizer(managedMachinePoolScope.GCPManagedMachinePool, infrav1exp.ManagedMachinePoolFinalizer)
 	managedMachinePoolScope.SetInfrastructureMachineKind()
-	if err := managedMachinePoolScope.PatchObject(); err != nil {
+	if err := managedMachinePoolScope.PatchObject(ctx); err != nil {
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

As discussed in https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1506#discussion_r2504245800 there's no proper context in place for scope methods and using `context.TODO()` is not a valid solution as it's only expected to be used temporarily, for testing or in non-production projects. Effectively this is simply a workaround for passing a nil value to functions that require a context object but it just won't ever timeout.

This PR tries to implement proper context to scope methods. I think I updated all of them, but feel free to call me out on any missing occurrences of `context.TODO()`.

**Which issue(s) this PR fixes**:
Fixes #1573 

**Special notes for your reviewer**:

No changes are applied to testing files where `context.TODO()` is still used and should be considered a valid solution for simpler context management.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
