### PR TITLE
WIP: fix: bump k8s version in ci conformance test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,6 @@ jobs:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 # v9.1.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.4

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -45,8 +45,8 @@ export GCP_NETWORK_NAME=${GCP_NETWORK_NAME:-"${TEST_NAME}-mynetwork"}
 GCP_B64ENCODED_CREDENTIALS=$(base64 -w0 "$GOOGLE_APPLICATION_CREDENTIALS")
 export GCP_B64ENCODED_CREDENTIALS
 export KUBERNETES_MAJOR_VERSION="1"
-export KUBERNETES_MINOR_VERSION="27"
-export KUBERNETES_PATCH_VERSION="3"
+export KUBERNETES_MINOR_VERSION="33"
+export KUBERNETES_PATCH_VERSION="2"
 export KUBERNETES_VERSION="v${KUBERNETES_MAJOR_VERSION}.${KUBERNETES_MINOR_VERSION}.${KUBERNETES_PATCH_VERSION}"
 # using prebuilt image from image-builder project the image is built everyday and the job is available here https://prow.k8s.io/?job=periodic-image-builder-gcp-all-nightly
 export IMAGE_ID="projects/k8s-staging-cluster-api-gcp/global/images/cluster-api-ubuntu-2204-${KUBERNETES_VERSION//[.+]/-}-nightly"


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

This is an attempt at fixing the ci conformance test which has been failing for a long time (see [prow dashboard](https://prow.k8s.io/?job=periodic-cluster-api-provider-gcp-make-conformance-main-ci-artifacts)) and has been reported in the list of failing Kubernetes jobs [here](https://storage.googleapis.com/k8s-metrics/failures-latest.html?include=cluster-api&sort=days&asc=0).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
