### PR TITLE
Adding dual-stack support for Cluster API GCP Provider

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -503,6 +503,14 @@ type SubnetSpec struct {
 	// can be set only at resource creation time.
 	CidrBlock string `json:"cidrBlock,omitempty"`
 
+	// Ipv6CidrRange is the range of internal IPv6 addresses that are owned by
+	// this subnetwork. Provide this property when you create the subnetwork. The
+	// range must be a unique /64 or larger from the ULA (Unique Local Address) range.
+	// For example, fd00:1234:5678::/64. This field can be set only at resource
+	// creation time and is only applicable when StackType is set to DualStack.
+	// +optional
+	Ipv6CidrRange string `json:"ipv6CidrRange,omitempty"`
+
 	// Description is an optional description associated with the resource.
 	// +optional
 	Description *string `json:"description,omitempty"`

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -511,6 +511,16 @@ type SubnetSpec struct {
 	// +optional
 	Ipv6CidrRange string `json:"ipv6CidrRange,omitempty"`
 
+	// ExternalIpv6 specifies whether the subnet should have external IPv6 access.
+	// When true, the subnet will use EXTERNAL IPv6 access type and instances can
+	// have public IPv6 addresses. When false (default), the subnet will use INTERNAL
+	// IPv6 access type with ULA (Unique Local Address) ranges.
+	// This is only applicable when StackType is set to DualStack.
+	// Note: Subnets with EXTERNAL IPv6 cannot be used with internal load balancers.
+	// +kubebuilder:default=false
+	// +optional
+	ExternalIpv6 *bool `json:"externalIpv6,omitempty"`
+
 	// Description is an optional description associated with the resource.
 	// +optional
 	Description *string `json:"description,omitempty"`

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -309,6 +309,32 @@ const (
 	RulesManagementUnmanaged RulesManagementPolicy = "Unmanaged"
 )
 
+// StackType is a string enum type indicating the types of network addresses that are valid.
+// +kubebuilder:validation:Enum=IPv4Only;DualStack
+type StackType string
+
+const (
+	// IPv4OnlyStackType indicates a stack type where only IPv4 addresses are valid.
+	IPv4OnlyStackType StackType = "IPv4Only"
+
+	// DualStackType indicates a stack type where both IPv4 and IPv6 addresses are valid.
+	DualStackType StackType = "DualStack"
+)
+
+const (
+	// DualStackAdditionalResourceSuffix is an identifier appended to the resource name to indicate
+	// that it is not for the ipv4 [default] stack type.
+	DualStackAdditionalResourceSuffix string = "ipv6"
+
+	// DualStackNetworkAccess is an identifier to describe the network access settings
+	// for dual stack infrastructure. IPv4 resources are default to an internal settings, but
+	// IPv6 resources require the identifier for ULAs.
+	DualStackNetworkAccess = "INTERNAL"
+
+	// GCPDualStack is the identifier used by GCP to indicate a dual stack infrastructure.
+	GCPDualStack = "IPV4_IPV6"
+)
+
 // NetworkSpec encapsulates all things related to a GCP network.
 type NetworkSpec struct {
 	// Name is the name of the network to be used.
@@ -363,6 +389,25 @@ type NetworkSpec struct {
 	// +kubebuilder:default:=64
 	// +optional
 	MinPortsPerVM int64 `json:"minPortsPerVm,omitempty"`
+
+	// Ipv6Address: An IPv6 internal network address for this network interface.
+	// To use a static internal IP address, it must be unused and in the same
+	// region as the instance's zone. If not specified, Google Cloud will
+	// automatically assign an internal IPv6 address from the instance's subnetwork.
+	// +optional
+	Ipv6Address string `json:"ipv6Address,omitempty"`
+
+	// StackType: The stackType for the subnets. If set to IPv4Only, new VMs in
+	// the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
+	// the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
+	// IPv4Only is used. This field can be both set at resource creation time and
+	// updated using patch.
+	// GCP allows subnet stack types to be set independently, but, for simplicity,
+	// all subnets in the network will be created with the same stackType.
+	//
+	// +kubebuilder:default=IPv4Only
+	// +optional
+	StackType StackType `json:"stackType,omitempty"`
 }
 
 // LoadBalancerType defines the Load Balancer that should be created.
@@ -457,21 +502,18 @@ type SubnetSpec struct {
 	// +optional
 	Purpose *string `json:"purpose,omitempty"`
 
-	// StackType: The stack type for the subnet. If set to IPV4_ONLY, new VMs in
-	// the subnet are assigned IPv4 addresses only. If set to IPV4_IPV6, new VMs in
+	// StackType: The stackType for the subnet. If set to IPv4Only, new VMs in
+	// the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
 	// the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
-	// IPV4_ONLY is used. This field can be both set at resource creation time and
+	// IPv4Only is used. This field can be both set at resource creation time and
 	// updated using patch.
 	//
-	// Possible values:
-	//   "IPV4_IPV6" - New VMs in this subnet can have both IPv4 and IPv6
-	// addresses.
-	//   "IPV4_ONLY" - New VMs in this subnet will only be assigned IPv4 addresses.
-	//   "IPV6_ONLY" - New VMs in this subnet will only be assigned IPv6 addresses.
-	// +kubebuilder:validation:Enum=IPV4_ONLY;IPV4_IPV6;IPV6_ONLY
-	// +kubebuilder:default=IPV4_ONLY
+	// NOT IMPLEMENTED: Stack type is currently set in the `NetworkSpec` and all
+	// subnets will have the same stack type.
+	//
+	// +kubebuilder:default=IPv4Only
 	// +optional
-	StackType string `json:"stackType,omitempty"`
+	StackType StackType `json:"stackType,omitempty"`
 }
 
 // String returns a string representation of the subnet.

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -61,6 +61,12 @@ type Network struct {
 	// +optional
 	APIServerAddress *string `json:"apiServerIpAddress,omitempty"`
 
+	// APIServerIPv6Address is the IPv6 global address assigned to the load balancer
+	// created for the API Server. This field is only applicable for dual stack
+	// configurations.
+	// +optional
+	APIServerIPv6Address *string `json:"apiServerIpv6Address,omitempty"`
+
 	// APIServerHealthCheck is the full reference to the health check
 	// created for the API Server.
 	// +optional
@@ -86,10 +92,22 @@ type Network struct {
 	// +optional
 	APIServerForwardingRule *string `json:"apiServerForwardingRule,omitempty"`
 
+	// APIServerIPv6ForwardingRule is the full reference to the IPv6 forwarding rule
+	// created for the API Server. This field is only applicable during dual stack
+	// configurations.
+	// +optional
+	APIServerIPv6ForwardingRule *string `json:"apiServerIpv6ForwardingRule,omitempty"`
+
 	// APIInternalAddress is the IPV4 regional address assigned to the
 	// internal Load Balancer.
 	// +optional
 	APIInternalAddress *string `json:"apiInternalIpAddress,omitempty"`
+
+	// APIInternalIPv6Address is the IPV6 regional address assigned to the
+	// internal Load Balancer. This field is only applicable for dual stack
+	// configurations.
+	// +optional
+	APIInternalIPv6Address *string `json:"apiInternalIpv6IpAddress,omitempty"`
 
 	// APIInternalHealthCheck is the full reference to the health check
 	// created for the internal Load Balancer.
@@ -105,6 +123,11 @@ type Network struct {
 	// created for the internal Load Balancer.
 	// +optional
 	APIInternalForwardingRule *string `json:"apiInternalForwardingRule,omitempty"`
+
+	// APIIPv6InternalForwardingRule is the full reference to the forwarding rule
+	// created for the internal IPv6 Load Balancer during dual stack configurations.
+	// +optional
+	APIIPv6InternalForwardingRule *string `json:"apiIpv6InternalForwardingRule,omitempty"`
 }
 
 // FirewallProtocol is a string enum type representing the IP Protocol for the firewall rule.
@@ -321,6 +344,18 @@ const (
 	DualStackType StackType = "DualStack"
 )
 
+// AddressPreferencePolicy is a string enum type indicating the preferred IP Address in a dual stack network configuration.
+// +kubebuilder:validation:Enum=IPv4Primary;IPv6Primary
+type AddressPreferencePolicy string
+
+const (
+	// IPv4Primary indicates a preference to use IPv4 addresses.
+	IPv4Primary AddressPreferencePolicy = "IPv4Primary"
+
+	// IPv6Primary indicates a preference to use IPv6 addresses.
+	IPv6Primary AddressPreferencePolicy = "IPv6Primary"
+)
+
 const (
 	// DualStackAdditionalResourceSuffix is an identifier appended to the resource name to indicate
 	// that it is not for the ipv4 [default] stack type.
@@ -408,6 +443,14 @@ type NetworkSpec struct {
 	// +kubebuilder:default=IPv4Only
 	// +optional
 	StackType StackType `json:"stackType,omitempty"`
+
+	// AddressPreferencePolicy: The AddressPreferencePolicy determines whether the
+	// IPv4 or IPv6 addresses should be preferred for load balancers. The value will
+	// also determine the address type in the APIEndpoint.
+	//
+	// +kubebuilder:default=IPv4Primary
+	// +optional
+	AddressPreferencePolicy AddressPreferencePolicy `json:"addressPreferencePolicy,omitempty"`
 }
 
 // LoadBalancerType defines the Load Balancer that should be created.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -934,6 +934,11 @@ func (in *Network) DeepCopyInto(out *Network) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.APIServerIPv6Address != nil {
+		in, out := &in.APIServerIPv6Address, &out.APIServerIPv6Address
+		*out = new(string)
+		**out = **in
+	}
 	if in.APIServerHealthCheck != nil {
 		in, out := &in.APIServerHealthCheck, &out.APIServerHealthCheck
 		*out = new(string)
@@ -961,8 +966,18 @@ func (in *Network) DeepCopyInto(out *Network) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.APIServerIPv6ForwardingRule != nil {
+		in, out := &in.APIServerIPv6ForwardingRule, &out.APIServerIPv6ForwardingRule
+		*out = new(string)
+		**out = **in
+	}
 	if in.APIInternalAddress != nil {
 		in, out := &in.APIInternalAddress, &out.APIInternalAddress
+		*out = new(string)
+		**out = **in
+	}
+	if in.APIInternalIPv6Address != nil {
+		in, out := &in.APIInternalIPv6Address, &out.APIInternalIPv6Address
 		*out = new(string)
 		**out = **in
 	}
@@ -978,6 +993,11 @@ func (in *Network) DeepCopyInto(out *Network) {
 	}
 	if in.APIInternalForwardingRule != nil {
 		in, out := &in.APIInternalForwardingRule, &out.APIInternalForwardingRule
+		*out = new(string)
+		**out = **in
+	}
+	if in.APIIPv6InternalForwardingRule != nil {
+		in, out := &in.APIIPv6InternalForwardingRule, &out.APIIPv6InternalForwardingRule
 		*out = new(string)
 		**out = **in
 	}

--- a/cloud/interfaces.go
+++ b/cloud/interfaces.go
@@ -68,6 +68,7 @@ type ClusterGetter interface {
 	ControlPlaneEndpoint() clusterv1.APIEndpoint
 	ResourceManagerTags() infrav1.ResourceManagerTags
 	LoadBalancer() infrav1.LoadBalancerSpec
+	Subnets() infrav1.Subnets
 }
 
 // ClusterSetter is an interface which can set cluster information.

--- a/cloud/interfaces.go
+++ b/cloud/interfaces.go
@@ -59,6 +59,8 @@ type ClusterGetter interface {
 	NetworkProject() string
 	IsSharedVpc() bool
 	SkipFirewallRulesManagement() bool
+	StackType() infrav1.StackType
+	Ipv6Address() string
 	Network() *infrav1.Network
 	AdditionalLabels() infrav1.Labels
 	FailureDomains() []string

--- a/cloud/interfaces.go
+++ b/cloud/interfaces.go
@@ -60,6 +60,7 @@ type ClusterGetter interface {
 	IsSharedVpc() bool
 	SkipFirewallRulesManagement() bool
 	StackType() infrav1.StackType
+	AddressPreferencePolicy() infrav1.AddressPreferencePolicy
 	Ipv6Address() string
 	Network() *infrav1.Network
 	AdditionalLabels() infrav1.Labels

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -321,6 +321,11 @@ func (s *ClusterScope) SubnetSpecs() []*compute.Subnetwork {
 			// IPv4 networks default to internal addresses. IPv6 does not, so
 			// access must be explicitly set to INTERNAL to enable ULAs.
 			subnet.Ipv6AccessType = infrav1.DualStackNetworkAccess
+
+			// If an IPv6 CIDR range is explicitly specified, use it
+			if subnetwork.Ipv6CidrRange != "" {
+				subnet.Ipv6CidrRange = subnetwork.Ipv6CidrRange
+			}
 		}
 
 		subnets = append(subnets, subnet)

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -19,6 +19,7 @@ package scope
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -116,6 +117,20 @@ func (s *ClusterScope) SkipFirewallRulesManagement() bool {
 // IsSharedVpc returns true If sharedVPC used else , returns false.
 func (s *ClusterScope) IsSharedVpc() bool {
 	return s.NetworkProject() != s.Project()
+}
+
+// StackType returns the network stack type for the cluster.
+func (s *ClusterScope) StackType() infrav1.StackType {
+	return s.GCPCluster.Spec.Network.StackType
+}
+
+// Ipv6Address returns the IPv6 address when one is provided in the spec and the cluster network is not IPv4 Only.
+func (s *ClusterScope) Ipv6Address() string {
+	address := ""
+	if s.StackType() != infrav1.IPv4OnlyStackType {
+		address = s.GCPCluster.Spec.Network.Ipv6Address
+	}
+	return address
 }
 
 // Region returns the cluster region.
@@ -241,6 +256,12 @@ func (s *ClusterScope) NetworkSpec() *compute.Network {
 		Mtu:                   s.NetworkMtu(),
 	}
 
+	if s.StackType() == infrav1.DualStackType {
+		// IPv6/Dual Stack networks will require ULAs, because the subnets are
+		// going to be set to INTERNAL Access
+		network.EnableUlaInternalIpv6 = true
+	}
+
 	return network
 }
 
@@ -265,12 +286,19 @@ func (s *ClusterScope) NatRouterSpec() *compute.Router {
 // SubnetSpecs returns google compute subnets spec.
 func (s *ClusterScope) SubnetSpecs() []*compute.Subnetwork {
 	subnets := []*compute.Subnetwork{}
+
+	stackType := "IPV4_ONLY"
+	if s.StackType() == infrav1.DualStackType {
+		stackType = infrav1.GCPDualStack
+	}
+
 	for _, subnetwork := range s.GCPCluster.Spec.Network.Subnets {
 		secondaryIPRanges := []*compute.SubnetworkSecondaryRange{}
 		for rangeName, secondaryCidrBlock := range subnetwork.SecondaryCidrBlocks {
 			secondaryIPRanges = append(secondaryIPRanges, &compute.SubnetworkSecondaryRange{RangeName: rangeName, IpCidrRange: secondaryCidrBlock})
 		}
-		subnets = append(subnets, &compute.Subnetwork{
+
+		subnet := &compute.Subnetwork{
 			Name:                  subnetwork.Name,
 			Region:                subnetwork.Region,
 			EnableFlowLogs:        ptr.Deref(subnetwork.EnableFlowLogs, false),
@@ -281,8 +309,16 @@ func (s *ClusterScope) SubnetSpecs() []*compute.Subnetwork {
 			Network:               s.NetworkLink(),
 			Purpose:               ptr.Deref(subnetwork.Purpose, "PRIVATE_RFC_1918"),
 			Role:                  "ACTIVE",
-			StackType:             subnetwork.StackType,
-		})
+			StackType:             stackType,
+		}
+
+		if s.StackType() == infrav1.DualStackType {
+			// IPv4 networks default to internal addresses. IPv6 does not, so
+			// access must be explicitly set to INTERNAL to enable ULAs.
+			subnet.Ipv6AccessType = infrav1.DualStackNetworkAccess
+		}
+
+		subnets = append(subnets, subnet)
 	}
 
 	return subnets
@@ -300,6 +336,35 @@ func (s *ClusterScope) FirewallRulesSpec() []*compute.Firewall {
 	)
 }
 
+// IPv6FirewallRulesSpec returns google compute firewall spec for ipv6 addresses.
+func (s *ClusterScope) IPv6FirewallRulesSpec() []*compute.Firewall {
+	firewallRules := []*compute.Firewall{
+		{
+			Name:    fmt.Sprintf("allow-%s-healthchecks-ipv6", s.Name()),
+			Network: s.NetworkLink(),
+			Allowed: []*compute.FirewallAllowed{
+				{
+					IPProtocol: "TCP",
+					Ports: []string{
+						strconv.FormatInt(6443, 10),
+					},
+				},
+			},
+			Direction: "INGRESS",
+			SourceRanges: []string{
+				// https://docs.cloud.google.com/load-balancing/docs/firewall-rules
+				"2600:2d00:1:b029::/64",
+				"2600:2d00:1:1::/64",
+			},
+			TargetTags: []string{
+				s.Name() + "-control-plane",
+			},
+		},
+	}
+
+	return firewallRules
+}
+
 // ANCHOR_END: ClusterFirewallSpec
 
 // ANCHOR: ClusterControlPlaneSpec
@@ -310,6 +375,15 @@ func (s *ClusterScope) AddressSpec(lbname string) *compute.Address {
 		Name:        fmt.Sprintf("%s-%s", s.Name(), lbname),
 		AddressType: "EXTERNAL",
 		IpVersion:   "IPV4",
+	}
+}
+
+// IPv6AddressSpec returns google compute IPv6 address spec.
+func (s *ClusterScope) IPv6AddressSpec(lbname string) *compute.Address {
+	return &compute.Address{
+		Name:        fmt.Sprintf("%s-%s-%s", s.Name(), lbname, infrav1.DualStackAdditionalResourceSuffix),
+		AddressType: "EXTERNAL",
+		IpVersion:   "IPV6",
 	}
 }
 
@@ -324,13 +398,14 @@ func (s *ClusterScope) BackendServiceSpec(lbname string) *compute.BackendService
 	}
 }
 
-// ForwardingRuleSpec returns google compute forwarding-rule spec.
+// ForwardingRuleSpec returns a google compute forwarding-rule spec.
 func (s *ClusterScope) ForwardingRuleSpec(lbname string) *compute.ForwardingRule {
 	port := int32(443)
 	if s.Cluster.Spec.ClusterNetwork.APIServerPort != 0 {
 		port = s.Cluster.Spec.ClusterNetwork.APIServerPort
 	}
 	portRange := fmt.Sprintf("%d-%d", port, port)
+
 	return &compute.ForwardingRule{
 		Name:                fmt.Sprintf("%s-%s", s.Name(), lbname),
 		IPProtocol:          "TCP",
@@ -340,7 +415,7 @@ func (s *ClusterScope) ForwardingRuleSpec(lbname string) *compute.ForwardingRule
 	}
 }
 
-// HealthCheckSpec returns google compute health-check spec.
+// HealthCheckSpec returns a google compute health-check spec.
 func (s *ClusterScope) HealthCheckSpec(lbname string) *compute.HealthCheck {
 	return &compute.HealthCheck{
 		Name: fmt.Sprintf("%s-%s", s.Name(), lbname),

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -124,6 +124,11 @@ func (s *ClusterScope) StackType() infrav1.StackType {
 	return s.GCPCluster.Spec.Network.StackType
 }
 
+// AddressPreferencePolicy returns the AddressPreferencePolicy for the cluster.
+func (s *ClusterScope) AddressPreferencePolicy() infrav1.AddressPreferencePolicy {
+	return s.GCPCluster.Spec.Network.AddressPreferencePolicy
+}
+
 // Ipv6Address returns the IPv6 address when one is provided in the spec and the cluster network is not IPv4 Only.
 func (s *ClusterScope) Ipv6Address() string {
 	address := ""

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -183,6 +183,11 @@ func (s *ClusterScope) Network() *infrav1.Network {
 	return &s.GCPCluster.Status.Network
 }
 
+// Subnets returns the cluster subnets configuration.
+func (s *ClusterScope) Subnets() infrav1.Subnets {
+	return s.GCPCluster.Spec.Network.Subnets
+}
+
 // AdditionalLabels returns the cluster additional labels.
 func (s *ClusterScope) AdditionalLabels() infrav1.Labels {
 	return s.GCPCluster.Spec.AdditionalLabels
@@ -318,9 +323,16 @@ func (s *ClusterScope) SubnetSpecs() []*compute.Subnetwork {
 		}
 
 		if s.StackType() == infrav1.DualStackType {
-			// IPv4 networks default to internal addresses. IPv6 does not, so
-			// access must be explicitly set to INTERNAL to enable ULAs.
-			subnet.Ipv6AccessType = infrav1.DualStackNetworkAccess
+			// Determine IPv6 access type based on subnet configuration
+			if ptr.Deref(subnetwork.ExternalIpv6, false) {
+				// External IPv6 - uses globally unique addresses (GUA)
+				// Allows instances to have public IPv6 addresses
+				subnet.Ipv6AccessType = "EXTERNAL"
+			} else {
+				// Internal IPv6 - uses ULA (Unique Local Address) ranges
+				// Required for internal load balancers
+				subnet.Ipv6AccessType = infrav1.DualStackNetworkAccess
+			}
 
 			// If an IPv6 CIDR range is explicitly specified, use it
 			if subnetwork.Ipv6CidrRange != "" {

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -19,6 +19,7 @@ package scope
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -122,6 +123,20 @@ func (s *ClusterScope) SkipFirewallRulesManagement() bool {
 // IsSharedVpc returns true If sharedVPC used else , returns false.
 func (s *ClusterScope) IsSharedVpc() bool {
 	return s.NetworkProject() != s.Project()
+}
+
+// StackType returns the network stack type for the cluster.
+func (s *ClusterScope) StackType() infrav1.StackType {
+	return s.GCPCluster.Spec.Network.StackType
+}
+
+// Ipv6Address returns the IPv6 address when one is provided in the spec and the cluster network is not IPv4 Only.
+func (s *ClusterScope) Ipv6Address() string {
+	address := ""
+	if s.StackType() != infrav1.IPv4OnlyStackType {
+		address = s.GCPCluster.Spec.Network.Ipv6Address
+	}
+	return address
 }
 
 // Region returns the cluster region.
@@ -247,6 +262,12 @@ func (s *ClusterScope) NetworkSpec() *compute.Network {
 		Mtu:                   s.NetworkMtu(),
 	}
 
+	if s.StackType() == infrav1.DualStackType {
+		// IPv6/Dual Stack networks will require ULAs, because the subnets are
+		// going to be set to INTERNAL Access
+		network.EnableUlaInternalIpv6 = true
+	}
+
 	return network
 }
 
@@ -271,12 +292,19 @@ func (s *ClusterScope) NatRouterSpec() *compute.Router {
 // SubnetSpecs returns google compute subnets spec.
 func (s *ClusterScope) SubnetSpecs() []*compute.Subnetwork {
 	subnets := make([]*compute.Subnetwork, 0, len(s.GCPCluster.Spec.Network.Subnets))
+
+	stackType := "IPV4_ONLY"
+	if s.StackType() == infrav1.DualStackType {
+		stackType = infrav1.GCPDualStack
+	}
+
 	for _, subnetwork := range s.GCPCluster.Spec.Network.Subnets {
 		secondaryIPRanges := make([]*compute.SubnetworkSecondaryRange, 0, len(subnetwork.SecondaryCidrBlocks))
 		for rangeName, secondaryCidrBlock := range subnetwork.SecondaryCidrBlocks {
 			secondaryIPRanges = append(secondaryIPRanges, &compute.SubnetworkSecondaryRange{RangeName: rangeName, IpCidrRange: secondaryCidrBlock})
 		}
-		subnets = append(subnets, &compute.Subnetwork{
+
+		subnet := &compute.Subnetwork{
 			Name:                  subnetwork.Name,
 			Region:                subnetwork.Region,
 			EnableFlowLogs:        ptr.Deref(subnetwork.EnableFlowLogs, false),
@@ -287,8 +315,16 @@ func (s *ClusterScope) SubnetSpecs() []*compute.Subnetwork {
 			Network:               s.NetworkLink(),
 			Purpose:               ptr.Deref(subnetwork.Purpose, "PRIVATE_RFC_1918"),
 			Role:                  "ACTIVE",
-			StackType:             subnetwork.StackType,
-		})
+			StackType:             stackType,
+		}
+
+		if s.StackType() == infrav1.DualStackType {
+			// IPv4 networks default to internal addresses. IPv6 does not, so
+			// access must be explicitly set to INTERNAL to enable ULAs.
+			subnet.Ipv6AccessType = infrav1.DualStackNetworkAccess
+		}
+
+		subnets = append(subnets, subnet)
 	}
 
 	return subnets
@@ -306,6 +342,35 @@ func (s *ClusterScope) FirewallRulesSpec() []*compute.Firewall {
 	)
 }
 
+// IPv6FirewallRulesSpec returns google compute firewall spec for ipv6 addresses.
+func (s *ClusterScope) IPv6FirewallRulesSpec() []*compute.Firewall {
+	firewallRules := []*compute.Firewall{
+		{
+			Name:    fmt.Sprintf("allow-%s-healthchecks-ipv6", s.Name()),
+			Network: s.NetworkLink(),
+			Allowed: []*compute.FirewallAllowed{
+				{
+					IPProtocol: "TCP",
+					Ports: []string{
+						strconv.FormatInt(6443, 10),
+					},
+				},
+			},
+			Direction: "INGRESS",
+			SourceRanges: []string{
+				// https://docs.cloud.google.com/load-balancing/docs/firewall-rules
+				"2600:2d00:1:b029::/64",
+				"2600:2d00:1:1::/64",
+			},
+			TargetTags: []string{
+				s.Name() + "-control-plane",
+			},
+		},
+	}
+
+	return firewallRules
+}
+
 // ANCHOR_END: ClusterFirewallSpec
 
 // ANCHOR: ClusterControlPlaneSpec
@@ -316,6 +381,15 @@ func (s *ClusterScope) AddressSpec(lbname string) *compute.Address {
 		Name:        fmt.Sprintf("%s-%s", s.Name(), lbname),
 		AddressType: loadBalanceTrafficExternal,
 		IpVersion:   "IPV4",
+	}
+}
+
+// IPv6AddressSpec returns google compute IPv6 address spec.
+func (s *ClusterScope) IPv6AddressSpec(lbname string) *compute.Address {
+	return &compute.Address{
+		Name:        fmt.Sprintf("%s-%s-%s", s.Name(), lbname, infrav1.DualStackAdditionalResourceSuffix),
+		AddressType: "EXTERNAL",
+		IpVersion:   "IPV6",
 	}
 }
 
@@ -330,13 +404,14 @@ func (s *ClusterScope) BackendServiceSpec(lbname string) *compute.BackendService
 	}
 }
 
-// ForwardingRuleSpec returns google compute forwarding-rule spec.
+// ForwardingRuleSpec returns a google compute forwarding-rule spec.
 func (s *ClusterScope) ForwardingRuleSpec(lbname string) *compute.ForwardingRule {
 	port := int32(443)
 	if s.Cluster.Spec.ClusterNetwork.APIServerPort != 0 {
 		port = s.Cluster.Spec.ClusterNetwork.APIServerPort
 	}
 	portRange := fmt.Sprintf("%d-%d", port, port)
+
 	return &compute.ForwardingRule{
 		Name:                fmt.Sprintf("%s-%s", s.Name(), lbname),
 		IPProtocol:          protocolTCP,
@@ -346,7 +421,7 @@ func (s *ClusterScope) ForwardingRuleSpec(lbname string) *compute.ForwardingRule
 	}
 }
 
-// HealthCheckSpec returns google compute health-check spec.
+// HealthCheckSpec returns a google compute health-check spec.
 func (s *ClusterScope) HealthCheckSpec(lbname string) *compute.HealthCheck {
 	return &compute.HealthCheck{
 		Name: fmt.Sprintf("%s-%s", s.Name(), lbname),

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -327,6 +327,11 @@ func (s *ClusterScope) SubnetSpecs() []*compute.Subnetwork {
 			// IPv4 networks default to internal addresses. IPv6 does not, so
 			// access must be explicitly set to INTERNAL to enable ULAs.
 			subnet.Ipv6AccessType = infrav1.DualStackNetworkAccess
+
+			// If an IPv6 CIDR range is explicitly specified, use it
+			if subnetwork.Ipv6CidrRange != "" {
+				subnet.Ipv6CidrRange = subnetwork.Ipv6CidrRange
+			}
 		}
 
 		subnets = append(subnets, subnet)

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -130,6 +130,11 @@ func (s *ClusterScope) StackType() infrav1.StackType {
 	return s.GCPCluster.Spec.Network.StackType
 }
 
+// AddressPreferencePolicy returns the AddressPreferencePolicy for the cluster.
+func (s *ClusterScope) AddressPreferencePolicy() infrav1.AddressPreferencePolicy {
+	return s.GCPCluster.Spec.Network.AddressPreferencePolicy
+}
+
 // Ipv6Address returns the IPv6 address when one is provided in the spec and the cluster network is not IPv4 Only.
 func (s *ClusterScope) Ipv6Address() string {
 	address := ""

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -189,6 +189,11 @@ func (s *ClusterScope) Network() *infrav1.Network {
 	return &s.GCPCluster.Status.Network
 }
 
+// Subnets returns the cluster subnets configuration.
+func (s *ClusterScope) Subnets() infrav1.Subnets {
+	return s.GCPCluster.Spec.Network.Subnets
+}
+
 // AdditionalLabels returns the cluster additional labels.
 func (s *ClusterScope) AdditionalLabels() infrav1.Labels {
 	return s.GCPCluster.Spec.AdditionalLabels
@@ -324,9 +329,16 @@ func (s *ClusterScope) SubnetSpecs() []*compute.Subnetwork {
 		}
 
 		if s.StackType() == infrav1.DualStackType {
-			// IPv4 networks default to internal addresses. IPv6 does not, so
-			// access must be explicitly set to INTERNAL to enable ULAs.
-			subnet.Ipv6AccessType = infrav1.DualStackNetworkAccess
+			// Determine IPv6 access type based on subnet configuration
+			if ptr.Deref(subnetwork.ExternalIpv6, false) {
+				// External IPv6 - uses globally unique addresses (GUA)
+				// Allows instances to have public IPv6 addresses
+				subnet.Ipv6AccessType = "EXTERNAL"
+			} else {
+				// Internal IPv6 - uses ULA (Unique Local Address) ranges
+				// Required for internal load balancers
+				subnet.Ipv6AccessType = infrav1.DualStackNetworkAccess
+			}
 
 			// If an IPv6 CIDR range is explicitly specified, use it
 			if subnetwork.Ipv6CidrRange != "" {

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -331,6 +331,8 @@ func InstanceNetworkInterfaceSpec(cluster cloud.ClusterGetter, publicIP *bool, s
 		Network: path.Join("projects", cluster.NetworkProject(), "global", "networks", cluster.NetworkName()),
 	}
 
+	ipv6AccessType := infrav1.DualStackNetworkAccess
+
 	if publicIP != nil && *publicIP {
 		networkInterface.AccessConfigs = []*compute.AccessConfig{
 			{
@@ -338,6 +340,28 @@ func InstanceNetworkInterfaceSpec(cluster cloud.ClusterGetter, publicIP *bool, s
 				Name: "External NAT",
 			},
 		}
+
+		// For now we cannot assign the IPv6AccessConfigs. The bootstrap node is the only one on our side
+		// that would be using this, but others may have different configurations.
+		// Issue: We set the subnets to internal so this external configuration will fail. The subnets (IPv6) are set
+		// to internal so that the internal load balancer address creation will complete.
+		// What we see: Error 400: Invalid value for field 'resource.networkInterfaces[0].ipv6AccessConfigs': ''.
+		//				IPv6 access config is not supported for this network interface.
+		// if cluster.StackType() == infrav1.DualStackType {
+		//	ipv6AccessType = "EXTERNAL"
+		//	networkInterface.Ipv6AccessConfigs = []*compute.AccessConfig{
+		//		{
+		//			Type: "DIRECT_IPV6",
+		//			Name: "External IPv6",
+		//		},
+		//	}
+		// }
+	}
+
+	if cluster.StackType() == infrav1.DualStackType {
+		networkInterface.Ipv6AccessType = ipv6AccessType
+		networkInterface.Ipv6Address = cluster.Ipv6Address()
+		networkInterface.StackType = infrav1.GCPDualStack
 	}
 
 	if subnet != nil {
@@ -509,6 +533,10 @@ func (m *MachineScope) InstanceSpec(log logr.Logger) *compute.Instance {
 	instance.GuestAccelerators = instanceGuestAcceleratorsSpec(m.GCPMachine.Spec.GuestAccelerators)
 	if len(instance.GuestAccelerators) > 0 {
 		instance.Scheduling.OnHostMaintenance = onHostMaintenanceTerminate
+	}
+
+	if m.ClusterGetter.StackType() == infrav1.DualStackType {
+		instance.PrivateIpv6GoogleAccess = "INHERIT_FROM_SUBNETWORK"
 	}
 
 	return instance

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -331,9 +331,23 @@ func InstanceNetworkInterfaceSpec(cluster cloud.ClusterGetter, publicIP *bool, s
 		Network: path.Join("projects", cluster.NetworkProject(), "global", "networks", cluster.NetworkName()),
 	}
 
+	// Determine if this subnet has external IPv6 access enabled
+	hasExternalIpv6 := false
+	if subnet != nil && cluster.StackType() == infrav1.DualStackType {
+		subnetSpec := cluster.Subnets().FindByName(*subnet)
+		if subnetSpec != nil {
+			hasExternalIpv6 = ptr.Deref(subnetSpec.ExternalIpv6, false)
+		}
+	}
+
+	// Determine IPv6 access type based on subnet configuration
 	ipv6AccessType := infrav1.DualStackNetworkAccess
+	if hasExternalIpv6 {
+		ipv6AccessType = "EXTERNAL"
+	}
 
 	if publicIP != nil && *publicIP {
+		// IPv4 public access
 		networkInterface.AccessConfigs = []*compute.AccessConfig{
 			{
 				Type: "ONE_TO_ONE_NAT",
@@ -341,21 +355,15 @@ func InstanceNetworkInterfaceSpec(cluster cloud.ClusterGetter, publicIP *bool, s
 			},
 		}
 
-		// For now we cannot assign the IPv6AccessConfigs. The bootstrap node is the only one on our side
-		// that would be using this, but others may have different configurations.
-		// Issue: We set the subnets to internal so this external configuration will fail. The subnets (IPv6) are set
-		// to internal so that the internal load balancer address creation will complete.
-		// What we see: Error 400: Invalid value for field 'resource.networkInterfaces[0].ipv6AccessConfigs': ''.
-		//				IPv6 access config is not supported for this network interface.
-		// if cluster.StackType() == infrav1.DualStackType {
-		//	ipv6AccessType = "EXTERNAL"
-		//	networkInterface.Ipv6AccessConfigs = []*compute.AccessConfig{
-		//		{
-		//			Type: "DIRECT_IPV6",
-		//			Name: "External IPv6",
-		//		},
-		//	}
-		// }
+		// IPv6 public access - only available on subnets with external IPv6 enabled
+		if cluster.StackType() == infrav1.DualStackType && hasExternalIpv6 {
+			networkInterface.Ipv6AccessConfigs = []*compute.AccessConfig{
+				{
+					Type: "DIRECT_IPV6",
+					Name: "External IPv6",
+				},
+			}
+		}
 	}
 
 	if cluster.StackType() == infrav1.DualStackType {

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -331,6 +331,8 @@ func InstanceNetworkInterfaceSpec(cluster cloud.ClusterGetter, publicIP *bool, s
 		Network: path.Join("projects", cluster.NetworkProject(), "global", "networks", cluster.NetworkName()),
 	}
 
+	ipv6AccessType := infrav1.DualStackNetworkAccess
+
 	if publicIP != nil && *publicIP {
 		networkInterface.AccessConfigs = []*compute.AccessConfig{
 			{
@@ -338,6 +340,28 @@ func InstanceNetworkInterfaceSpec(cluster cloud.ClusterGetter, publicIP *bool, s
 				Name: "External NAT",
 			},
 		}
+
+		// For now we cannot assign the IPv6AccessConfigs. The bootstrap node is the only one on our side
+		// that would be using this, but others may have different configurations.
+		// Issue: We set the subnets to internal so this external configuration will fail. The subnets (IPv6) are set
+		// to internal so that the internal load balancer address creation will complete.
+		// What we see: Error 400: Invalid value for field 'resource.networkInterfaces[0].ipv6AccessConfigs': ''.
+		//				IPv6 access config is not supported for this network interface.
+		// if cluster.StackType() == infrav1.DualStackType {
+		//	ipv6AccessType = "EXTERNAL"
+		//	networkInterface.Ipv6AccessConfigs = []*compute.AccessConfig{
+		//		{
+		//			Type: "DIRECT_IPV6",
+		//			Name: "External IPv6",
+		//		},
+		//	}
+		// }
+	}
+
+	if cluster.StackType() == infrav1.DualStackType {
+		networkInterface.Ipv6AccessType = ipv6AccessType
+		networkInterface.Ipv6Address = cluster.Ipv6Address()
+		networkInterface.StackType = infrav1.GCPDualStack
 	}
 
 	if subnet != nil {
@@ -507,6 +531,10 @@ func (m *MachineScope) InstanceSpec(ctx context.Context, log logr.Logger) *compu
 	instance.GuestAccelerators = instanceGuestAcceleratorsSpec(m.GCPMachine.Spec.GuestAccelerators)
 	if len(instance.GuestAccelerators) > 0 {
 		instance.Scheduling.OnHostMaintenance = onHostMaintenanceTerminate
+	}
+
+	if m.ClusterGetter.StackType() == infrav1.DualStackType {
+		instance.PrivateIpv6GoogleAccess = "INHERIT_FROM_SUBNETWORK"
 	}
 
 	return instance

--- a/cloud/scope/managedcluster.go
+++ b/cloud/scope/managedcluster.go
@@ -141,6 +141,20 @@ func (s *ManagedClusterScope) IsSharedVpc() bool {
 	return s.NetworkProject() != s.Project()
 }
 
+// StackType returns the network stack type for the cluster.
+func (s *ManagedClusterScope) StackType() infrav1.StackType {
+	return s.GCPManagedCluster.Spec.Network.StackType
+}
+
+// Ipv6Address returns the IPv6 address when one is provided in the spec and the cluster network is not IPv4 Only.
+func (s *ManagedClusterScope) Ipv6Address() string {
+	address := ""
+	if s.StackType() != infrav1.IPv4OnlyStackType {
+		address = s.GCPManagedCluster.Spec.Network.Ipv6Address
+	}
+	return address
+}
+
 // NetworkLink returns the partial URL for the network.
 func (s *ManagedClusterScope) NetworkLink() string {
 	return fmt.Sprintf("projects/%s/global/networks/%s", s.NetworkProject(), s.NetworkName())
@@ -227,6 +241,12 @@ func (s *ManagedClusterScope) NetworkSpec() *compute.Network {
 		ForceSendFields:       []string{"AutoCreateSubnetworks"},
 	}
 
+	if s.StackType() == infrav1.DualStackType {
+		// IPv6/Dual Stack networks will require ULAs, because the subnets are
+		// going to be set to INTERNAL Access
+		network.EnableUlaInternalIpv6 = true
+	}
+
 	return network
 }
 
@@ -251,12 +271,19 @@ func (s *ManagedClusterScope) NatRouterSpec() *compute.Router {
 // SubnetSpecs returns google compute subnets spec.
 func (s *ManagedClusterScope) SubnetSpecs() []*compute.Subnetwork {
 	subnets := []*compute.Subnetwork{}
+
+	stackType := "IPV4_ONLY"
+	if s.StackType() == infrav1.DualStackType {
+		stackType = infrav1.GCPDualStack
+	}
+
 	for _, subnetwork := range s.GCPManagedCluster.Spec.Network.Subnets {
 		secondaryIPRanges := []*compute.SubnetworkSecondaryRange{}
 		for rangeName, secondaryCidrBlock := range subnetwork.SecondaryCidrBlocks {
 			secondaryIPRanges = append(secondaryIPRanges, &compute.SubnetworkSecondaryRange{RangeName: rangeName, IpCidrRange: secondaryCidrBlock})
 		}
-		subnets = append(subnets, &compute.Subnetwork{
+
+		subnet := &compute.Subnetwork{
 			Name:                  subnetwork.Name,
 			Region:                subnetwork.Region,
 			EnableFlowLogs:        ptr.Deref(subnetwork.EnableFlowLogs, false),
@@ -267,8 +294,16 @@ func (s *ManagedClusterScope) SubnetSpecs() []*compute.Subnetwork {
 			Network:               s.NetworkLink(),
 			Purpose:               ptr.Deref(subnetwork.Purpose, "PRIVATE_RFC_1918"),
 			Role:                  "ACTIVE",
-			StackType:             subnetwork.StackType,
-		})
+			StackType:             stackType,
+		}
+
+		if s.StackType() == infrav1.DualStackType {
+			// IPv4 networks default to internal addresses. IPv6 does not, so
+			// access must be explicitly set to INTERNAL to enable ULAs.
+			subnet.Ipv6AccessType = infrav1.DualStackNetworkAccess
+		}
+
+		subnets = append(subnets, subnet)
 	}
 
 	return subnets
@@ -284,6 +319,35 @@ func (s *ManagedClusterScope) FirewallRulesSpec() []*compute.Firewall {
 		s.GCPManagedCluster.Spec.Network.Firewall.DefaultRulesManagement,
 		s.GCPManagedCluster.Spec.Network.Firewall.FirewallRules,
 	)
+}
+
+// IPv6FirewallRulesSpec returns google compute firewall spec for ipv6 addresses.
+func (s *ManagedClusterScope) IPv6FirewallRulesSpec() []*compute.Firewall {
+	firewallRules := []*compute.Firewall{
+		{
+			Name:    fmt.Sprintf("allow-%s-healthchecks-ipv6", s.Name()),
+			Network: s.NetworkLink(),
+			Allowed: []*compute.FirewallAllowed{
+				{
+					IPProtocol: "TCP",
+					Ports: []string{
+						strconv.FormatInt(6443, 10),
+					},
+				},
+			},
+			Direction: "INGRESS",
+			SourceRanges: []string{
+				// https://docs.cloud.google.com/load-balancing/docs/firewall-rules
+				"2600:2d00:1:b029::/64",
+				"2600:2d00:1:1::/64",
+			},
+			TargetTags: []string{
+				s.Name() + "-control-plane",
+			},
+		},
+	}
+
+	return firewallRules
 }
 
 // ANCHOR_END: ClusterFirewallSpec

--- a/cloud/scope/managedcluster.go
+++ b/cloud/scope/managedcluster.go
@@ -171,6 +171,11 @@ func (s *ManagedClusterScope) Network() *infrav1.Network {
 	return &s.GCPManagedCluster.Status.Network
 }
 
+// Subnets returns the cluster subnets configuration.
+func (s *ManagedClusterScope) Subnets() infrav1.Subnets {
+	return s.GCPManagedCluster.Spec.Network.Subnets
+}
+
 // AdditionalLabels returns the cluster additional labels.
 func (s *ManagedClusterScope) AdditionalLabels() infrav1.Labels {
 	return s.GCPManagedCluster.Spec.AdditionalLabels
@@ -304,9 +309,16 @@ func (s *ManagedClusterScope) SubnetSpecs() []*compute.Subnetwork {
 		}
 
 		if s.StackType() == infrav1.DualStackType {
-			// IPv4 networks default to internal addresses. IPv6 does not, so
-			// access must be explicitly set to INTERNAL to enable ULAs.
-			subnet.Ipv6AccessType = infrav1.DualStackNetworkAccess
+			// Determine IPv6 access type based on subnet configuration
+			if ptr.Deref(subnetwork.ExternalIpv6, false) {
+				// External IPv6 - uses globally unique addresses (GUA)
+				// Allows instances to have public IPv6 addresses
+				subnet.Ipv6AccessType = "EXTERNAL"
+			} else {
+				// Internal IPv6 - uses ULA (Unique Local Address) ranges
+				// Required for internal load balancers
+				subnet.Ipv6AccessType = infrav1.DualStackNetworkAccess
+			}
 
 			// If an IPv6 CIDR range is explicitly specified, use it
 			if subnetwork.Ipv6CidrRange != "" {

--- a/cloud/scope/managedcluster.go
+++ b/cloud/scope/managedcluster.go
@@ -307,6 +307,11 @@ func (s *ManagedClusterScope) SubnetSpecs() []*compute.Subnetwork {
 			// IPv4 networks default to internal addresses. IPv6 does not, so
 			// access must be explicitly set to INTERNAL to enable ULAs.
 			subnet.Ipv6AccessType = infrav1.DualStackNetworkAccess
+
+			// If an IPv6 CIDR range is explicitly specified, use it
+			if subnetwork.Ipv6CidrRange != "" {
+				subnet.Ipv6CidrRange = subnetwork.Ipv6CidrRange
+			}
 		}
 
 		subnets = append(subnets, subnet)

--- a/cloud/scope/managedcluster.go
+++ b/cloud/scope/managedcluster.go
@@ -146,6 +146,11 @@ func (s *ManagedClusterScope) StackType() infrav1.StackType {
 	return s.GCPManagedCluster.Spec.Network.StackType
 }
 
+// AddressPreferencePolicy returns the AddressPreferencePolicy for the cluster.
+func (s *ManagedClusterScope) AddressPreferencePolicy() infrav1.AddressPreferencePolicy {
+	return s.GCPManagedCluster.Spec.Network.AddressPreferencePolicy
+}
+
 // Ipv6Address returns the IPv6 address when one is provided in the spec and the cluster network is not IPv4 Only.
 func (s *ManagedClusterScope) Ipv6Address() string {
 	address := ""

--- a/cloud/scope/managedcluster.go
+++ b/cloud/scope/managedcluster.go
@@ -19,6 +19,7 @@ package scope
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"google.golang.org/api/compute/v1"

--- a/cloud/scope/managedcluster.go
+++ b/cloud/scope/managedcluster.go
@@ -147,6 +147,11 @@ func (s *ManagedClusterScope) StackType() infrav1.StackType {
 	return s.GCPManagedCluster.Spec.Network.StackType
 }
 
+// AddressPreferencePolicy returns the AddressPreferencePolicy for the cluster.
+func (s *ManagedClusterScope) AddressPreferencePolicy() infrav1.AddressPreferencePolicy {
+	return s.GCPManagedCluster.Spec.Network.AddressPreferencePolicy
+}
+
 // Ipv6Address returns the IPv6 address when one is provided in the spec and the cluster network is not IPv4 Only.
 func (s *ManagedClusterScope) Ipv6Address() string {
 	address := ""

--- a/cloud/scope/managedcluster.go
+++ b/cloud/scope/managedcluster.go
@@ -19,6 +19,7 @@ package scope
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"google.golang.org/api/compute/v1"
@@ -141,6 +142,20 @@ func (s *ManagedClusterScope) IsSharedVpc() bool {
 	return s.NetworkProject() != s.Project()
 }
 
+// StackType returns the network stack type for the cluster.
+func (s *ManagedClusterScope) StackType() infrav1.StackType {
+	return s.GCPManagedCluster.Spec.Network.StackType
+}
+
+// Ipv6Address returns the IPv6 address when one is provided in the spec and the cluster network is not IPv4 Only.
+func (s *ManagedClusterScope) Ipv6Address() string {
+	address := ""
+	if s.StackType() != infrav1.IPv4OnlyStackType {
+		address = s.GCPManagedCluster.Spec.Network.Ipv6Address
+	}
+	return address
+}
+
 // NetworkLink returns the partial URL for the network.
 func (s *ManagedClusterScope) NetworkLink() string {
 	return fmt.Sprintf("projects/%s/global/networks/%s", s.NetworkProject(), s.NetworkName())
@@ -227,6 +242,12 @@ func (s *ManagedClusterScope) NetworkSpec() *compute.Network {
 		ForceSendFields:       []string{"AutoCreateSubnetworks"},
 	}
 
+	if s.StackType() == infrav1.DualStackType {
+		// IPv6/Dual Stack networks will require ULAs, because the subnets are
+		// going to be set to INTERNAL Access
+		network.EnableUlaInternalIpv6 = true
+	}
+
 	return network
 }
 
@@ -251,12 +272,19 @@ func (s *ManagedClusterScope) NatRouterSpec() *compute.Router {
 // SubnetSpecs returns google compute subnets spec.
 func (s *ManagedClusterScope) SubnetSpecs() []*compute.Subnetwork {
 	subnets := make([]*compute.Subnetwork, 0, len(s.GCPManagedCluster.Spec.Network.Subnets))
+
+	stackType := "IPV4_ONLY"
+	if s.StackType() == infrav1.DualStackType {
+		stackType = infrav1.GCPDualStack
+	}
+
 	for _, subnetwork := range s.GCPManagedCluster.Spec.Network.Subnets {
 		secondaryIPRanges := make([]*compute.SubnetworkSecondaryRange, 0, len(subnetwork.SecondaryCidrBlocks))
 		for rangeName, secondaryCidrBlock := range subnetwork.SecondaryCidrBlocks {
 			secondaryIPRanges = append(secondaryIPRanges, &compute.SubnetworkSecondaryRange{RangeName: rangeName, IpCidrRange: secondaryCidrBlock})
 		}
-		subnets = append(subnets, &compute.Subnetwork{
+
+		subnet := &compute.Subnetwork{
 			Name:                  subnetwork.Name,
 			Region:                subnetwork.Region,
 			EnableFlowLogs:        ptr.Deref(subnetwork.EnableFlowLogs, false),
@@ -267,8 +295,16 @@ func (s *ManagedClusterScope) SubnetSpecs() []*compute.Subnetwork {
 			Network:               s.NetworkLink(),
 			Purpose:               ptr.Deref(subnetwork.Purpose, "PRIVATE_RFC_1918"),
 			Role:                  "ACTIVE",
-			StackType:             subnetwork.StackType,
-		})
+			StackType:             stackType,
+		}
+
+		if s.StackType() == infrav1.DualStackType {
+			// IPv4 networks default to internal addresses. IPv6 does not, so
+			// access must be explicitly set to INTERNAL to enable ULAs.
+			subnet.Ipv6AccessType = infrav1.DualStackNetworkAccess
+		}
+
+		subnets = append(subnets, subnet)
 	}
 
 	return subnets
@@ -284,6 +320,35 @@ func (s *ManagedClusterScope) FirewallRulesSpec() []*compute.Firewall {
 		s.GCPManagedCluster.Spec.Network.Firewall.DefaultRulesManagement,
 		s.GCPManagedCluster.Spec.Network.Firewall.FirewallRules,
 	)
+}
+
+// IPv6FirewallRulesSpec returns google compute firewall spec for ipv6 addresses.
+func (s *ManagedClusterScope) IPv6FirewallRulesSpec() []*compute.Firewall {
+	firewallRules := []*compute.Firewall{
+		{
+			Name:    fmt.Sprintf("allow-%s-healthchecks-ipv6", s.Name()),
+			Network: s.NetworkLink(),
+			Allowed: []*compute.FirewallAllowed{
+				{
+					IPProtocol: "TCP",
+					Ports: []string{
+						strconv.FormatInt(6443, 10),
+					},
+				},
+			},
+			Direction: "INGRESS",
+			SourceRanges: []string{
+				// https://docs.cloud.google.com/load-balancing/docs/firewall-rules
+				"2600:2d00:1:b029::/64",
+				"2600:2d00:1:1::/64",
+			},
+			TargetTags: []string{
+				s.Name() + "-control-plane",
+			},
+		},
+	}
+
+	return firewallRules
 }
 
 // ANCHOR_END: ClusterFirewallSpec

--- a/cloud/services/compute/firewalls/reconcile.go
+++ b/cloud/services/compute/firewalls/reconcile.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud/gcperrors"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -33,7 +34,13 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		return nil
 	}
 	log.Info("Reconciling firewall resources")
-	for _, spec := range s.scope.FirewallRulesSpec() {
+
+	firewallRules := s.scope.FirewallRulesSpec()
+	if s.scope.StackType() == infrav1.DualStackType {
+		firewallRules = append(firewallRules, s.scope.IPv6FirewallRulesSpec()...)
+	}
+
+	for _, spec := range firewallRules {
 		log.V(2).Info("Looking firewall", "name", spec.Name)
 		firewallKey := meta.GlobalKey(spec.Name)
 		if _, err := s.firewalls.Get(ctx, firewallKey); err != nil {
@@ -59,7 +66,13 @@ func (s *Service) Delete(ctx context.Context) error {
 		return nil
 	}
 	log.Info("Deleting firewall resources")
-	for _, spec := range s.scope.FirewallRulesSpec() {
+
+	firewallRules := s.scope.FirewallRulesSpec()
+	if s.scope.StackType() == infrav1.DualStackType {
+		firewallRules = append(firewallRules, s.scope.IPv6FirewallRulesSpec()...)
+	}
+
+	for _, spec := range firewallRules {
 		log.V(2).Info("Deleting firewall", "name", spec.Name)
 		firewallKey := meta.GlobalKey(spec.Name)
 		if err := s.firewalls.Delete(ctx, firewallKey); err != nil {

--- a/cloud/services/compute/firewalls/service.go
+++ b/cloud/services/compute/firewalls/service.go
@@ -37,6 +37,7 @@ type firewallsInterface interface {
 type Scope interface {
 	cloud.ClusterGetter
 	FirewallRulesSpec() []*compute.Firewall
+	IPv6FirewallRulesSpec() []*compute.Firewall
 }
 
 // Service implements firewalls reconciler.

--- a/cloud/services/compute/instances/reconcile_test.go
+++ b/cloud/services/compute/instances/reconcile_test.go
@@ -119,6 +119,20 @@ var fakeGCPCluster = &infrav1.GCPCluster{
 	},
 }
 
+var fakeGCPClusterIpv6 = &infrav1.GCPCluster{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "my-cluster",
+		Namespace: "default",
+	},
+	Spec: infrav1.GCPClusterSpec{
+		Project: "my-proj",
+		Region:  "us-central1",
+		Network: infrav1.NetworkSpec{
+			StackType: infrav1.DualStackType,
+		},
+	},
+}
+
 func getFakeGCPMachine() *infrav1.GCPMachine {
 	return &infrav1.GCPMachine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -154,11 +168,33 @@ func TestService_createOrGetInstance(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	clusterScopeIpv6, err := scope.NewClusterScope(context.TODO(), scope.ClusterScopeParams{
+		Client:     fakec,
+		Cluster:    fakeCluster,
+		GCPCluster: fakeGCPClusterIpv6,
+		GCPServices: scope.GCPServices{
+			Compute: &compute.Service{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	machineScope, err := scope.NewMachineScope(scope.MachineScopeParams{
 		Client:        fakec,
 		Machine:       fakeMachine,
 		GCPMachine:    fakeGCPMachine,
 		ClusterGetter: clusterScope,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machineScopeIpv6, err := scope.NewMachineScope(scope.MachineScopeParams{
+		Client:        fakec,
+		Machine:       fakeMachine,
+		GCPMachine:    fakeGCPMachine,
+		ClusterGetter: clusterScopeIpv6,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1071,6 +1107,73 @@ func TestService_createOrGetInstance(t *testing.T) {
 				},
 				SelfLink:   "https://www.googleapis.com/compute/v1/projects/proj-id/zones/us-central1-c/instances/my-machine",
 				Scheduling: &compute.Scheduling{},
+				ServiceAccounts: []*compute.ServiceAccount{
+					{
+						Email:  "default",
+						Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
+					},
+				},
+				Tags: &compute.Tags{
+					Items: []string{
+						"my-cluster-node",
+						"my-cluster",
+					},
+				},
+				Zone: "us-central1-c",
+			},
+		},
+		{
+			name:  "ipv6 instance does not exist (should create instance)",
+			scope: func() Scope { return machineScopeIpv6 },
+			mockInstance: &cloud.MockInstances{
+				ProjectRouter: &cloud.SingleProjectRouter{ID: "proj-id"},
+				Objects:       map[meta.Key]*cloud.MockInstancesObj{},
+			},
+			want: &compute.Instance{
+				Name:         "my-machine",
+				CanIpForward: true,
+				Disks: []*compute.AttachedDisk{
+					{
+						AutoDelete: true,
+						Boot:       true,
+						InitializeParams: &compute.AttachedDiskInitializeParams{
+							DiskType:            "zones/us-central1-c/diskTypes/pd-standard",
+							SourceImage:         "projects/my-proj/global/images/family/capi-ubuntu-1804-k8s-v1-19",
+							ResourceManagerTags: map[string]string{},
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+				Labels: map[string]string{
+					"capg-role":               "node",
+					"capg-cluster-my-cluster": "owned",
+					"foo":                     "bar",
+				},
+				MachineType: "zones/us-central1-c/machineTypes",
+				Metadata: &compute.Metadata{
+					Items: []*compute.MetadataItems{
+						{
+							Key:   "user-data",
+							Value: ptr.To[string]("Zm9vCg=="),
+						},
+					},
+				},
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{
+						Network:        "projects/my-proj/global/networks/default",
+						Ipv6AccessType: "INTERNAL", // default, this was not overridden with a public ip address set.
+						Ipv6Address:    "",
+						StackType:      infrav1.GCPDualStack,
+					},
+				},
+				Params: &compute.InstanceParams{
+					ResourceManagerTags: map[string]string{},
+				},
+				PrivateIpv6GoogleAccess: "INHERIT_FROM_SUBNETWORK",
+				SelfLink:                "https://www.googleapis.com/compute/v1/projects/proj-id/zones/us-central1-c/instances/my-machine",
+				Scheduling:              &compute.Scheduling{},
 				ServiceAccounts: []*compute.ServiceAccount{
 					{
 						Email:  "default",

--- a/cloud/services/compute/loadbalancers/reconcile.go
+++ b/cloud/services/compute/loadbalancers/reconcile.go
@@ -225,7 +225,6 @@ func (s *Service) createExternalLoadBalancer(ctx context.Context, lbType infrav1
 	s.scope.Network().APIServerAddress = ptr.To[string](addr.SelfLink)
 	// For now the ip address/host for the control plane endpoint will always be the IPv4 Address
 	endpoint.Host = addr.Address
-	s.scope.SetControlPlaneEndpoint(endpoint)
 
 	forwardingrule, err := s.createOrGetForwardingRule(ctx, name, target, addr)
 	if err != nil {
@@ -234,20 +233,24 @@ func (s *Service) createExternalLoadBalancer(ctx context.Context, lbType infrav1
 	// For now the forwarding rule associated with IPv4 address will always be set as the API Server Forwarding Rule
 	s.scope.Network().APIServerForwardingRule = ptr.To[string](forwardingrule.SelfLink)
 
-	// Not sure what to do below yet but this will create the ipv6 address and the forwarding rule.
 	if s.scope.StackType() == infrav1.DualStackType {
-		// This ip address will need to be provided back in the status
 		ipv6Addr, err := s.createOrGetIPv6Address(ctx, name)
 		if err != nil {
 			return err
 		}
+		s.scope.Network().APIServerIPv6Address = ptr.To[string](ipv6Addr.SelfLink)
+		if s.scope.AddressPreferencePolicy() == infrav1.IPv6Primary {
+			endpoint.Host = ipv6Addr.Address
+		}
 
-		// This should be saved to s.scope.Network().APIServerIPv6ForwardingRule
-		_, err = s.createOrGetForwardingRule(ctx, name+"-ipv6", target, ipv6Addr)
+		ipv6ForwardingRule, err := s.createOrGetForwardingRule(ctx, name+"-ipv6", target, ipv6Addr)
 		if err != nil {
 			return err
 		}
+		s.scope.Network().APIServerIPv6ForwardingRule = ptr.To[string](ipv6ForwardingRule.SelfLink)
 	}
+
+	s.scope.SetControlPlaneEndpoint(endpoint)
 
 	return nil
 }
@@ -279,12 +282,8 @@ func (s *Service) createInternalLoadBalancer(ctx context.Context, name string, l
 		return err
 	}
 	s.scope.Network().APIInternalAddress = ptr.To[string](addr.SelfLink)
-	if lbType == infrav1.Internal {
-		// If only creating an internal Load Balancer, set the control plane endpoint
-		endpoint := s.scope.ControlPlaneEndpoint()
-		endpoint.Host = addr.Address
-		s.scope.SetControlPlaneEndpoint(endpoint)
-	}
+	endpoint := s.scope.ControlPlaneEndpoint()
+	endpoint.Host = addr.Address
 
 	// Create a regional forwarding rule to the backend service
 	forwardingrule, err := s.createOrGetRegionalForwardingRule(ctx, name, backendsvc, addr)
@@ -294,17 +293,25 @@ func (s *Service) createInternalLoadBalancer(ctx context.Context, name string, l
 	s.scope.Network().APIInternalForwardingRule = ptr.To[string](forwardingrule.SelfLink)
 
 	if s.scope.StackType() == infrav1.DualStackType {
-		// This ip address will need to be provided back in the status
 		ipv6Addr, err := s.createOrGetInternalIPv6Address(ctx, name)
 		if err != nil {
 			return err
 		}
+		s.scope.Network().APIInternalIPv6Address = ptr.To[string](ipv6Addr.SelfLink)
+		if s.scope.AddressPreferencePolicy() == infrav1.IPv6Primary {
+			endpoint.Host = ipv6Addr.Address
+		}
 
-		// This should be saved to s.scope.Network().APIInternalIPv6ForwardingRule
-		_, err = s.createOrGetRegionalForwardingRule(ctx, name+"-ipv6", backendsvc, ipv6Addr)
+		ipv6ForwardingRule, err := s.createOrGetRegionalForwardingRule(ctx, name+"-ipv6", backendsvc, ipv6Addr)
 		if err != nil {
 			return err
 		}
+		s.scope.Network().APIIPv6InternalForwardingRule = ptr.To[string](ipv6ForwardingRule.SelfLink)
+	}
+
+	// If only creating an internal Load Balancer, set the control plane endpoint
+	if lbType == infrav1.Internal {
+		s.scope.SetControlPlaneEndpoint(endpoint)
 	}
 
 	return nil

--- a/cloud/services/compute/loadbalancers/reconcile.go
+++ b/cloud/services/compute/loadbalancers/reconcile.go
@@ -138,6 +138,16 @@ func (s *Service) deleteExternalLoadBalancer(ctx context.Context) error {
 	}
 	s.scope.Network().APIServerHealthCheck = nil
 
+	if s.scope.StackType() == infrav1.DualStackType {
+		if err := s.deleteForwardingRule(ctx, name+"-ipv6"); err != nil {
+			return fmt.Errorf("deleting ForwardingRule: %w", err)
+		}
+
+		if err := s.deleteAddress(ctx, name+"-ipv6"); err != nil {
+			return fmt.Errorf("deleting Address: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -163,6 +173,16 @@ func (s *Service) deleteInternalLoadBalancer(ctx context.Context, name string) e
 		return fmt.Errorf("deleting RegionalHealthCheck: %w", err)
 	}
 	s.scope.Network().APIInternalHealthCheck = nil
+
+	if s.scope.StackType() == infrav1.DualStackType {
+		if err := s.deleteForwardingRule(ctx, name+"-ipv6"); err != nil {
+			return fmt.Errorf("deleting ForwardingRule: %w", err)
+		}
+
+		if err := s.deleteAddress(ctx, name+"-ipv6"); err != nil {
+			return fmt.Errorf("deleting Address: %w", err)
+		}
+	}
 
 	return nil
 }
@@ -200,16 +220,34 @@ func (s *Service) createExternalLoadBalancer(ctx context.Context, lbType infrav1
 	if err != nil {
 		return err
 	}
-	s.scope.Network().APIServerAddress = ptr.To[string](addr.SelfLink)
+
 	endpoint := s.scope.ControlPlaneEndpoint()
+	s.scope.Network().APIServerAddress = ptr.To[string](addr.SelfLink)
+	// For now the ip address/host for the control plane endpoint will always be the IPv4 Address
 	endpoint.Host = addr.Address
 	s.scope.SetControlPlaneEndpoint(endpoint)
 
-	forwarding, err := s.createOrGetForwardingRule(ctx, name, target, addr)
+	forwardingrule, err := s.createOrGetForwardingRule(ctx, name, target, addr)
 	if err != nil {
 		return err
 	}
-	s.scope.Network().APIServerForwardingRule = ptr.To[string](forwarding.SelfLink)
+	// For now the forwarding rule associated with IPv4 address will always be set as the API Server Forwarding Rule
+	s.scope.Network().APIServerForwardingRule = ptr.To[string](forwardingrule.SelfLink)
+
+	// Not sure what to do below yet but this will create the ipv6 address and the forwarding rule.
+	if s.scope.StackType() == infrav1.DualStackType {
+		// This ip address will need to be provided back in the status
+		ipv6Addr, err := s.createOrGetIPv6Address(ctx, name)
+		if err != nil {
+			return err
+		}
+
+		// This should be saved to s.scope.Network().APIServerIPv6ForwardingRule
+		_, err = s.createOrGetForwardingRule(ctx, name+"-ipv6", target, ipv6Addr)
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -221,6 +259,7 @@ func (s *Service) createInternalLoadBalancer(ctx context.Context, name string, l
 	if err != nil {
 		return err
 	}
+
 	s.scope.Network().APIInternalHealthCheck = ptr.To[string](healthcheck.SelfLink)
 
 	backendsvc, err := s.createOrGetRegionalBackendService(ctx, name, instancegroups, healthcheck)
@@ -228,6 +267,11 @@ func (s *Service) createInternalLoadBalancer(ctx context.Context, name string, l
 		return err
 	}
 	s.scope.Network().APIInternalBackendService = ptr.To[string](backendsvc.SelfLink)
+
+	// During Dual Stack installations, an IPv4 and IPv6 address should be made available
+	// to the frontends and then connected to the backends to create the load balancer.
+	// An internal load balancer will only use an IPv4 Address, and the
+	// IpAddressSelectionPolicy cannot be set to PREFER_IPV6.
 
 	// Create an address on internal subnet.
 	addr, err := s.createOrGetInternalAddress(ctx, name)
@@ -243,11 +287,25 @@ func (s *Service) createInternalLoadBalancer(ctx context.Context, name string, l
 	}
 
 	// Create a regional forwarding rule to the backend service
-	forwarding, err := s.createOrGetRegionalForwardingRule(ctx, name, backendsvc, addr)
+	forwardingrule, err := s.createOrGetRegionalForwardingRule(ctx, name, backendsvc, addr)
 	if err != nil {
 		return err
 	}
-	s.scope.Network().APIInternalForwardingRule = ptr.To[string](forwarding.SelfLink)
+	s.scope.Network().APIInternalForwardingRule = ptr.To[string](forwardingrule.SelfLink)
+
+	if s.scope.StackType() == infrav1.DualStackType {
+		// This ip address will need to be provided back in the status
+		ipv6Addr, err := s.createOrGetInternalIPv6Address(ctx, name)
+		if err != nil {
+			return err
+		}
+
+		// This should be saved to s.scope.Network().APIInternalIPv6ForwardingRule
+		_, err = s.createOrGetRegionalForwardingRule(ctx, name+"-ipv6", backendsvc, ipv6Addr)
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -315,7 +373,6 @@ func (s *Service) createOrGetHealthCheck(ctx context.Context, lbname string) (*c
 			return nil, err
 		}
 	}
-
 	return healthcheck, nil
 }
 
@@ -343,7 +400,6 @@ func (s *Service) createOrGetRegionalHealthCheck(ctx context.Context, lbname str
 			return nil, err
 		}
 	}
-
 	return healthcheck, nil
 }
 
@@ -486,6 +542,7 @@ func (s *Service) createOrGetTargetTCPProxy(ctx context.Context, service *comput
 func (s *Service) createOrGetAddress(ctx context.Context, lbname string) (*compute.Address, error) {
 	log := log.FromContext(ctx)
 	addrSpec := s.scope.AddressSpec(lbname)
+
 	log.V(2).Info("Looking for address", "name", addrSpec.Name)
 	key := meta.GlobalKey(addrSpec.Name)
 	addr, err := s.addresses.Get(ctx, key)
@@ -506,7 +563,37 @@ func (s *Service) createOrGetAddress(ctx context.Context, lbname string) (*compu
 			return nil, err
 		}
 	}
+	return addr, nil
+}
 
+// createOrGetIPv6Address is used to obtain a Global IPv6 address.
+func (s *Service) createOrGetIPv6Address(ctx context.Context, lbname string) (*compute.Address, error) {
+	log := log.FromContext(ctx)
+	addrSpec := s.scope.IPv6AddressSpec(lbname)
+	// When the IPv6EndpointType is set, the address is interpreted as EXTERNAL no
+	// matter what the AddressType is set to.
+	addrSpec.Ipv6EndpointType = "NETLB"
+
+	log.V(2).Info("Looking for address", "name", addrSpec.Name)
+	key := meta.GlobalKey(addrSpec.Name)
+	addr, err := s.addresses.Get(ctx, key)
+	if err != nil {
+		if !gcperrors.IsNotFound(err) {
+			log.Error(err, "Error looking for address", "name", addrSpec.Name)
+			return nil, err
+		}
+
+		log.V(2).Info("Creating an address", "name", addrSpec.Name)
+		if err := s.addresses.Insert(ctx, key, addrSpec); err != nil {
+			log.Error(err, "Error creating an address", "name", addrSpec.Name)
+			return nil, err
+		}
+
+		addr, err = s.addresses.Get(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return addr, nil
 }
 
@@ -514,6 +601,7 @@ func (s *Service) createOrGetAddress(ctx context.Context, lbname string) (*compu
 func (s *Service) createOrGetInternalAddress(ctx context.Context, lbname string) (*compute.Address, error) {
 	log := log.FromContext(ctx)
 	addrSpec := s.scope.AddressSpec(lbname)
+
 	addrSpec.AddressType = string(loadBalanceTrafficInternal)
 	addrSpec.Region = s.scope.Region()
 	subnet, err := s.getSubnet(ctx)
@@ -548,14 +636,53 @@ func (s *Service) createOrGetInternalAddress(ctx context.Context, lbname string)
 			return nil, err
 		}
 	}
-
 	return addr, nil
 }
 
-// createOrGetForwardingRule is used obtain a Global ForwardingRule.
+// createOrGetInternalIPv6Address is used to obtain an internal IPv6 address.
+func (s *Service) createOrGetInternalIPv6Address(ctx context.Context, lbname string) (*compute.Address, error) {
+	log := log.FromContext(ctx)
+	addrSpec := s.scope.IPv6AddressSpec(lbname)
+
+	addrSpec.AddressType = string(loadBalanceTrafficInternal)
+	addrSpec.Region = s.scope.Region()
+	subnet, err := s.getSubnet(ctx)
+	if err != nil {
+		log.Error(err, "Error getting subnet for Internal Load Balancer")
+		return nil, err
+	}
+
+	addrSpec.Subnetwork = subnet.SelfLink
+	addrSpec.Purpose = "GCE_ENDPOINT"
+
+	log.V(2).Info("Looking for internal address", "name", addrSpec.Name)
+	key := meta.RegionalKey(addrSpec.Name, s.scope.Region())
+	addr, err := s.internaladdresses.Get(ctx, key)
+	if err != nil {
+		if !gcperrors.IsNotFound(err) {
+			log.Error(err, "Error looking for internal address", "name", addrSpec.Name)
+			return nil, err
+		}
+
+		log.V(2).Info("Creating an internal address", "name", addrSpec.Name)
+		if err := s.internaladdresses.Insert(ctx, key, addrSpec); err != nil {
+			log.Error(err, "Error creating an internal address", "name", addrSpec.Name)
+			return nil, err
+		}
+
+		addr, err = s.internaladdresses.Get(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return addr, nil
+}
+
+// createOrGetForwardingRule is used to obtain a Global ForwardingRule.
 func (s *Service) createOrGetForwardingRule(ctx context.Context, lbname string, target *compute.TargetTcpProxy, addr *compute.Address) (*compute.ForwardingRule, error) {
 	log := log.FromContext(ctx)
 	spec := s.scope.ForwardingRuleSpec(lbname)
+
 	spec.Target = target.SelfLink
 	spec.IPAddress = addr.SelfLink
 
@@ -622,6 +749,7 @@ func (s *Service) createOrGetRegionalForwardingRule(ctx context.Context, lbname 
 	}
 	spec.Subnetwork = subnet.SelfLink
 	spec.IPAddress = addr.SelfLink
+	spec.IpVersion = addr.IpVersion
 
 	key := meta.RegionalKey(spec.Name, s.scope.Region())
 	log.V(2).Info("Looking for regional forwardingrule", "name", spec.Name)
@@ -668,7 +796,6 @@ func (s *Service) deleteForwardingRule(ctx context.Context, lbname string) error
 		log.Error(err, "Error updating a forwardingrule", "name", spec.Name)
 		return err
 	}
-
 	return nil
 }
 
@@ -681,7 +808,6 @@ func (s *Service) deleteRegionalForwardingRule(ctx context.Context, lbname strin
 		log.Error(err, "Error updating a regional forwardingrule", "name", spec.Name)
 		return err
 	}
-
 	return nil
 }
 
@@ -693,7 +819,6 @@ func (s *Service) deleteAddress(ctx context.Context, lbname string) error {
 	if err := s.addresses.Delete(ctx, key); err != nil && !gcperrors.IsNotFound(err) {
 		return err
 	}
-
 	return nil
 }
 
@@ -705,7 +830,6 @@ func (s *Service) deleteInternalAddress(ctx context.Context, lbname string) erro
 	if err := s.internaladdresses.Delete(ctx, key); err != nil && !gcperrors.IsNotFound(err) {
 		return err
 	}
-
 	return nil
 }
 
@@ -757,7 +881,6 @@ func (s *Service) deleteHealthCheck(ctx context.Context, lbname string) error {
 		log.Error(err, "Error deleting a healthcheck", "name", spec.Name)
 		return err
 	}
-
 	return nil
 }
 
@@ -770,7 +893,6 @@ func (s *Service) deleteRegionalHealthCheck(ctx context.Context, lbname string) 
 		log.Error(err, "Error deleting a regional healthcheck", "name", spec.Name)
 		return err
 	}
-
 	return nil
 }
 

--- a/cloud/services/compute/loadbalancers/reconcile.go
+++ b/cloud/services/compute/loadbalancers/reconcile.go
@@ -450,7 +450,23 @@ func (s *Service) createOrGetBackendService(ctx context.Context, lbname string, 
 		}
 	}
 
-	if len(backendsvc.Backends) != len(backendsvcSpec.Backends) {
+	// Check if backends need updating by comparing both count and actual backend references
+	backendsChanged := len(backendsvc.Backends) != len(backendsvcSpec.Backends)
+	if !backendsChanged && len(backendsvc.Backends) > 0 {
+		// If counts match, compare the actual instance group references
+		existingGroups := make(map[string]bool)
+		for _, be := range backendsvc.Backends {
+			existingGroups[be.Group] = true
+		}
+		for _, be := range backendsvcSpec.Backends {
+			if !existingGroups[be.Group] {
+				backendsChanged = true
+				break
+			}
+		}
+	}
+
+	if backendsChanged {
 		log.V(2).Info("Updating a backendservice", "name", backendsvcSpec.Name)
 		backendsvc.Backends = backendsvcSpec.Backends
 		if err := s.backendservices.Update(ctx, key, backendsvc); err != nil {
@@ -506,7 +522,23 @@ func (s *Service) createOrGetRegionalBackendService(ctx context.Context, lbname 
 		}
 	}
 
-	if len(backendsvc.Backends) != len(backendsvcSpec.Backends) {
+	// Check if backends need updating by comparing both count and actual backend references
+	backendsChanged := len(backendsvc.Backends) != len(backendsvcSpec.Backends)
+	if !backendsChanged && len(backendsvc.Backends) > 0 {
+		// If counts match, compare the actual instance group references
+		existingGroups := make(map[string]bool)
+		for _, be := range backendsvc.Backends {
+			existingGroups[be.Group] = true
+		}
+		for _, be := range backendsvcSpec.Backends {
+			if !existingGroups[be.Group] {
+				backendsChanged = true
+				break
+			}
+		}
+	}
+
+	if backendsChanged {
 		log.V(2).Info("Updating a regional backendservice", "name", backendsvcSpec.Name)
 		backendsvc.Backends = backendsvcSpec.Backends
 		if err := s.regionalbackendservices.Update(ctx, key, backendsvc); err != nil {

--- a/cloud/services/compute/loadbalancers/reconcile.go
+++ b/cloud/services/compute/loadbalancers/reconcile.go
@@ -451,7 +451,23 @@ func (s *Service) createOrGetBackendService(ctx context.Context, lbname string, 
 		}
 	}
 
-	if len(backendsvc.Backends) != len(backendsvcSpec.Backends) {
+	// Check if backends need updating by comparing both count and actual backend references
+	backendsChanged := len(backendsvc.Backends) != len(backendsvcSpec.Backends)
+	if !backendsChanged && len(backendsvc.Backends) > 0 {
+		// If counts match, compare the actual instance group references
+		existingGroups := make(map[string]bool)
+		for _, be := range backendsvc.Backends {
+			existingGroups[be.Group] = true
+		}
+		for _, be := range backendsvcSpec.Backends {
+			if !existingGroups[be.Group] {
+				backendsChanged = true
+				break
+			}
+		}
+	}
+
+	if backendsChanged {
 		log.V(2).Info("Updating a backendservice", "name", backendsvcSpec.Name)
 		backendsvc.Backends = backendsvcSpec.Backends
 		if err := s.backendservices.Update(ctx, key, backendsvc); err != nil {
@@ -507,7 +523,23 @@ func (s *Service) createOrGetRegionalBackendService(ctx context.Context, lbname 
 		}
 	}
 
-	if len(backendsvc.Backends) != len(backendsvcSpec.Backends) {
+	// Check if backends need updating by comparing both count and actual backend references
+	backendsChanged := len(backendsvc.Backends) != len(backendsvcSpec.Backends)
+	if !backendsChanged && len(backendsvc.Backends) > 0 {
+		// If counts match, compare the actual instance group references
+		existingGroups := make(map[string]bool)
+		for _, be := range backendsvc.Backends {
+			existingGroups[be.Group] = true
+		}
+		for _, be := range backendsvcSpec.Backends {
+			if !existingGroups[be.Group] {
+				backendsChanged = true
+				break
+			}
+		}
+	}
+
+	if backendsChanged {
 		log.V(2).Info("Updating a regional backendservice", "name", backendsvcSpec.Name)
 		backendsvc.Backends = backendsvcSpec.Backends
 		if err := s.regionalbackendservices.Update(ctx, key, backendsvc); err != nil {

--- a/cloud/services/compute/loadbalancers/reconcile.go
+++ b/cloud/services/compute/loadbalancers/reconcile.go
@@ -139,6 +139,16 @@ func (s *Service) deleteExternalLoadBalancer(ctx context.Context) error {
 	}
 	s.scope.Network().APIServerHealthCheck = nil
 
+	if s.scope.StackType() == infrav1.DualStackType {
+		if err := s.deleteForwardingRule(ctx, name+"-ipv6"); err != nil {
+			return fmt.Errorf("deleting ForwardingRule: %w", err)
+		}
+
+		if err := s.deleteAddress(ctx, name+"-ipv6"); err != nil {
+			return fmt.Errorf("deleting Address: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -164,6 +174,16 @@ func (s *Service) deleteInternalLoadBalancer(ctx context.Context, name string) e
 		return fmt.Errorf("deleting RegionalHealthCheck: %w", err)
 	}
 	s.scope.Network().APIInternalHealthCheck = nil
+
+	if s.scope.StackType() == infrav1.DualStackType {
+		if err := s.deleteForwardingRule(ctx, name+"-ipv6"); err != nil {
+			return fmt.Errorf("deleting ForwardingRule: %w", err)
+		}
+
+		if err := s.deleteAddress(ctx, name+"-ipv6"); err != nil {
+			return fmt.Errorf("deleting Address: %w", err)
+		}
+	}
 
 	return nil
 }
@@ -201,16 +221,34 @@ func (s *Service) createExternalLoadBalancer(ctx context.Context, lbType infrav1
 	if err != nil {
 		return err
 	}
-	s.scope.Network().APIServerAddress = ptr.To[string](addr.SelfLink)
+
 	endpoint := s.scope.ControlPlaneEndpoint()
+	s.scope.Network().APIServerAddress = ptr.To[string](addr.SelfLink)
+	// For now the ip address/host for the control plane endpoint will always be the IPv4 Address
 	endpoint.Host = addr.Address
 	s.scope.SetControlPlaneEndpoint(endpoint)
 
-	forwarding, err := s.createOrGetForwardingRule(ctx, name, target, addr)
+	forwardingrule, err := s.createOrGetForwardingRule(ctx, name, target, addr)
 	if err != nil {
 		return err
 	}
-	s.scope.Network().APIServerForwardingRule = ptr.To[string](forwarding.SelfLink)
+	// For now the forwarding rule associated with IPv4 address will always be set as the API Server Forwarding Rule
+	s.scope.Network().APIServerForwardingRule = ptr.To[string](forwardingrule.SelfLink)
+
+	// Not sure what to do below yet but this will create the ipv6 address and the forwarding rule.
+	if s.scope.StackType() == infrav1.DualStackType {
+		// This ip address will need to be provided back in the status
+		ipv6Addr, err := s.createOrGetIPv6Address(ctx, name)
+		if err != nil {
+			return err
+		}
+
+		// This should be saved to s.scope.Network().APIServerIPv6ForwardingRule
+		_, err = s.createOrGetForwardingRule(ctx, name+"-ipv6", target, ipv6Addr)
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -222,6 +260,7 @@ func (s *Service) createInternalLoadBalancer(ctx context.Context, name string, l
 	if err != nil {
 		return err
 	}
+
 	s.scope.Network().APIInternalHealthCheck = ptr.To[string](healthcheck.SelfLink)
 
 	backendsvc, err := s.createOrGetRegionalBackendService(ctx, name, instancegroups, healthcheck)
@@ -229,6 +268,11 @@ func (s *Service) createInternalLoadBalancer(ctx context.Context, name string, l
 		return err
 	}
 	s.scope.Network().APIInternalBackendService = ptr.To[string](backendsvc.SelfLink)
+
+	// During Dual Stack installations, an IPv4 and IPv6 address should be made available
+	// to the frontends and then connected to the backends to create the load balancer.
+	// An internal load balancer will only use an IPv4 Address, and the
+	// IpAddressSelectionPolicy cannot be set to PREFER_IPV6.
 
 	// Create an address on internal subnet.
 	addr, err := s.createOrGetInternalAddress(ctx, name)
@@ -244,11 +288,25 @@ func (s *Service) createInternalLoadBalancer(ctx context.Context, name string, l
 	}
 
 	// Create a regional forwarding rule to the backend service
-	forwarding, err := s.createOrGetRegionalForwardingRule(ctx, name, backendsvc, addr)
+	forwardingrule, err := s.createOrGetRegionalForwardingRule(ctx, name, backendsvc, addr)
 	if err != nil {
 		return err
 	}
-	s.scope.Network().APIInternalForwardingRule = ptr.To[string](forwarding.SelfLink)
+	s.scope.Network().APIInternalForwardingRule = ptr.To[string](forwardingrule.SelfLink)
+
+	if s.scope.StackType() == infrav1.DualStackType {
+		// This ip address will need to be provided back in the status
+		ipv6Addr, err := s.createOrGetInternalIPv6Address(ctx, name)
+		if err != nil {
+			return err
+		}
+
+		// This should be saved to s.scope.Network().APIInternalIPv6ForwardingRule
+		_, err = s.createOrGetRegionalForwardingRule(ctx, name+"-ipv6", backendsvc, ipv6Addr)
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -316,7 +374,6 @@ func (s *Service) createOrGetHealthCheck(ctx context.Context, lbname string) (*c
 			return nil, err
 		}
 	}
-
 	return healthcheck, nil
 }
 
@@ -344,7 +401,6 @@ func (s *Service) createOrGetRegionalHealthCheck(ctx context.Context, lbname str
 			return nil, err
 		}
 	}
-
 	return healthcheck, nil
 }
 
@@ -487,6 +543,7 @@ func (s *Service) createOrGetTargetTCPProxy(ctx context.Context, service *comput
 func (s *Service) createOrGetAddress(ctx context.Context, lbname string) (*compute.Address, error) {
 	log := log.FromContext(ctx)
 	addrSpec := s.scope.AddressSpec(lbname)
+
 	log.V(2).Info("Looking for address", "name", addrSpec.Name)
 	key := meta.GlobalKey(addrSpec.Name)
 	addr, err := s.addresses.Get(ctx, key)
@@ -507,7 +564,37 @@ func (s *Service) createOrGetAddress(ctx context.Context, lbname string) (*compu
 			return nil, err
 		}
 	}
+	return addr, nil
+}
 
+// createOrGetIPv6Address is used to obtain a Global IPv6 address.
+func (s *Service) createOrGetIPv6Address(ctx context.Context, lbname string) (*compute.Address, error) {
+	log := log.FromContext(ctx)
+	addrSpec := s.scope.IPv6AddressSpec(lbname)
+	// When the IPv6EndpointType is set, the address is interpreted as EXTERNAL no
+	// matter what the AddressType is set to.
+	addrSpec.Ipv6EndpointType = "NETLB"
+
+	log.V(2).Info("Looking for address", "name", addrSpec.Name)
+	key := meta.GlobalKey(addrSpec.Name)
+	addr, err := s.addresses.Get(ctx, key)
+	if err != nil {
+		if !gcperrors.IsNotFound(err) {
+			log.Error(err, "Error looking for address", "name", addrSpec.Name)
+			return nil, err
+		}
+
+		log.V(2).Info("Creating an address", "name", addrSpec.Name)
+		if err := s.addresses.Insert(ctx, key, addrSpec); err != nil {
+			log.Error(err, "Error creating an address", "name", addrSpec.Name)
+			return nil, err
+		}
+
+		addr, err = s.addresses.Get(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return addr, nil
 }
 
@@ -515,6 +602,7 @@ func (s *Service) createOrGetAddress(ctx context.Context, lbname string) (*compu
 func (s *Service) createOrGetInternalAddress(ctx context.Context, lbname string) (*compute.Address, error) {
 	log := log.FromContext(ctx)
 	addrSpec := s.scope.AddressSpec(lbname)
+
 	addrSpec.AddressType = string(loadBalanceTrafficInternal)
 	addrSpec.Region = s.scope.Region()
 	subnet, err := s.getSubnet(ctx)
@@ -549,14 +637,53 @@ func (s *Service) createOrGetInternalAddress(ctx context.Context, lbname string)
 			return nil, err
 		}
 	}
-
 	return addr, nil
 }
 
-// createOrGetForwardingRule is used obtain a Global ForwardingRule.
+// createOrGetInternalIPv6Address is used to obtain an internal IPv6 address.
+func (s *Service) createOrGetInternalIPv6Address(ctx context.Context, lbname string) (*compute.Address, error) {
+	log := log.FromContext(ctx)
+	addrSpec := s.scope.IPv6AddressSpec(lbname)
+
+	addrSpec.AddressType = string(loadBalanceTrafficInternal)
+	addrSpec.Region = s.scope.Region()
+	subnet, err := s.getSubnet(ctx)
+	if err != nil {
+		log.Error(err, "Error getting subnet for Internal Load Balancer")
+		return nil, err
+	}
+
+	addrSpec.Subnetwork = subnet.SelfLink
+	addrSpec.Purpose = "GCE_ENDPOINT"
+
+	log.V(2).Info("Looking for internal address", "name", addrSpec.Name)
+	key := meta.RegionalKey(addrSpec.Name, s.scope.Region())
+	addr, err := s.internaladdresses.Get(ctx, key)
+	if err != nil {
+		if !gcperrors.IsNotFound(err) {
+			log.Error(err, "Error looking for internal address", "name", addrSpec.Name)
+			return nil, err
+		}
+
+		log.V(2).Info("Creating an internal address", "name", addrSpec.Name)
+		if err := s.internaladdresses.Insert(ctx, key, addrSpec); err != nil {
+			log.Error(err, "Error creating an internal address", "name", addrSpec.Name)
+			return nil, err
+		}
+
+		addr, err = s.internaladdresses.Get(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return addr, nil
+}
+
+// createOrGetForwardingRule is used to obtain a Global ForwardingRule.
 func (s *Service) createOrGetForwardingRule(ctx context.Context, lbname string, target *compute.TargetTcpProxy, addr *compute.Address) (*compute.ForwardingRule, error) {
 	log := log.FromContext(ctx)
 	spec := s.scope.ForwardingRuleSpec(lbname)
+
 	spec.Target = target.SelfLink
 	spec.IPAddress = addr.SelfLink
 
@@ -622,6 +749,7 @@ func (s *Service) createOrGetRegionalForwardingRule(ctx context.Context, lbname 
 	}
 	spec.Subnetwork = subnet.SelfLink
 	spec.IPAddress = addr.SelfLink
+	spec.IpVersion = addr.IpVersion
 
 	key := meta.RegionalKey(spec.Name, s.scope.Region())
 	log.V(2).Info("Looking for regional forwardingrule", "name", spec.Name)
@@ -668,7 +796,6 @@ func (s *Service) deleteForwardingRule(ctx context.Context, lbname string) error
 		log.Error(err, "Error updating a forwardingrule", "name", spec.Name)
 		return err
 	}
-
 	return nil
 }
 
@@ -681,7 +808,6 @@ func (s *Service) deleteRegionalForwardingRule(ctx context.Context, lbname strin
 		log.Error(err, "Error updating a regional forwardingrule", "name", spec.Name)
 		return err
 	}
-
 	return nil
 }
 
@@ -693,7 +819,6 @@ func (s *Service) deleteAddress(ctx context.Context, lbname string) error {
 	if err := s.addresses.Delete(ctx, key); err != nil && !gcperrors.IsNotFound(err) {
 		return err
 	}
-
 	return nil
 }
 
@@ -705,7 +830,6 @@ func (s *Service) deleteInternalAddress(ctx context.Context, lbname string) erro
 	if err := s.internaladdresses.Delete(ctx, key); err != nil && !gcperrors.IsNotFound(err) {
 		return err
 	}
-
 	return nil
 }
 
@@ -757,7 +881,6 @@ func (s *Service) deleteHealthCheck(ctx context.Context, lbname string) error {
 		log.Error(err, "Error deleting a healthcheck", "name", spec.Name)
 		return err
 	}
-
 	return nil
 }
 
@@ -770,7 +893,6 @@ func (s *Service) deleteRegionalHealthCheck(ctx context.Context, lbname string) 
 		log.Error(err, "Error deleting a regional healthcheck", "name", spec.Name)
 		return err
 	}
-
 	return nil
 }
 

--- a/cloud/services/compute/loadbalancers/reconcile.go
+++ b/cloud/services/compute/loadbalancers/reconcile.go
@@ -226,7 +226,6 @@ func (s *Service) createExternalLoadBalancer(ctx context.Context, lbType infrav1
 	s.scope.Network().APIServerAddress = ptr.To[string](addr.SelfLink)
 	// For now the ip address/host for the control plane endpoint will always be the IPv4 Address
 	endpoint.Host = addr.Address
-	s.scope.SetControlPlaneEndpoint(endpoint)
 
 	forwardingrule, err := s.createOrGetForwardingRule(ctx, name, target, addr)
 	if err != nil {
@@ -235,20 +234,24 @@ func (s *Service) createExternalLoadBalancer(ctx context.Context, lbType infrav1
 	// For now the forwarding rule associated with IPv4 address will always be set as the API Server Forwarding Rule
 	s.scope.Network().APIServerForwardingRule = ptr.To[string](forwardingrule.SelfLink)
 
-	// Not sure what to do below yet but this will create the ipv6 address and the forwarding rule.
 	if s.scope.StackType() == infrav1.DualStackType {
-		// This ip address will need to be provided back in the status
 		ipv6Addr, err := s.createOrGetIPv6Address(ctx, name)
 		if err != nil {
 			return err
 		}
+		s.scope.Network().APIServerIPv6Address = ptr.To[string](ipv6Addr.SelfLink)
+		if s.scope.AddressPreferencePolicy() == infrav1.IPv6Primary {
+			endpoint.Host = ipv6Addr.Address
+		}
 
-		// This should be saved to s.scope.Network().APIServerIPv6ForwardingRule
-		_, err = s.createOrGetForwardingRule(ctx, name+"-ipv6", target, ipv6Addr)
+		ipv6ForwardingRule, err := s.createOrGetForwardingRule(ctx, name+"-ipv6", target, ipv6Addr)
 		if err != nil {
 			return err
 		}
+		s.scope.Network().APIServerIPv6ForwardingRule = ptr.To[string](ipv6ForwardingRule.SelfLink)
 	}
+
+	s.scope.SetControlPlaneEndpoint(endpoint)
 
 	return nil
 }
@@ -280,12 +283,8 @@ func (s *Service) createInternalLoadBalancer(ctx context.Context, name string, l
 		return err
 	}
 	s.scope.Network().APIInternalAddress = ptr.To[string](addr.SelfLink)
-	if lbType == infrav1.Internal {
-		// If only creating an internal Load Balancer, set the control plane endpoint
-		endpoint := s.scope.ControlPlaneEndpoint()
-		endpoint.Host = addr.Address
-		s.scope.SetControlPlaneEndpoint(endpoint)
-	}
+	endpoint := s.scope.ControlPlaneEndpoint()
+	endpoint.Host = addr.Address
 
 	// Create a regional forwarding rule to the backend service
 	forwardingrule, err := s.createOrGetRegionalForwardingRule(ctx, name, backendsvc, addr)
@@ -295,17 +294,25 @@ func (s *Service) createInternalLoadBalancer(ctx context.Context, name string, l
 	s.scope.Network().APIInternalForwardingRule = ptr.To[string](forwardingrule.SelfLink)
 
 	if s.scope.StackType() == infrav1.DualStackType {
-		// This ip address will need to be provided back in the status
 		ipv6Addr, err := s.createOrGetInternalIPv6Address(ctx, name)
 		if err != nil {
 			return err
 		}
+		s.scope.Network().APIInternalIPv6Address = ptr.To[string](ipv6Addr.SelfLink)
+		if s.scope.AddressPreferencePolicy() == infrav1.IPv6Primary {
+			endpoint.Host = ipv6Addr.Address
+		}
 
-		// This should be saved to s.scope.Network().APIInternalIPv6ForwardingRule
-		_, err = s.createOrGetRegionalForwardingRule(ctx, name+"-ipv6", backendsvc, ipv6Addr)
+		ipv6ForwardingRule, err := s.createOrGetRegionalForwardingRule(ctx, name+"-ipv6", backendsvc, ipv6Addr)
 		if err != nil {
 			return err
 		}
+		s.scope.Network().APIIPv6InternalForwardingRule = ptr.To[string](ipv6ForwardingRule.SelfLink)
+	}
+
+	// If only creating an internal Load Balancer, set the control plane endpoint
+	if lbType == infrav1.Internal {
+		s.scope.SetControlPlaneEndpoint(endpoint)
 	}
 
 	return nil

--- a/cloud/services/compute/loadbalancers/reconcile_test.go
+++ b/cloud/services/compute/loadbalancers/reconcile_test.go
@@ -897,3 +897,145 @@ func TestService_createOrGetRegionalForwardingRule(t *testing.T) {
 		})
 	}
 }
+
+const (
+	exampleIPv4Addr = "192.0.2.1"
+	exampleIPv6Addr = "2001:db8::1"
+)
+
+func TestService_AddressPreferencePolicy(t *testing.T) {
+	tests := []struct {
+		name              string
+		stackType         infrav1.StackType
+		addressPreference infrav1.AddressPreferencePolicy
+		wantIPv4Host      bool
+		wantIPv6Host      bool
+	}{
+		{
+			name:              "IPv4Primary with IPv4Only stack type - should use IPv4 address",
+			stackType:         infrav1.IPv4OnlyStackType,
+			addressPreference: infrav1.IPv4Primary,
+			wantIPv4Host:      true,
+			wantIPv6Host:      false,
+		},
+		{
+			name:              "IPv4Primary with DualStack type - should use IPv4 address",
+			stackType:         infrav1.DualStackType,
+			addressPreference: infrav1.IPv4Primary,
+			wantIPv4Host:      true,
+			wantIPv6Host:      false,
+		},
+		{
+			name:              "IPv6Primary with DualStack type - should use IPv6 address",
+			stackType:         infrav1.DualStackType,
+			addressPreference: infrav1.IPv6Primary,
+			wantIPv4Host:      false,
+			wantIPv6Host:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			clusterScope, err := getBaseClusterScope()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Set stack type and address preference policy
+			clusterScope.GCPCluster.Spec.Network.StackType = tt.stackType
+			clusterScope.GCPCluster.Spec.Network.AddressPreferencePolicy = tt.addressPreference
+
+			// Mock addresses with hooks to populate IP addresses
+			mockAddresses := &cloud.MockGlobalAddresses{
+				ProjectRouter: &cloud.SingleProjectRouter{ID: "proj-id"},
+				Objects:       map[meta.Key]*cloud.MockGlobalAddressesObj{},
+				InsertHook: func(_ context.Context, _ *meta.Key, obj *compute.Address, _ *cloud.MockGlobalAddresses, _ ...cloud.Option) (bool, error) {
+					// Populate the Address field based on IpVersion
+					if obj.IpVersion == "IPV6" {
+						obj.Address = exampleIPv6Addr
+					} else {
+						obj.Address = exampleIPv4Addr
+					}
+					return false, nil
+				},
+			}
+
+			// Mock target TCP proxy
+			mockTargetTCPProxy := &cloud.MockTargetTcpProxies{
+				ProjectRouter: &cloud.SingleProjectRouter{ID: "proj-id"},
+				Objects:       map[meta.Key]*cloud.MockTargetTcpProxiesObj{},
+			}
+
+			// Mock backend services
+			mockBackendServices := &cloud.MockBackendServices{
+				ProjectRouter: &cloud.SingleProjectRouter{ID: "proj-id"},
+				Objects:       map[meta.Key]*cloud.MockBackendServicesObj{},
+			}
+
+			// Mock health checks
+			mockHealthChecks := &cloud.MockHealthChecks{
+				ProjectRouter: &cloud.SingleProjectRouter{ID: "proj-id"},
+				Objects:       map[meta.Key]*cloud.MockHealthChecksObj{},
+			}
+
+			// Mock instance groups
+			mockInstanceGroups := &cloud.MockInstanceGroups{
+				ProjectRouter: &cloud.SingleProjectRouter{ID: "proj-id"},
+				Objects:       map[meta.Key]*cloud.MockInstanceGroupsObj{},
+			}
+
+			// Mock forwarding rules
+			mockForwardingRules := &cloud.MockGlobalForwardingRules{
+				ProjectRouter: &cloud.SingleProjectRouter{ID: "proj-id"},
+				Objects:       map[meta.Key]*cloud.MockGlobalForwardingRulesObj{},
+			}
+
+			s := New(clusterScope)
+			s.addresses = mockAddresses
+			s.targettcpproxies = mockTargetTCPProxy
+			s.backendservices = mockBackendServices
+			s.healthchecks = mockHealthChecks
+			s.instancegroups = mockInstanceGroups
+			s.forwardingrules = mockForwardingRules
+
+			// Create instance groups
+			instancegroups, err := s.createOrGetInstanceGroups(ctx)
+			if err != nil {
+				t.Fatalf("createOrGetInstanceGroups() error = %v", err)
+			}
+
+			// Create external load balancer
+			err = s.createExternalLoadBalancer(ctx, infrav1.External, instancegroups)
+			if err != nil {
+				t.Fatalf("createExternalLoadBalancer() error = %v", err)
+			}
+
+			// Get the control plane endpoint
+			endpoint := clusterScope.ControlPlaneEndpoint()
+
+			// Verify the endpoint host based on expectations
+			if tt.wantIPv4Host && endpoint.Host != exampleIPv4Addr {
+				// For IPv4, we expect the address to be in IPv4 format (192.0.2.1)
+				t.Errorf("Expected IPv4 host to be %s, but got %s", exampleIPv4Addr, endpoint.Host)
+			}
+
+			if tt.wantIPv6Host && endpoint.Host != exampleIPv6Addr {
+				// For IPv6Primary with DualStack, the endpoint should be set to IPv6 address (2001:db8::1)
+				t.Errorf("Expected IPv6 host to be %s, but got %s", exampleIPv6Addr, endpoint.Host)
+			}
+
+			// Verify that IPv6 resources are created only for DualStack
+			if tt.stackType == infrav1.DualStackType {
+				if clusterScope.GCPCluster.Status.Network.APIServerIPv6Address == nil {
+					t.Errorf("Expected APIServerIPv6Address to be set for DualStack, but got nil")
+				}
+				if clusterScope.GCPCluster.Status.Network.APIServerIPv6ForwardingRule == nil {
+					t.Errorf("Expected APIServerIPv6ForwardingRule to be set for DualStack, but got nil")
+				}
+			} else if clusterScope.GCPCluster.Status.Network.APIServerIPv6Address != nil {
+				t.Errorf("Expected APIServerIPv6Address to be nil for IPv4Only stack, but got %v", clusterScope.GCPCluster.Status.Network.APIServerIPv6Address)
+			}
+		})
+	}
+}

--- a/cloud/services/compute/loadbalancers/service.go
+++ b/cloud/services/compute/loadbalancers/service.go
@@ -81,6 +81,7 @@ type subnetsInterface interface {
 type Scope interface {
 	cloud.Cluster
 	AddressSpec(name string) *compute.Address
+	IPv6AddressSpec(name string) *compute.Address
 	BackendServiceSpec(name string) *compute.BackendService
 	ForwardingRuleSpec(name string) *compute.ForwardingRule
 	HealthCheckSpec(name string) *compute.HealthCheck

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -421,6 +421,13 @@ spec:
                     description: HostProject is the name of the project hosting the
                       shared VPC network resources.
                     type: string
+                  ipv6Address:
+                    description: |-
+                      Ipv6Address: An IPv6 internal network address for this network interface.
+                      To use a static internal IP address, it must be unused and in the same
+                      region as the instance's zone. If not specified, Google Cloud will
+                      automatically assign an internal IPv6 address from the instance's subnetwork.
+                    type: string
                   loadBalancerBackendPort:
                     description: Allow for configuration of load balancer backend
                       (useful for changing apiserver port)
@@ -451,6 +458,20 @@ spec:
                     type: integer
                   name:
                     description: Name is the name of the network to be used.
+                    type: string
+                  stackType:
+                    default: IPv4Only
+                    description: |-
+                      StackType: The stackType for the subnets. If set to IPv4Only, new VMs in
+                      the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
+                      the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
+                      IPv4Only is used. This field can be both set at resource creation time and
+                      updated using patch.
+                      GCP allows subnet stack types to be set independently, but, for simplicity,
+                      all subnets in the network will be created with the same stackType.
+                    enum:
+                    - IPv4Only
+                    - DualStack
                     type: string
                   subnets:
                     description: Subnets configuration.
@@ -520,23 +541,19 @@ spec:
                             from which secondary IP ranges of a VM may be allocated
                           type: object
                         stackType:
-                          default: IPV4_ONLY
+                          default: IPv4Only
                           description: |-
-                            StackType: The stack type for the subnet. If set to IPV4_ONLY, new VMs in
-                            the subnet are assigned IPv4 addresses only. If set to IPV4_IPV6, new VMs in
+                            StackType: The stackType for the subnet. If set to IPv4Only, new VMs in
+                            the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
                             the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
-                            IPV4_ONLY is used. This field can be both set at resource creation time and
+                            IPv4Only is used. This field can be both set at resource creation time and
                             updated using patch.
 
-                            Possible values:
-                              "IPV4_IPV6" - New VMs in this subnet can have both IPv4 and IPv6
-                            addresses.
-                              "IPV4_ONLY" - New VMs in this subnet will only be assigned IPv4 addresses.
-                              "IPV6_ONLY" - New VMs in this subnet will only be assigned IPv6 addresses.
+                            NOT IMPLEMENTED: Stack type is currently set in the `NetworkSpec` and all
+                            subnets will have the same stack type.
                           enum:
-                          - IPV4_ONLY
-                          - IPV4_IPV6
-                          - IPV6_ONLY
+                          - IPv4Only
+                          - DualStack
                           type: string
                       type: object
                     type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -169,6 +169,16 @@ spec:
               network:
                 description: NetworkSpec encapsulates all things related to GCP network.
                 properties:
+                  addressPreferencePolicy:
+                    default: IPv4Primary
+                    description: |-
+                      AddressPreferencePolicy: The AddressPreferencePolicy determines whether the
+                      IPv4 or IPv6 addresses should be preferred for load balancers. The value will
+                      also determine the address type in the APIEndpoint.
+                    enum:
+                    - IPv4Primary
+                    - IPv6Primary
+                    type: string
                   autoCreateSubnetworks:
                     description: |-
                       AutoCreateSubnetworks: When set to true, the VPC network is created
@@ -691,6 +701,17 @@ spec:
                       APIInternalAddress is the IPV4 regional address assigned to the
                       internal Load Balancer.
                     type: string
+                  apiInternalIpv6IpAddress:
+                    description: |-
+                      APIInternalIPv6Address is the IPV6 regional address assigned to the
+                      internal Load Balancer. This field is only applicable for dual stack
+                      configurations.
+                    type: string
+                  apiIpv6InternalForwardingRule:
+                    description: |-
+                      APIIPv6InternalForwardingRule is the full reference to the forwarding rule
+                      created for the internal IPv6 Load Balancer during dual stack configurations.
+                    type: string
                   apiServerBackendService:
                     description: |-
                       APIServerBackendService is the full reference to the backend service
@@ -717,6 +738,18 @@ spec:
                     description: |-
                       APIServerAddress is the IPV4 global address assigned to the load balancer
                       created for the API Server.
+                    type: string
+                  apiServerIpv6Address:
+                    description: |-
+                      APIServerIPv6Address is the IPv6 global address assigned to the load balancer
+                      created for the API Server. This field is only applicable for dual stack
+                      configurations.
+                    type: string
+                  apiServerIpv6ForwardingRule:
+                    description: |-
+                      APIServerIPv6ForwardingRule is the full reference to the IPv6 forwarding rule
+                      created for the API Server. This field is only applicable during dual stack
+                      configurations.
                     type: string
                   apiServerTargetProxy:
                     description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -506,6 +506,14 @@ spec:
                             If this field is not explicitly set, it will not appear in get
                             listings. If not set the default behavior is to disable flow logging.
                           type: boolean
+                        ipv6CidrRange:
+                          description: |-
+                            Ipv6CidrRange is the range of internal IPv6 addresses that are owned by
+                            this subnetwork. Provide this property when you create the subnetwork. The
+                            range must be a unique /64 or larger from the ULA (Unique Local Address) range.
+                            For example, fd00:1234:5678::/64. This field can be set only at resource
+                            creation time and is only applicable when StackType is set to DualStack.
+                          type: string
                         name:
                           description: Name defines a unique identifier to reference
                             this resource.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -506,6 +506,16 @@ spec:
                             If this field is not explicitly set, it will not appear in get
                             listings. If not set the default behavior is to disable flow logging.
                           type: boolean
+                        externalIpv6:
+                          default: false
+                          description: |-
+                            ExternalIpv6 specifies whether the subnet should have external IPv6 access.
+                            When true, the subnet will use EXTERNAL IPv6 access type and instances can
+                            have public IPv6 addresses. When false (default), the subnet will use INTERNAL
+                            IPv6 access type with ULA (Unique Local Address) ranges.
+                            This is only applicable when StackType is set to DualStack.
+                            Note: Subnets with EXTERNAL IPv6 cannot be used with internal load balancers.
+                          type: boolean
                         ipv6CidrRange:
                           description: |-
                             Ipv6CidrRange is the range of internal IPv6 addresses that are owned by

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -166,6 +166,16 @@ spec:
               network:
                 description: NetworkSpec encapsulates all things related to GCP network.
                 properties:
+                  addressPreferencePolicy:
+                    default: IPv4Primary
+                    description: |-
+                      AddressPreferencePolicy: The AddressPreferencePolicy determines whether the
+                      IPv4 or IPv6 addresses should be preferred for load balancers. The value will
+                      also determine the address type in the APIEndpoint.
+                    enum:
+                    - IPv4Primary
+                    - IPv6Primary
+                    type: string
                   autoCreateSubnetworks:
                     description: |-
                       AutoCreateSubnetworks: When set to true, the VPC network is created
@@ -688,6 +698,17 @@ spec:
                       APIInternalAddress is the IPV4 regional address assigned to the
                       internal Load Balancer.
                     type: string
+                  apiInternalIpv6IpAddress:
+                    description: |-
+                      APIInternalIPv6Address is the IPV6 regional address assigned to the
+                      internal Load Balancer. This field is only applicable for dual stack
+                      configurations.
+                    type: string
+                  apiIpv6InternalForwardingRule:
+                    description: |-
+                      APIIPv6InternalForwardingRule is the full reference to the forwarding rule
+                      created for the internal IPv6 Load Balancer during dual stack configurations.
+                    type: string
                   apiServerBackendService:
                     description: |-
                       APIServerBackendService is the full reference to the backend service
@@ -714,6 +735,18 @@ spec:
                     description: |-
                       APIServerAddress is the IPV4 global address assigned to the load balancer
                       created for the API Server.
+                    type: string
+                  apiServerIpv6Address:
+                    description: |-
+                      APIServerIPv6Address is the IPv6 global address assigned to the load balancer
+                      created for the API Server. This field is only applicable for dual stack
+                      configurations.
+                    type: string
+                  apiServerIpv6ForwardingRule:
+                    description: |-
+                      APIServerIPv6ForwardingRule is the full reference to the IPv6 forwarding rule
+                      created for the API Server. This field is only applicable during dual stack
+                      configurations.
                     type: string
                   apiServerTargetProxy:
                     description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -503,6 +503,14 @@ spec:
                             If this field is not explicitly set, it will not appear in get
                             listings. If not set the default behavior is to disable flow logging.
                           type: boolean
+                        ipv6CidrRange:
+                          description: |-
+                            Ipv6CidrRange is the range of internal IPv6 addresses that are owned by
+                            this subnetwork. Provide this property when you create the subnetwork. The
+                            range must be a unique /64 or larger from the ULA (Unique Local Address) range.
+                            For example, fd00:1234:5678::/64. This field can be set only at resource
+                            creation time and is only applicable when StackType is set to DualStack.
+                          type: string
                         name:
                           description: Name defines a unique identifier to reference
                             this resource.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -503,6 +503,16 @@ spec:
                             If this field is not explicitly set, it will not appear in get
                             listings. If not set the default behavior is to disable flow logging.
                           type: boolean
+                        externalIpv6:
+                          default: false
+                          description: |-
+                            ExternalIpv6 specifies whether the subnet should have external IPv6 access.
+                            When true, the subnet will use EXTERNAL IPv6 access type and instances can
+                            have public IPv6 addresses. When false (default), the subnet will use INTERNAL
+                            IPv6 access type with ULA (Unique Local Address) ranges.
+                            This is only applicable when StackType is set to DualStack.
+                            Note: Subnets with EXTERNAL IPv6 cannot be used with internal load balancers.
+                          type: boolean
                         ipv6CidrRange:
                           description: |-
                             Ipv6CidrRange is the range of internal IPv6 addresses that are owned by

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -418,6 +418,13 @@ spec:
                     description: HostProject is the name of the project hosting the
                       shared VPC network resources.
                     type: string
+                  ipv6Address:
+                    description: |-
+                      Ipv6Address: An IPv6 internal network address for this network interface.
+                      To use a static internal IP address, it must be unused and in the same
+                      region as the instance's zone. If not specified, Google Cloud will
+                      automatically assign an internal IPv6 address from the instance's subnetwork.
+                    type: string
                   loadBalancerBackendPort:
                     description: Allow for configuration of load balancer backend
                       (useful for changing apiserver port)
@@ -448,6 +455,20 @@ spec:
                     type: integer
                   name:
                     description: Name is the name of the network to be used.
+                    type: string
+                  stackType:
+                    default: IPv4Only
+                    description: |-
+                      StackType: The stackType for the subnets. If set to IPv4Only, new VMs in
+                      the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
+                      the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
+                      IPv4Only is used. This field can be both set at resource creation time and
+                      updated using patch.
+                      GCP allows subnet stack types to be set independently, but, for simplicity,
+                      all subnets in the network will be created with the same stackType.
+                    enum:
+                    - IPv4Only
+                    - DualStack
                     type: string
                   subnets:
                     description: Subnets configuration.
@@ -517,23 +538,19 @@ spec:
                             from which secondary IP ranges of a VM may be allocated
                           type: object
                         stackType:
-                          default: IPV4_ONLY
+                          default: IPv4Only
                           description: |-
-                            StackType: The stack type for the subnet. If set to IPV4_ONLY, new VMs in
-                            the subnet are assigned IPv4 addresses only. If set to IPV4_IPV6, new VMs in
+                            StackType: The stackType for the subnet. If set to IPv4Only, new VMs in
+                            the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
                             the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
-                            IPV4_ONLY is used. This field can be both set at resource creation time and
+                            IPv4Only is used. This field can be both set at resource creation time and
                             updated using patch.
 
-                            Possible values:
-                              "IPV4_IPV6" - New VMs in this subnet can have both IPv4 and IPv6
-                            addresses.
-                              "IPV4_ONLY" - New VMs in this subnet will only be assigned IPv4 addresses.
-                              "IPV6_ONLY" - New VMs in this subnet will only be assigned IPv6 addresses.
+                            NOT IMPLEMENTED: Stack type is currently set in the `NetworkSpec` and all
+                            subnets will have the same stack type.
                           enum:
-                          - IPV4_ONLY
-                          - IPV4_IPV6
-                          - IPV6_ONLY
+                          - IPv4Only
+                          - DualStack
                           type: string
                       type: object
                     type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -528,6 +528,16 @@ spec:
                                     If this field is not explicitly set, it will not appear in get
                                     listings. If not set the default behavior is to disable flow logging.
                                   type: boolean
+                                externalIpv6:
+                                  default: false
+                                  description: |-
+                                    ExternalIpv6 specifies whether the subnet should have external IPv6 access.
+                                    When true, the subnet will use EXTERNAL IPv6 access type and instances can
+                                    have public IPv6 addresses. When false (default), the subnet will use INTERNAL
+                                    IPv6 access type with ULA (Unique Local Address) ranges.
+                                    This is only applicable when StackType is set to DualStack.
+                                    Note: Subnets with EXTERNAL IPv6 cannot be used with internal load balancers.
+                                  type: boolean
                                 ipv6CidrRange:
                                   description: |-
                                     Ipv6CidrRange is the range of internal IPv6 addresses that are owned by

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -443,6 +443,13 @@ spec:
                             description: HostProject is the name of the project hosting
                               the shared VPC network resources.
                             type: string
+                          ipv6Address:
+                            description: |-
+                              Ipv6Address: An IPv6 internal network address for this network interface.
+                              To use a static internal IP address, it must be unused and in the same
+                              region as the instance's zone. If not specified, Google Cloud will
+                              automatically assign an internal IPv6 address from the instance's subnetwork.
+                            type: string
                           loadBalancerBackendPort:
                             description: Allow for configuration of load balancer
                               backend (useful for changing apiserver port)
@@ -473,6 +480,20 @@ spec:
                             type: integer
                           name:
                             description: Name is the name of the network to be used.
+                            type: string
+                          stackType:
+                            default: IPv4Only
+                            description: |-
+                              StackType: The stackType for the subnets. If set to IPv4Only, new VMs in
+                              the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
+                              the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
+                              IPv4Only is used. This field can be both set at resource creation time and
+                              updated using patch.
+                              GCP allows subnet stack types to be set independently, but, for simplicity,
+                              all subnets in the network will be created with the same stackType.
+                            enum:
+                            - IPv4Only
+                            - DualStack
                             type: string
                           subnets:
                             description: Subnets configuration.
@@ -542,23 +563,19 @@ spec:
                                     from which secondary IP ranges of a VM may be allocated
                                   type: object
                                 stackType:
-                                  default: IPV4_ONLY
+                                  default: IPv4Only
                                   description: |-
-                                    StackType: The stack type for the subnet. If set to IPV4_ONLY, new VMs in
-                                    the subnet are assigned IPv4 addresses only. If set to IPV4_IPV6, new VMs in
+                                    StackType: The stackType for the subnet. If set to IPv4Only, new VMs in
+                                    the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
                                     the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
-                                    IPV4_ONLY is used. This field can be both set at resource creation time and
+                                    IPv4Only is used. This field can be both set at resource creation time and
                                     updated using patch.
 
-                                    Possible values:
-                                      "IPV4_IPV6" - New VMs in this subnet can have both IPv4 and IPv6
-                                    addresses.
-                                      "IPV4_ONLY" - New VMs in this subnet will only be assigned IPv4 addresses.
-                                      "IPV6_ONLY" - New VMs in this subnet will only be assigned IPv6 addresses.
+                                    NOT IMPLEMENTED: Stack type is currently set in the `NetworkSpec` and all
+                                    subnets will have the same stack type.
                                   enum:
-                                  - IPV4_ONLY
-                                  - IPV4_IPV6
-                                  - IPV6_ONLY
+                                  - IPv4Only
+                                  - DualStack
                                   type: string
                               type: object
                             type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -528,6 +528,14 @@ spec:
                                     If this field is not explicitly set, it will not appear in get
                                     listings. If not set the default behavior is to disable flow logging.
                                   type: boolean
+                                ipv6CidrRange:
+                                  description: |-
+                                    Ipv6CidrRange is the range of internal IPv6 addresses that are owned by
+                                    this subnetwork. Provide this property when you create the subnetwork. The
+                                    range must be a unique /64 or larger from the ULA (Unique Local Address) range.
+                                    For example, fd00:1234:5678::/64. This field can be set only at resource
+                                    creation time and is only applicable when StackType is set to DualStack.
+                                  type: string
                                 name:
                                   description: Name defines a unique identifier to
                                     reference this resource.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -188,6 +188,16 @@ spec:
                         description: NetworkSpec encapsulates all things related to
                           GCP network.
                         properties:
+                          addressPreferencePolicy:
+                            default: IPv4Primary
+                            description: |-
+                              AddressPreferencePolicy: The AddressPreferencePolicy determines whether the
+                              IPv4 or IPv6 addresses should be preferred for load balancers. The value will
+                              also determine the address type in the APIEndpoint.
+                            enum:
+                            - IPv4Primary
+                            - IPv6Primary
+                            type: string
                           autoCreateSubnetworks:
                             description: |-
                               AutoCreateSubnetworks: When set to true, the VPC network is created

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -525,6 +525,14 @@ spec:
                                     If this field is not explicitly set, it will not appear in get
                                     listings. If not set the default behavior is to disable flow logging.
                                   type: boolean
+                                ipv6CidrRange:
+                                  description: |-
+                                    Ipv6CidrRange is the range of internal IPv6 addresses that are owned by
+                                    this subnetwork. Provide this property when you create the subnetwork. The
+                                    range must be a unique /64 or larger from the ULA (Unique Local Address) range.
+                                    For example, fd00:1234:5678::/64. This field can be set only at resource
+                                    creation time and is only applicable when StackType is set to DualStack.
+                                  type: string
                                 name:
                                   description: Name defines a unique identifier to
                                     reference this resource.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -440,6 +440,13 @@ spec:
                             description: HostProject is the name of the project hosting
                               the shared VPC network resources.
                             type: string
+                          ipv6Address:
+                            description: |-
+                              Ipv6Address: An IPv6 internal network address for this network interface.
+                              To use a static internal IP address, it must be unused and in the same
+                              region as the instance's zone. If not specified, Google Cloud will
+                              automatically assign an internal IPv6 address from the instance's subnetwork.
+                            type: string
                           loadBalancerBackendPort:
                             description: Allow for configuration of load balancer
                               backend (useful for changing apiserver port)
@@ -470,6 +477,20 @@ spec:
                             type: integer
                           name:
                             description: Name is the name of the network to be used.
+                            type: string
+                          stackType:
+                            default: IPv4Only
+                            description: |-
+                              StackType: The stackType for the subnets. If set to IPv4Only, new VMs in
+                              the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
+                              the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
+                              IPv4Only is used. This field can be both set at resource creation time and
+                              updated using patch.
+                              GCP allows subnet stack types to be set independently, but, for simplicity,
+                              all subnets in the network will be created with the same stackType.
+                            enum:
+                            - IPv4Only
+                            - DualStack
                             type: string
                           subnets:
                             description: Subnets configuration.
@@ -539,23 +560,19 @@ spec:
                                     from which secondary IP ranges of a VM may be allocated
                                   type: object
                                 stackType:
-                                  default: IPV4_ONLY
+                                  default: IPv4Only
                                   description: |-
-                                    StackType: The stack type for the subnet. If set to IPV4_ONLY, new VMs in
-                                    the subnet are assigned IPv4 addresses only. If set to IPV4_IPV6, new VMs in
+                                    StackType: The stackType for the subnet. If set to IPv4Only, new VMs in
+                                    the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
                                     the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
-                                    IPV4_ONLY is used. This field can be both set at resource creation time and
+                                    IPv4Only is used. This field can be both set at resource creation time and
                                     updated using patch.
 
-                                    Possible values:
-                                      "IPV4_IPV6" - New VMs in this subnet can have both IPv4 and IPv6
-                                    addresses.
-                                      "IPV4_ONLY" - New VMs in this subnet will only be assigned IPv4 addresses.
-                                      "IPV6_ONLY" - New VMs in this subnet will only be assigned IPv6 addresses.
+                                    NOT IMPLEMENTED: Stack type is currently set in the `NetworkSpec` and all
+                                    subnets will have the same stack type.
                                   enum:
-                                  - IPV4_ONLY
-                                  - IPV4_IPV6
-                                  - IPV6_ONLY
+                                  - IPv4Only
+                                  - DualStack
                                   type: string
                               type: object
                             type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -185,6 +185,16 @@ spec:
                         description: NetworkSpec encapsulates all things related to
                           GCP network.
                         properties:
+                          addressPreferencePolicy:
+                            default: IPv4Primary
+                            description: |-
+                              AddressPreferencePolicy: The AddressPreferencePolicy determines whether the
+                              IPv4 or IPv6 addresses should be preferred for load balancers. The value will
+                              also determine the address type in the APIEndpoint.
+                            enum:
+                            - IPv4Primary
+                            - IPv6Primary
+                            type: string
                           autoCreateSubnetworks:
                             description: |-
                               AutoCreateSubnetworks: When set to true, the VPC network is created

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -525,6 +525,16 @@ spec:
                                     If this field is not explicitly set, it will not appear in get
                                     listings. If not set the default behavior is to disable flow logging.
                                   type: boolean
+                                externalIpv6:
+                                  default: false
+                                  description: |-
+                                    ExternalIpv6 specifies whether the subnet should have external IPv6 access.
+                                    When true, the subnet will use EXTERNAL IPv6 access type and instances can
+                                    have public IPv6 addresses. When false (default), the subnet will use INTERNAL
+                                    IPv6 access type with ULA (Unique Local Address) ranges.
+                                    This is only applicable when StackType is set to DualStack.
+                                    Note: Subnets with EXTERNAL IPv6 cannot be used with internal load balancers.
+                                  type: boolean
                                 ipv6CidrRange:
                                   description: |-
                                     Ipv6CidrRange is the range of internal IPv6 addresses that are owned by

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -500,6 +500,16 @@ spec:
                             If this field is not explicitly set, it will not appear in get
                             listings. If not set the default behavior is to disable flow logging.
                           type: boolean
+                        externalIpv6:
+                          default: false
+                          description: |-
+                            ExternalIpv6 specifies whether the subnet should have external IPv6 access.
+                            When true, the subnet will use EXTERNAL IPv6 access type and instances can
+                            have public IPv6 addresses. When false (default), the subnet will use INTERNAL
+                            IPv6 access type with ULA (Unique Local Address) ranges.
+                            This is only applicable when StackType is set to DualStack.
+                            Note: Subnets with EXTERNAL IPv6 cannot be used with internal load balancers.
+                          type: boolean
                         ipv6CidrRange:
                           description: |-
                             Ipv6CidrRange is the range of internal IPv6 addresses that are owned by

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -500,6 +500,14 @@ spec:
                             If this field is not explicitly set, it will not appear in get
                             listings. If not set the default behavior is to disable flow logging.
                           type: boolean
+                        ipv6CidrRange:
+                          description: |-
+                            Ipv6CidrRange is the range of internal IPv6 addresses that are owned by
+                            this subnetwork. Provide this property when you create the subnetwork. The
+                            range must be a unique /64 or larger from the ULA (Unique Local Address) range.
+                            For example, fd00:1234:5678::/64. This field can be set only at resource
+                            creation time and is only applicable when StackType is set to DualStack.
+                          type: string
                         name:
                           description: Name defines a unique identifier to reference
                             this resource.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -163,6 +163,16 @@ spec:
                 description: NetworkSpec encapsulates all things related to the GCP
                   network.
                 properties:
+                  addressPreferencePolicy:
+                    default: IPv4Primary
+                    description: |-
+                      AddressPreferencePolicy: The AddressPreferencePolicy determines whether the
+                      IPv4 or IPv6 addresses should be preferred for load balancers. The value will
+                      also determine the address type in the APIEndpoint.
+                    enum:
+                    - IPv4Primary
+                    - IPv6Primary
+                    type: string
                   autoCreateSubnetworks:
                     description: |-
                       AutoCreateSubnetworks: When set to true, the VPC network is created
@@ -738,6 +748,17 @@ spec:
                       APIInternalAddress is the IPV4 regional address assigned to the
                       internal Load Balancer.
                     type: string
+                  apiInternalIpv6IpAddress:
+                    description: |-
+                      APIInternalIPv6Address is the IPV6 regional address assigned to the
+                      internal Load Balancer. This field is only applicable for dual stack
+                      configurations.
+                    type: string
+                  apiIpv6InternalForwardingRule:
+                    description: |-
+                      APIIPv6InternalForwardingRule is the full reference to the forwarding rule
+                      created for the internal IPv6 Load Balancer during dual stack configurations.
+                    type: string
                   apiServerBackendService:
                     description: |-
                       APIServerBackendService is the full reference to the backend service
@@ -764,6 +785,18 @@ spec:
                     description: |-
                       APIServerAddress is the IPV4 global address assigned to the load balancer
                       created for the API Server.
+                    type: string
+                  apiServerIpv6Address:
+                    description: |-
+                      APIServerIPv6Address is the IPv6 global address assigned to the load balancer
+                      created for the API Server. This field is only applicable for dual stack
+                      configurations.
+                    type: string
+                  apiServerIpv6ForwardingRule:
+                    description: |-
+                      APIServerIPv6ForwardingRule is the full reference to the IPv6 forwarding rule
+                      created for the API Server. This field is only applicable during dual stack
+                      configurations.
                     type: string
                   apiServerTargetProxy:
                     description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -415,6 +415,13 @@ spec:
                     description: HostProject is the name of the project hosting the
                       shared VPC network resources.
                     type: string
+                  ipv6Address:
+                    description: |-
+                      Ipv6Address: An IPv6 internal network address for this network interface.
+                      To use a static internal IP address, it must be unused and in the same
+                      region as the instance's zone. If not specified, Google Cloud will
+                      automatically assign an internal IPv6 address from the instance's subnetwork.
+                    type: string
                   loadBalancerBackendPort:
                     description: Allow for configuration of load balancer backend
                       (useful for changing apiserver port)
@@ -445,6 +452,20 @@ spec:
                     type: integer
                   name:
                     description: Name is the name of the network to be used.
+                    type: string
+                  stackType:
+                    default: IPv4Only
+                    description: |-
+                      StackType: The stackType for the subnets. If set to IPv4Only, new VMs in
+                      the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
+                      the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
+                      IPv4Only is used. This field can be both set at resource creation time and
+                      updated using patch.
+                      GCP allows subnet stack types to be set independently, but, for simplicity,
+                      all subnets in the network will be created with the same stackType.
+                    enum:
+                    - IPv4Only
+                    - DualStack
                     type: string
                   subnets:
                     description: Subnets configuration.
@@ -514,23 +535,19 @@ spec:
                             from which secondary IP ranges of a VM may be allocated
                           type: object
                         stackType:
-                          default: IPV4_ONLY
+                          default: IPv4Only
                           description: |-
-                            StackType: The stack type for the subnet. If set to IPV4_ONLY, new VMs in
-                            the subnet are assigned IPv4 addresses only. If set to IPV4_IPV6, new VMs in
+                            StackType: The stackType for the subnet. If set to IPv4Only, new VMs in
+                            the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
                             the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
-                            IPV4_ONLY is used. This field can be both set at resource creation time and
+                            IPv4Only is used. This field can be both set at resource creation time and
                             updated using patch.
 
-                            Possible values:
-                              "IPV4_IPV6" - New VMs in this subnet can have both IPv4 and IPv6
-                            addresses.
-                              "IPV4_ONLY" - New VMs in this subnet will only be assigned IPv4 addresses.
-                              "IPV6_ONLY" - New VMs in this subnet will only be assigned IPv6 addresses.
+                            NOT IMPLEMENTED: Stack type is currently set in the `NetworkSpec` and all
+                            subnets will have the same stack type.
                           enum:
-                          - IPV4_ONLY
-                          - IPV4_IPV6
-                          - IPV6_ONLY
+                          - IPv4Only
+                          - DualStack
                           type: string
                       type: object
                     type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -412,6 +412,13 @@ spec:
                     description: HostProject is the name of the project hosting the
                       shared VPC network resources.
                     type: string
+                  ipv6Address:
+                    description: |-
+                      Ipv6Address: An IPv6 internal network address for this network interface.
+                      To use a static internal IP address, it must be unused and in the same
+                      region as the instance's zone. If not specified, Google Cloud will
+                      automatically assign an internal IPv6 address from the instance's subnetwork.
+                    type: string
                   loadBalancerBackendPort:
                     description: Allow for configuration of load balancer backend
                       (useful for changing apiserver port)
@@ -442,6 +449,20 @@ spec:
                     type: integer
                   name:
                     description: Name is the name of the network to be used.
+                    type: string
+                  stackType:
+                    default: IPv4Only
+                    description: |-
+                      StackType: The stackType for the subnets. If set to IPv4Only, new VMs in
+                      the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
+                      the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
+                      IPv4Only is used. This field can be both set at resource creation time and
+                      updated using patch.
+                      GCP allows subnet stack types to be set independently, but, for simplicity,
+                      all subnets in the network will be created with the same stackType.
+                    enum:
+                    - IPv4Only
+                    - DualStack
                     type: string
                   subnets:
                     description: Subnets configuration.
@@ -511,23 +532,19 @@ spec:
                             from which secondary IP ranges of a VM may be allocated
                           type: object
                         stackType:
-                          default: IPV4_ONLY
+                          default: IPv4Only
                           description: |-
-                            StackType: The stack type for the subnet. If set to IPV4_ONLY, new VMs in
-                            the subnet are assigned IPv4 addresses only. If set to IPV4_IPV6, new VMs in
+                            StackType: The stackType for the subnet. If set to IPv4Only, new VMs in
+                            the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
                             the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
-                            IPV4_ONLY is used. This field can be both set at resource creation time and
+                            IPv4Only is used. This field can be both set at resource creation time and
                             updated using patch.
 
-                            Possible values:
-                              "IPV4_IPV6" - New VMs in this subnet can have both IPv4 and IPv6
-                            addresses.
-                              "IPV4_ONLY" - New VMs in this subnet will only be assigned IPv4 addresses.
-                              "IPV6_ONLY" - New VMs in this subnet will only be assigned IPv6 addresses.
+                            NOT IMPLEMENTED: Stack type is currently set in the `NetworkSpec` and all
+                            subnets will have the same stack type.
                           enum:
-                          - IPV4_ONLY
-                          - IPV4_IPV6
-                          - IPV6_ONLY
+                          - IPv4Only
+                          - DualStack
                           type: string
                       type: object
                     type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -160,6 +160,16 @@ spec:
                 description: NetworkSpec encapsulates all things related to the GCP
                   network.
                 properties:
+                  addressPreferencePolicy:
+                    default: IPv4Primary
+                    description: |-
+                      AddressPreferencePolicy: The AddressPreferencePolicy determines whether the
+                      IPv4 or IPv6 addresses should be preferred for load balancers. The value will
+                      also determine the address type in the APIEndpoint.
+                    enum:
+                    - IPv4Primary
+                    - IPv6Primary
+                    type: string
                   autoCreateSubnetworks:
                     description: |-
                       AutoCreateSubnetworks: When set to true, the VPC network is created
@@ -735,6 +745,17 @@ spec:
                       APIInternalAddress is the IPV4 regional address assigned to the
                       internal Load Balancer.
                     type: string
+                  apiInternalIpv6IpAddress:
+                    description: |-
+                      APIInternalIPv6Address is the IPV6 regional address assigned to the
+                      internal Load Balancer. This field is only applicable for dual stack
+                      configurations.
+                    type: string
+                  apiIpv6InternalForwardingRule:
+                    description: |-
+                      APIIPv6InternalForwardingRule is the full reference to the forwarding rule
+                      created for the internal IPv6 Load Balancer during dual stack configurations.
+                    type: string
                   apiServerBackendService:
                     description: |-
                       APIServerBackendService is the full reference to the backend service
@@ -761,6 +782,18 @@ spec:
                     description: |-
                       APIServerAddress is the IPV4 global address assigned to the load balancer
                       created for the API Server.
+                    type: string
+                  apiServerIpv6Address:
+                    description: |-
+                      APIServerIPv6Address is the IPv6 global address assigned to the load balancer
+                      created for the API Server. This field is only applicable for dual stack
+                      configurations.
+                    type: string
+                  apiServerIpv6ForwardingRule:
+                    description: |-
+                      APIServerIPv6ForwardingRule is the full reference to the IPv6 forwarding rule
+                      created for the API Server. This field is only applicable during dual stack
+                      configurations.
                     type: string
                   apiServerTargetProxy:
                     description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -497,6 +497,14 @@ spec:
                             If this field is not explicitly set, it will not appear in get
                             listings. If not set the default behavior is to disable flow logging.
                           type: boolean
+                        ipv6CidrRange:
+                          description: |-
+                            Ipv6CidrRange is the range of internal IPv6 addresses that are owned by
+                            this subnetwork. Provide this property when you create the subnetwork. The
+                            range must be a unique /64 or larger from the ULA (Unique Local Address) range.
+                            For example, fd00:1234:5678::/64. This field can be set only at resource
+                            creation time and is only applicable when StackType is set to DualStack.
+                          type: string
                         name:
                           description: Name defines a unique identifier to reference
                             this resource.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -497,6 +497,16 @@ spec:
                             If this field is not explicitly set, it will not appear in get
                             listings. If not set the default behavior is to disable flow logging.
                           type: boolean
+                        externalIpv6:
+                          default: false
+                          description: |-
+                            ExternalIpv6 specifies whether the subnet should have external IPv6 access.
+                            When true, the subnet will use EXTERNAL IPv6 access type and instances can
+                            have public IPv6 addresses. When false (default), the subnet will use INTERNAL
+                            IPv6 access type with ULA (Unique Local Address) ranges.
+                            This is only applicable when StackType is set to DualStack.
+                            Note: Subnets with EXTERNAL IPv6 cannot be used with internal load balancers.
+                          type: boolean
                         ipv6CidrRange:
                           description: |-
                             Ipv6CidrRange is the range of internal IPv6 addresses that are owned by

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
@@ -497,6 +497,16 @@ spec:
                                     If this field is not explicitly set, it will not appear in get
                                     listings. If not set the default behavior is to disable flow logging.
                                   type: boolean
+                                externalIpv6:
+                                  default: false
+                                  description: |-
+                                    ExternalIpv6 specifies whether the subnet should have external IPv6 access.
+                                    When true, the subnet will use EXTERNAL IPv6 access type and instances can
+                                    have public IPv6 addresses. When false (default), the subnet will use INTERNAL
+                                    IPv6 access type with ULA (Unique Local Address) ranges.
+                                    This is only applicable when StackType is set to DualStack.
+                                    Note: Subnets with EXTERNAL IPv6 cannot be used with internal load balancers.
+                                  type: boolean
                                 ipv6CidrRange:
                                   description: |-
                                     Ipv6CidrRange is the range of internal IPv6 addresses that are owned by

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
@@ -412,6 +412,13 @@ spec:
                             description: HostProject is the name of the project hosting
                               the shared VPC network resources.
                             type: string
+                          ipv6Address:
+                            description: |-
+                              Ipv6Address: An IPv6 internal network address for this network interface.
+                              To use a static internal IP address, it must be unused and in the same
+                              region as the instance's zone. If not specified, Google Cloud will
+                              automatically assign an internal IPv6 address from the instance's subnetwork.
+                            type: string
                           loadBalancerBackendPort:
                             description: Allow for configuration of load balancer
                               backend (useful for changing apiserver port)
@@ -442,6 +449,20 @@ spec:
                             type: integer
                           name:
                             description: Name is the name of the network to be used.
+                            type: string
+                          stackType:
+                            default: IPv4Only
+                            description: |-
+                              StackType: The stackType for the subnets. If set to IPv4Only, new VMs in
+                              the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
+                              the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
+                              IPv4Only is used. This field can be both set at resource creation time and
+                              updated using patch.
+                              GCP allows subnet stack types to be set independently, but, for simplicity,
+                              all subnets in the network will be created with the same stackType.
+                            enum:
+                            - IPv4Only
+                            - DualStack
                             type: string
                           subnets:
                             description: Subnets configuration.
@@ -511,23 +532,19 @@ spec:
                                     from which secondary IP ranges of a VM may be allocated
                                   type: object
                                 stackType:
-                                  default: IPV4_ONLY
+                                  default: IPv4Only
                                   description: |-
-                                    StackType: The stack type for the subnet. If set to IPV4_ONLY, new VMs in
-                                    the subnet are assigned IPv4 addresses only. If set to IPV4_IPV6, new VMs in
+                                    StackType: The stackType for the subnet. If set to IPv4Only, new VMs in
+                                    the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
                                     the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
-                                    IPV4_ONLY is used. This field can be both set at resource creation time and
+                                    IPv4Only is used. This field can be both set at resource creation time and
                                     updated using patch.
 
-                                    Possible values:
-                                      "IPV4_IPV6" - New VMs in this subnet can have both IPv4 and IPv6
-                                    addresses.
-                                      "IPV4_ONLY" - New VMs in this subnet will only be assigned IPv4 addresses.
-                                      "IPV6_ONLY" - New VMs in this subnet will only be assigned IPv6 addresses.
+                                    NOT IMPLEMENTED: Stack type is currently set in the `NetworkSpec` and all
+                                    subnets will have the same stack type.
                                   enum:
-                                  - IPV4_ONLY
-                                  - IPV4_IPV6
-                                  - IPV6_ONLY
+                                  - IPv4Only
+                                  - DualStack
                                   type: string
                               type: object
                             type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
@@ -497,6 +497,14 @@ spec:
                                     If this field is not explicitly set, it will not appear in get
                                     listings. If not set the default behavior is to disable flow logging.
                                   type: boolean
+                                ipv6CidrRange:
+                                  description: |-
+                                    Ipv6CidrRange is the range of internal IPv6 addresses that are owned by
+                                    this subnetwork. Provide this property when you create the subnetwork. The
+                                    range must be a unique /64 or larger from the ULA (Unique Local Address) range.
+                                    For example, fd00:1234:5678::/64. This field can be set only at resource
+                                    creation time and is only applicable when StackType is set to DualStack.
+                                  type: string
                                 name:
                                   description: Name defines a unique identifier to
                                     reference this resource.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
@@ -157,6 +157,16 @@ spec:
                         description: NetworkSpec encapsulates all things related to
                           the GCP network.
                         properties:
+                          addressPreferencePolicy:
+                            default: IPv4Primary
+                            description: |-
+                              AddressPreferencePolicy: The AddressPreferencePolicy determines whether the
+                              IPv4 or IPv6 addresses should be preferred for load balancers. The value will
+                              also determine the address type in the APIEndpoint.
+                            enum:
+                            - IPv4Primary
+                            - IPv6Primary
+                            type: string
                           autoCreateSubnetworks:
                             description: |-
                               AutoCreateSubnetworks: When set to true, the VPC network is created

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
@@ -154,6 +154,16 @@ spec:
                         description: NetworkSpec encapsulates all things related to
                           the GCP network.
                         properties:
+                          addressPreferencePolicy:
+                            default: IPv4Primary
+                            description: |-
+                              AddressPreferencePolicy: The AddressPreferencePolicy determines whether the
+                              IPv4 or IPv6 addresses should be preferred for load balancers. The value will
+                              also determine the address type in the APIEndpoint.
+                            enum:
+                            - IPv4Primary
+                            - IPv6Primary
+                            type: string
                           autoCreateSubnetworks:
                             description: |-
                               AutoCreateSubnetworks: When set to true, the VPC network is created

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
@@ -494,6 +494,14 @@ spec:
                                     If this field is not explicitly set, it will not appear in get
                                     listings. If not set the default behavior is to disable flow logging.
                                   type: boolean
+                                ipv6CidrRange:
+                                  description: |-
+                                    Ipv6CidrRange is the range of internal IPv6 addresses that are owned by
+                                    this subnetwork. Provide this property when you create the subnetwork. The
+                                    range must be a unique /64 or larger from the ULA (Unique Local Address) range.
+                                    For example, fd00:1234:5678::/64. This field can be set only at resource
+                                    creation time and is only applicable when StackType is set to DualStack.
+                                  type: string
                                 name:
                                   description: Name defines a unique identifier to
                                     reference this resource.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
@@ -409,6 +409,13 @@ spec:
                             description: HostProject is the name of the project hosting
                               the shared VPC network resources.
                             type: string
+                          ipv6Address:
+                            description: |-
+                              Ipv6Address: An IPv6 internal network address for this network interface.
+                              To use a static internal IP address, it must be unused and in the same
+                              region as the instance's zone. If not specified, Google Cloud will
+                              automatically assign an internal IPv6 address from the instance's subnetwork.
+                            type: string
                           loadBalancerBackendPort:
                             description: Allow for configuration of load balancer
                               backend (useful for changing apiserver port)
@@ -439,6 +446,20 @@ spec:
                             type: integer
                           name:
                             description: Name is the name of the network to be used.
+                            type: string
+                          stackType:
+                            default: IPv4Only
+                            description: |-
+                              StackType: The stackType for the subnets. If set to IPv4Only, new VMs in
+                              the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
+                              the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
+                              IPv4Only is used. This field can be both set at resource creation time and
+                              updated using patch.
+                              GCP allows subnet stack types to be set independently, but, for simplicity,
+                              all subnets in the network will be created with the same stackType.
+                            enum:
+                            - IPv4Only
+                            - DualStack
                             type: string
                           subnets:
                             description: Subnets configuration.
@@ -508,23 +529,19 @@ spec:
                                     from which secondary IP ranges of a VM may be allocated
                                   type: object
                                 stackType:
-                                  default: IPV4_ONLY
+                                  default: IPv4Only
                                   description: |-
-                                    StackType: The stack type for the subnet. If set to IPV4_ONLY, new VMs in
-                                    the subnet are assigned IPv4 addresses only. If set to IPV4_IPV6, new VMs in
+                                    StackType: The stackType for the subnet. If set to IPv4Only, new VMs in
+                                    the subnet are assigned IPv4 addresses only. If set to DualStack, new VMs in
                                     the subnet can be assigned both IPv4 and IPv6 addresses. If not specified,
-                                    IPV4_ONLY is used. This field can be both set at resource creation time and
+                                    IPv4Only is used. This field can be both set at resource creation time and
                                     updated using patch.
 
-                                    Possible values:
-                                      "IPV4_IPV6" - New VMs in this subnet can have both IPv4 and IPv6
-                                    addresses.
-                                      "IPV4_ONLY" - New VMs in this subnet will only be assigned IPv4 addresses.
-                                      "IPV6_ONLY" - New VMs in this subnet will only be assigned IPv6 addresses.
+                                    NOT IMPLEMENTED: Stack type is currently set in the `NetworkSpec` and all
+                                    subnets will have the same stack type.
                                   enum:
-                                  - IPV4_ONLY
-                                  - IPV4_IPV6
-                                  - IPV6_ONLY
+                                  - IPv4Only
+                                  - DualStack
                                   type: string
                               type: object
                             type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
@@ -494,6 +494,16 @@ spec:
                                     If this field is not explicitly set, it will not appear in get
                                     listings. If not set the default behavior is to disable flow logging.
                                   type: boolean
+                                externalIpv6:
+                                  default: false
+                                  description: |-
+                                    ExternalIpv6 specifies whether the subnet should have external IPv6 access.
+                                    When true, the subnet will use EXTERNAL IPv6 access type and instances can
+                                    have public IPv6 addresses. When false (default), the subnet will use INTERNAL
+                                    IPv6 access type with ULA (Unique Local Address) ranges.
+                                    This is only applicable when StackType is set to DualStack.
+                                    Note: Subnets with EXTERNAL IPv6 cannot be used with internal load balancers.
+                                  type: boolean
                                 ipv6CidrRange:
                                   description: |-
                                     Ipv6CidrRange is the range of internal IPv6 addresses that are owned by

--- a/templates/DUAL_STACK_GUIDE.md
+++ b/templates/DUAL_STACK_GUIDE.md
@@ -1,0 +1,537 @@
+# Dual Stack Cluster Configuration Guide
+
+This guide explains how to configure a dual stack (IPv4 + IPv6) GCP cluster with public bootstrap nodes and private worker nodes.
+
+## Overview
+
+The dual stack configuration uses a **two-subnet architecture**:
+
+1. **Public Subnet** - For control plane/bootstrap nodes
+   - Has external IPv6 access enabled (`externalIpv6: true`)
+   - Uses EXTERNAL IPv6 access type with GUA (Globally Unique Address) ranges
+   - Allows instances to receive public IPv4 and IPv6 addresses when `publicIP: true`
+
+2. **Private Subnet** - For worker nodes
+   - Has internal IPv6 access (`externalIpv6: false`, the default)
+   - Uses INTERNAL IPv6 access type with ULA (Unique Local Address) ranges
+   - Required for compatibility with internal load balancers
+   - Instances receive private IPv4 and internal IPv6 addresses only
+
+## Key Configuration Fields
+
+### Cluster Network Configuration
+
+When using dual stack, you must configure both IPv4 and IPv6 CIDR blocks for pods and services:
+
+```yaml
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - "192.168.0.0/16"    # IPv4 pod network
+      - "fd00:100:64::/48"   # IPv6 pod network
+    services:
+      cidrBlocks:
+      - "10.96.0.0/12"       # IPv4 service network
+      - "fd00:100:96::/108"  # IPv6 service network
+```
+
+**Important:** When using `addressPreferencePolicy: "IPv6Primary"`, list the IPv6 CIDR blocks **first**:
+```yaml
+    pods:
+      cidrBlocks:
+      - "fd00:100:64::/48"   # IPv6 FIRST for IPv6Primary
+      - "192.168.0.0/16"     # IPv4 second
+```
+
+### GCPCluster Network Configuration
+
+```yaml
+spec:
+  network:
+    stackType: "DualStack"  # Required for dual stack
+    addressPreferencePolicy: "IPv4Primary"  # Or "IPv6Primary" - affects control plane endpoint
+    autoCreateSubnetworks: false  # Must be false to define custom subnets
+    subnets:
+      - name: "control-plane-subnet"
+        cidrBlock: "10.0.0.0/24"
+        externalIpv6: true  # Enable public IPv6
+        ipv6CidrRange: ""  # Optional: specify custom IPv6 CIDR (e.g., "fd00:1234:5678::/64")
+                           # If omitted, Google will auto-assign from ULA or GUA range
+        region: "${GCP_REGION}"
+      - name: "worker-subnet"
+        cidrBlock: "10.0.1.0/24"
+        externalIpv6: false  # Internal IPv6 only (default)
+        ipv6CidrRange: ""  # Optional: specify custom ULA range
+        region: "${GCP_REGION}"
+```
+
+### Machine Configuration
+
+#### Control Plane Nodes (Public Access)
+```yaml
+spec:
+  template:
+    spec:
+      publicIP: true  # Enable public IPv4 + IPv6 (when subnet has externalIpv6: true)
+      subnet: "control-plane-subnet"  # Assign to public subnet
+```
+
+#### Worker Nodes (Private Access)
+```yaml
+spec:
+  template:
+    spec:
+      # publicIP omitted (defaults to false) - private only
+      subnet: "worker-subnet"  # Assign to private subnet
+```
+
+## Network Access Matrix
+
+| Machine Type | `publicIP` | Subnet `externalIpv6` | IPv4 Address | IPv6 Address | Use Case |
+|--------------|------------|----------------------|--------------|--------------|----------|
+| Control Plane | `true` | `true` | Public | Public (GUA) | Bootstrap nodes, bastion hosts |
+| Control Plane | `true` | `false` | Public | Internal (ULA) | Control plane with NAT |
+| Worker | `false` | `false` | Private | Internal (ULA) | Standard worker nodes |
+| Worker | `false` | `true` | Private | Internal (ULA)* | Not recommended |
+
+*Note: When `publicIP: false`, instances cannot receive public IPv6 addresses even on external IPv6 subnets.
+
+## Important Constraints
+
+1. **Internal Load Balancers** require subnets with `externalIpv6: false` (INTERNAL IPv6 with ULA)
+2. **External IPv6 subnets** cannot be used with internal load balancers
+3. **Public IPv6 addresses** are only assigned when:
+   - Machine has `publicIP: true` **AND**
+   - Subnet has `externalIpv6: true`
+
+## AddressPreferencePolicy
+
+The `addressPreferencePolicy` determines which IP address family is used for the Kubernetes API server endpoint:
+
+- **`IPv4Primary`** (default): The control plane endpoint uses the IPv4 address
+  - `spec.controlPlaneEndpoint.host` will be the IPv4 address
+  - Both IPv4 and IPv6 load balancers are created
+  - Clients can access the API server via either protocol
+
+- **`IPv6Primary`**: The control plane endpoint uses the IPv6 address
+  - `spec.controlPlaneEndpoint.host` will be the IPv6 address
+  - Both IPv4 and IPv6 load balancers are created
+  - Clients must support IPv6 to access the API server endpoint
+
+```yaml
+# Example: IPv6-first cluster
+network:
+  stackType: "DualStack"
+  addressPreferencePolicy: "IPv6Primary"
+```
+
+**Note:** Both load balancers (IPv4 and IPv6) are always created in dual stack mode. The preference policy only affects which address is published as the primary control plane endpoint.
+
+## Load Balancers in Dual Stack Mode
+
+When `stackType: "DualStack"` is configured:
+
+1. **Two external load balancers are created**:
+   - IPv4 forwarding rule: `${CLUSTER_NAME}-apiserver`
+   - IPv6 forwarding rule: `${CLUSTER_NAME}-apiserver-ipv6`
+
+2. **Two IP addresses are allocated**:
+   - `status.network.apiServerAddress`: IPv4 address
+   - `status.network.apiServerIPv6Address`: IPv6 address
+
+3. **Both load balancers route to the same backend**:
+   - Same instance groups
+   - Same health checks
+   - Same backend service
+
+## IPv6 Firewall Rules
+
+Dual stack clusters automatically create additional firewall rules for IPv6 traffic:
+
+### Automatic IPv6 Rules Created
+
+1. **Health Check Rule** (`allow-${CLUSTER_NAME}-healthchecks-ipv6`):
+   - Allows health checks from Google Cloud Load Balancer IPv6 ranges
+   - Source ranges:
+     - `2600:2d00:1:b029::/64`
+     - `2600:2d00:1:1::/64`
+   - Target: Control plane nodes (tagged with `${CLUSTER_NAME}-control-plane`)
+   - Protocol: TCP port 6443
+
+### Custom IPv6 Firewall Rules
+
+You can define custom IPv6 firewall rules in the `GCPCluster` spec:
+
+```yaml
+spec:
+  network:
+    firewall:
+      firewallRules:
+        - name: "allow-ipv6-ssh"
+          allowed:
+            - IPProtocol: "TCP"
+              ports: ["22"]
+          sourceRanges:
+            - "2001:db8::/32"  # IPv6 CIDR
+          targetTags:
+            - "ssh-access"
+```
+
+## IPv6 CIDR Range Configuration
+
+You have two options for IPv6 CIDR assignment:
+
+### Option 1: Auto-Assignment (Recommended)
+
+Omit the `ipv6CidrRange` field and let Google Cloud assign the range:
+
+```yaml
+subnets:
+  - name: "my-subnet"
+    cidrBlock: "10.0.0.0/24"
+    externalIpv6: false  # Google assigns ULA range (fd00::/8)
+```
+
+### Option 2: Manual Assignment
+
+Specify a custom IPv6 CIDR range:
+
+```yaml
+subnets:
+  - name: "my-subnet"
+    cidrBlock: "10.0.0.0/24"
+    ipv6CidrRange: "fd00:1234:5678::/64"  # Must be /64 or larger
+    externalIpv6: false
+```
+
+**Requirements:**
+- Range must be `/64` or larger
+- For INTERNAL IPv6 (`externalIpv6: false`): must be from ULA range (`fd00::/8`)
+- For EXTERNAL IPv6 (`externalIpv6: true`): Google assigns from GUA range
+- Ranges must be unique across all subnets in the VPC
+
+## IPv6 Access Types Explained
+
+### INTERNAL IPv6 Access (ULA)
+
+**When to use:** Private subnets, internal load balancers, most cluster nodes
+
+```yaml
+externalIpv6: false  # Default
+```
+
+**Characteristics:**
+- Uses Unique Local Address (ULA) ranges (`fd00::/8`)
+- Addresses are NOT routable on the internet
+- Compatible with internal load balancers
+- Instances can access Google services via IPv6
+- Cloud NAT not required for IPv6 (unlike IPv4)
+
+**Use cases:**
+- Worker nodes
+- Private control planes
+- Internal services
+
+### EXTERNAL IPv6 Access (GUA)
+
+**When to use:** Public-facing instances that need internet accessibility
+
+```yaml
+externalIpv6: true
+```
+
+**Characteristics:**
+- Uses Globally Unique Address (GUA) ranges
+- Addresses are routable on the internet
+- **NOT compatible** with internal load balancers
+- Instances with `publicIP: true` receive public IPv6 addresses
+- No NAT required - direct internet access
+
+**Use cases:**
+- Bootstrap/bastion nodes
+- Public-facing control planes
+- Edge/ingress nodes
+
+## Architecture Patterns
+
+### Pattern 1: Public Control Plane + Private Workers (Recommended)
+
+Best for most production workloads where control plane needs external access but workers should be private.
+
+```yaml
+subnets:
+  - name: "control-plane-subnet"
+    cidrBlock: "10.0.0.0/24"
+    externalIpv6: true   # Public IPv6 for bootstrap
+  - name: "worker-subnet"
+    cidrBlock: "10.0.1.0/24"
+    externalIpv6: false  # Private IPv6 for security
+
+# Control plane machines
+publicIP: true
+subnet: "control-plane-subnet"
+
+# Worker machines
+publicIP: false
+subnet: "worker-subnet"
+```
+
+**Benefits:**
+- Bootstrap nodes accessible via public IPv4 and IPv6
+- Workers remain secure on private network
+- Internal load balancers work correctly with worker subnet
+- Defense in depth security model
+
+### Pattern 2: All Private (Maximum Security)
+
+Best for highly secure environments with VPN/Cloud Interconnect access.
+
+```yaml
+subnets:
+  - name: "private-subnet"
+    cidrBlock: "10.0.0.0/23"
+    externalIpv6: false  # All nodes use internal IPv6
+
+# All machines
+publicIP: false
+subnet: "private-subnet"
+```
+
+**Benefits:**
+- No public IP exposure
+- Reduced attack surface
+- Requires VPN/Interconnect for cluster access
+
+### Pattern 3: All Public (Development/Testing)
+
+Best for development clusters that need easy external access.
+
+```yaml
+subnets:
+  - name: "public-subnet"
+    cidrBlock: "10.0.0.0/23"
+    externalIpv6: true  # All nodes can get public IPv6
+
+# All machines
+publicIP: true
+subnet: "public-subnet"
+```
+
+**Warning:** Not recommended for production. Cannot use internal load balancers.
+
+## Using the Template
+
+### Prerequisites
+Set the following environment variables:
+```bash
+export CLUSTER_NAME="my-dual-stack-cluster"
+export GCP_PROJECT="my-gcp-project"
+export GCP_REGION="us-central1"
+export GCP_NETWORK_NAME="my-network"
+export CONTROL_PLANE_MACHINE_COUNT=3
+export WORKER_MACHINE_COUNT=3
+export GCP_CONTROL_PLANE_MACHINE_TYPE="n1-standard-2"
+export GCP_NODE_MACHINE_TYPE="n1-standard-2"
+export KUBERNETES_VERSION="v1.28.0"
+export IMAGE_ID="projects/my-project/global/images/family/capi-ubuntu-2004-k8s-v1-28"
+```
+
+### Create the Cluster
+```bash
+clusterctl generate cluster my-cluster \
+  --from templates/cluster-template-dual-stack.yaml \
+  | kubectl apply -f -
+```
+
+## Troubleshooting
+
+### Control plane nodes not getting IPv6 addresses
+**Symptoms:** Nodes only have IPv4 addresses, no IPv6
+
+**Solutions:**
+- Verify subnet has `externalIpv6: true` in the GCPCluster spec
+- Verify machine template has `publicIP: true`
+- Check GCP console for subnet IPv6 access type (should be "EXTERNAL")
+- Confirm `stackType: "DualStack"` is set on the network
+- Check that the network has `enableUlaInternalIpv6: true` (auto-set for dual stack)
+
+### Internal load balancer creation fails
+**Symptoms:** Error creating internal load balancer or forwarding rule
+
+**Solutions:**
+- Ensure the subnet used by the load balancer has `externalIpv6: false`
+- Check that subnet IPv6 access type is "INTERNAL" in GCP console
+- Verify `loadBalancerType: Internal` is not used with external IPv6 subnets
+- Check that you're not mixing internal LB with external IPv6 subnets
+
+### IPv6 connectivity issues
+**Symptoms:** Pods cannot reach IPv6 endpoints
+
+**Solutions:**
+- Verify CNI plugin supports dual stack (Calico, Cilium, etc.)
+- Check that both IPv4 and IPv6 pod CIDRs are configured in `clusterNetwork.pods.cidrBlocks`
+- Ensure firewall rules allow IPv6 traffic
+- Verify nodes have IPv6 addresses: `kubectl get nodes -o wide`
+- Check pod IPv6 assignments: `kubectl get pods -o wide`
+
+### Control plane endpoint uses wrong IP family
+**Symptoms:** Endpoint is IPv4 but you want IPv6 (or vice versa)
+
+**Solutions:**
+- Set `addressPreferencePolicy: "IPv6Primary"` for IPv6 endpoint
+- Set `addressPreferencePolicy: "IPv4Primary"` (default) for IPv4 endpoint
+- **Important:** When using IPv6Primary, ensure client tools support IPv6
+- Verify both load balancers are created in GCP console
+
+### IPv6 CIDR conflicts
+**Symptoms:** Subnet creation fails with CIDR overlap error
+
+**Solutions:**
+- Ensure `ipv6CidrRange` values are unique across all subnets
+- Use auto-assignment by omitting `ipv6CidrRange` (recommended)
+- For ULA ranges, use different /64 blocks from `fd00::/8`
+- Check existing VPC subnets for conflicts
+
+### Worker nodes cannot communicate
+**Symptoms:** Nodes or pods cannot reach each other or external services
+
+**Solutions:**
+- Ensure Cloud NAT is configured for IPv4 egress (IPv6 doesn't need NAT)
+- Verify firewall rules allow traffic between subnets for both IPv4 and IPv6
+- Check that all subnets are in the same VPC network
+- Verify default firewall rules are not disabled: check `firewall.defaultRulesManagement: "Managed"`
+- Ensure the `allow-${CLUSTER_NAME}-healthchecks-ipv6` firewall rule exists
+
+### Bootstrap process fails
+**Symptoms:** Control plane nodes fail to initialize
+
+**Solutions:**
+- Verify control plane nodes can reach the internet for package downloads
+- Check that `publicIP: true` is set for bootstrap nodes
+- Ensure external IPv6 subnet is configured if relying on IPv6 connectivity
+- Verify firewall rules allow egress traffic
+- Check Cloud NAT configuration for IPv4 egress if using private subnet
+
+## Common Gotchas and Best Practices
+
+### ✅ DO
+
+1. **Use auto-assignment for IPv6 CIDRs** - Let Google manage the addressing
+2. **Set `autoCreateSubnetworks: false`** - Required for custom subnet configuration
+3. **Use separate subnets** - Public subnet for bootstrap, private for workers
+4. **Test with IPv4Primary first** - Easier to debug, then switch to IPv6Primary if needed
+5. **Enable flow logs during development** - Set `enableFlowLogs: true` on subnets
+6. **Use CNI with dual stack support** - Calico, Cilium, or GCP's own CNI
+
+### ❌ DON'T
+
+1. **Don't mix internal LB with external IPv6 subnets** - They're incompatible
+2. **Don't manually manage firewall rules** - Use `defaultRulesManagement: "Managed"`
+3. **Don't forget cluster network CIDRs** - Must configure both IPv4 and IPv6 ranges
+4. **Don't use /128 or small IPv6 ranges** - Use /64 or larger for subnets
+5. **Don't expect IPv6-only** - GCP dual stack always includes IPv4
+6. **Don't reuse IPv6 CIDRs** - Each subnet needs a unique range
+
+### Performance Considerations
+
+- **IPv6 adds minimal overhead** - Modern networks handle it efficiently
+- **No NAT for IPv6** - Direct routing is faster than IPv4 NAT
+- **Health check latency** - Same for IPv4 and IPv6
+- **Load balancer costs** - Two load balancers (IPv4 + IPv6) incur additional costs
+
+## Migration from IPv4-Only to Dual Stack
+
+**Warning:** Migrating an existing IPv4-only cluster to dual stack requires recreating the cluster. In-place migration is not supported.
+
+### Migration Steps
+
+1. **Create new dual stack cluster** using the template
+2. **Migrate workloads** to the new cluster
+3. **Update DNS** to point to new load balancer IPs
+4. **Decommission old cluster** after validation
+
+### What Changes
+
+| Component | IPv4-Only | Dual Stack |
+|-----------|-----------|------------|
+| Network stack | `IPv4Only` | `DualStack` |
+| Subnet IPv6 access | N/A | `INTERNAL` or `EXTERNAL` |
+| Pod addresses | IPv4 only | IPv4 + IPv6 |
+| Service addresses | IPv4 only | IPv4 + IPv6 |
+| Node addresses | IPv4 only | IPv4 + IPv6 |
+| Load balancers | 1 (IPv4) | 2 (IPv4 + IPv6) |
+| Firewall rules | IPv4 only | IPv4 + IPv6 |
+| API endpoint | IPv4 | IPv4 or IPv6 (based on preference) |
+
+## Advanced Configuration
+
+### Using Custom IPv6 CIDR Ranges
+
+If you need specific IPv6 addressing:
+
+```yaml
+subnets:
+  - name: "custom-subnet"
+    cidrBlock: "10.0.0.0/24"
+    ipv6CidrRange: "fd00:1234:5678:abcd::/64"  # Custom ULA range
+    externalIpv6: false
+```
+
+**Best practices:**
+- Use sequential ranges for easier management (e.g., `fd00:1234:5678:1::/64`, `fd00:1234:5678:2::/64`)
+- Document your IPv6 addressing scheme
+- Leave room for future expansion
+
+### Multiple Regions
+
+For multi-region clusters, use different IPv6 ranges per region:
+
+```yaml
+subnets:
+  # us-central1
+  - name: "us-central1-subnet"
+    region: "us-central1"
+    cidrBlock: "10.0.0.0/24"
+    ipv6CidrRange: "fd00:1234:5678:100::/64"
+    
+  # us-east1
+  - name: "us-east1-subnet"
+    region: "us-east1"
+    cidrBlock: "10.1.0.0/24"
+    ipv6CidrRange: "fd00:1234:5678:200::/64"
+```
+
+## Feature Compatibility Matrix
+
+| Feature | IPv4Only | DualStack + IPv4Primary | DualStack + IPv6Primary |
+|---------|----------|------------------------|------------------------|
+| External Load Balancer | ✅ | ✅ | ✅ |
+| Internal Load Balancer | ✅ | ✅ (requires INTERNAL IPv6) | ✅ (requires INTERNAL IPv6) |
+| Cloud NAT | ✅ (required) | ✅ (IPv4 only) | ✅ (IPv4 only) |
+| Private Google Access | ✅ | ✅ | ✅ |
+| Shared VPC | ✅ | ✅ | ✅ |
+| Custom Firewall Rules | ✅ | ✅ (both families) | ✅ (both families) |
+| Public Bootstrap Nodes | ✅ | ✅ (both families) | ✅ (both families) |
+
+## References
+
+### Documentation
+- [GCP Dual Stack Documentation](https://cloud.google.com/vpc/docs/ipv6)
+- [GCP IPv6 Subnet Configuration](https://cloud.google.com/vpc/docs/subnets#ipv6-access-type)
+- [GCP Load Balancer Firewall Rules](https://cloud.google.com/load-balancing/docs/firewall-rules)
+- [Cluster API Provider GCP](https://github.com/kubernetes-sigs/cluster-api-provider-gcp)
+- [Kubernetes Dual Stack Networking](https://kubernetes.io/docs/concepts/services-networking/dual-stack/)
+
+### Relevant Code
+- Network interface configuration: `cloud/scope/machine.go:329-382`
+- Subnet specification: `cloud/scope/cluster.go:296-347`
+- IPv6 firewall rules: `cloud/scope/cluster.go:361-388`
+- Load balancer setup: `cloud/services/compute/loadbalancers/reconcile.go`
+- API types: `api/v1beta1/types.go:506-523`
+
+### Related Features
+- `externalIpv6` field (commit 672f6ee7): Enables public IPv6 on bootstrap nodes
+- `ipv6CidrRange` field (commit 35b4b8f9): Custom IPv6 CIDR assignment
+- `addressPreferencePolicy` field: Control plane endpoint IP family selection
+- Automatic IPv6 firewall rules: Health checks for dual stack load balancers

--- a/templates/cluster-template-dual-stack.yaml
+++ b/templates/cluster-template-dual-stack.yaml
@@ -1,0 +1,212 @@
+---
+# Dual Stack Cluster Template with Public Bootstrap Nodes
+#
+# This template demonstrates how to create a dual stack (IPv4 + IPv6) cluster with:
+# - Control plane nodes on a public subnet with both IPv4 and IPv6 public access (for bootstrap)
+# - Worker nodes on a private subnet with internal IPv6 (ULA) addresses only
+#
+# Key Configuration:
+# 1. GCPCluster.spec.network.stackType: "DualStack" enables dual stack networking
+# 2. Subnets with externalIpv6: true use EXTERNAL IPv6 (GUA ranges) for public access
+# 3. Subnets with externalIpv6: false (default) use INTERNAL IPv6 (ULA ranges)
+# 4. Control plane machines set publicIP: true to get public addresses
+# 5. Worker machines omit publicIP (defaults to false) for private-only access
+#
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+  labels:
+    cni: "${CLUSTER_NAME}-crs-cni"
+    ccm: "${CLUSTER_NAME}-crs-ccm"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - "192.168.0.0/16"  # IPv4 pod network
+      - "fd00:100:64::/48"  # IPv6 pod network
+    services:
+      cidrBlocks:
+      - "10.96.0.0/12"  # IPv4 service network
+      - "fd00:100:96::/108"  # IPv6 service network
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: GCPCluster
+    name: "${CLUSTER_NAME}"
+  controlPlaneRef:
+    kind: KubeadmControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: "${CLUSTER_NAME}-control-plane"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  project: "${GCP_PROJECT}"
+  region: "${GCP_REGION}"
+  network:
+    name: "${GCP_NETWORK_NAME}"
+    autoCreateSubnetworks: false
+    stackType: "DualStack"
+    # AddressPreferencePolicy determines which address family is preferred
+    # Options: IPv4Primary (default) or IPv6Primary
+    addressPreferencePolicy: "IPv4Primary"
+    subnets:
+      # Public subnet for control plane / bootstrap nodes
+      # externalIpv6: true enables EXTERNAL IPv6 access type
+      # Instances with publicIP: true will get both public IPv4 and IPv6 addresses
+      - name: "${CLUSTER_NAME}-control-plane-subnet"
+        cidrBlock: "10.0.0.0/24"
+        region: "${GCP_REGION}"
+        purpose: PRIVATE_RFC_1918
+        externalIpv6: true
+        description: "Public subnet for control plane nodes"
+        privateGoogleAccess: true
+        enableFlowLogs: false
+
+      # Private subnet for worker nodes
+      # externalIpv6: false (default) uses INTERNAL IPv6 with ULA ranges
+      # Required for compatibility with internal load balancers
+      - name: "${CLUSTER_NAME}-worker-subnet"
+        cidrBlock: "10.0.1.0/24"
+        region: "${GCP_REGION}"
+        purpose: PRIVATE_RFC_1918
+        externalIpv6: false
+        description: "Private subnet for worker nodes with internal IPv6"
+        privateGoogleAccess: true
+        enableFlowLogs: false
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  machineTemplate:
+    infrastructureRef:
+      kind: GCPMachineTemplate
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      name: "${CLUSTER_NAME}-control-plane"
+  kubeadmConfigSpec:
+    initConfiguration:
+      nodeRegistration:
+        name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+        kubeletExtraArgs:
+          cloud-provider: external
+    clusterConfiguration:
+      apiServer:
+        timeoutForControlPlane: 20m
+      controllerManager:
+        extraArgs:
+          cloud-provider: external
+          allocate-node-cidrs: "false"
+    joinConfiguration:
+      nodeRegistration:
+        name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+        kubeletExtraArgs:
+          cloud-provider: external
+  version: "${KUBERNETES_VERSION}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
+      image: "${IMAGE_ID}"
+      # publicIP: true enables public IPv4 address
+      # When combined with externalIpv6: true subnet, also enables public IPv6
+      publicIP: true
+      # Assign to the public subnet with external IPv6 access
+      subnet: "${CLUSTER_NAME}-control-plane-subnet"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-md-0"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: GCPMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      instanceType: "${GCP_NODE_MACHINE_TYPE}"
+      image: "${IMAGE_ID}"
+      # publicIP omitted (defaults to false) - worker nodes are private-only
+      # Will use private IPv4 and internal IPv6 (ULA) addresses
+      # Assign to the private subnet with internal IPv6 access
+      subnet: "${CLUSTER_NAME}-worker-subnet"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+          kubeletExtraArgs:
+            cloud-provider: external
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "${CLUSTER_NAME}-crs-cni"
+data: ${CNI_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: "${CLUSTER_NAME}-crs-cni"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-cni"
+  resources:
+    - name: "${CLUSTER_NAME}-crs-cni"
+      kind: ConfigMap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "${CLUSTER_NAME}-crs-ccm"
+data: ${CCM_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: "${CLUSTER_NAME}-crs-ccm"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      ccm: "${CLUSTER_NAME}-crs-ccm"
+  resources:
+    - name: "${CLUSTER_NAME}-crs-ccm"
+      kind: ConfigMap

--- a/test/e2e/config/gcp-ci.yaml
+++ b/test/e2e/config/gcp-ci.yaml
@@ -79,6 +79,7 @@ providers:
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/withclusterclass/cluster-template-ci-gke-autopilot-topology.yaml"
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-firewall-rules.yaml"
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-dual-stack.yaml"
+      - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-dual-stack-with-ipv6primary.yaml"
 
 variables:
   KUBERNETES_VERSION: "v1.33.2"

--- a/test/e2e/config/gcp-ci.yaml
+++ b/test/e2e/config/gcp-ci.yaml
@@ -78,6 +78,7 @@ providers:
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-internal-lb.yaml"
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/withclusterclass/cluster-template-ci-gke-autopilot-topology.yaml"
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-firewall-rules.yaml"
+      - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-dual-stack.yaml"
 
 variables:
   KUBERNETES_VERSION: "v1.33.2"

--- a/test/e2e/config/gcp-ci.yaml
+++ b/test/e2e/config/gcp-ci.yaml
@@ -79,6 +79,7 @@ providers:
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/withclusterclass/cluster-template-ci-gke-autopilot-topology.yaml"
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-firewall-rules.yaml"
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-dual-stack.yaml"
+      - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-dual-stack-with-ipv6primary.yaml"
 
 variables:
   KUBERNETES_VERSION: "v1.35.5"

--- a/test/e2e/config/gcp-ci.yaml
+++ b/test/e2e/config/gcp-ci.yaml
@@ -78,6 +78,7 @@ providers:
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-internal-lb.yaml"
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/withclusterclass/cluster-template-ci-gke-autopilot-topology.yaml"
       - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-firewall-rules.yaml"
+      - sourcePath: "${PWD}/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-dual-stack.yaml"
 
 variables:
   KUBERNETES_VERSION: "v1.35.5"

--- a/test/e2e/data/infrastructure-gcp/cluster-template-ci-dual-stack-with-ipv6primary.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-ci-dual-stack-with-ipv6primary.yaml
@@ -1,0 +1,169 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+  labels:
+    cni: "${CLUSTER_NAME}-crs-cni"
+    ccm: "${CLUSTER_NAME}-crs-ccm"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: GCPCluster
+    name: "${CLUSTER_NAME}"
+  controlPlaneRef:
+    kind: KubeadmControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: "${CLUSTER_NAME}-control-plane"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  project: "${GCP_PROJECT}"
+  region: "${GCP_REGION}"
+  network:
+    name: "${GCP_NETWORK_NAME}"
+    internalIpv6PrefixLength: 64
+    stackType: "DualStack"
+    addressPreferencePolicy: "IPv6Primary"
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  machineTemplate:
+    infrastructureRef:
+      kind: GCPMachineTemplate
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      name: "${CLUSTER_NAME}-control-plane"
+  kubeadmConfigSpec:
+    initConfiguration:
+      nodeRegistration:
+        name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+        kubeletExtraArgs:
+          cloud-provider: external
+    clusterConfiguration:
+      apiServer:
+        timeoutForControlPlane: 20m
+      controllerManager:
+        extraArgs:
+          cloud-provider: external
+          allocate-node-cidrs: "false"
+      kubernetesVersion: "${KUBERNETES_VERSION}"
+    files:
+      - content: |
+          [Global]
+
+          project-id = "${GCP_PROJECT}"
+          network-name = "${GCP_NETWORK_NAME}"
+          multizone = true
+        owner: root:root
+        path: /etc/kubernetes/cloud.config
+        permissions: "0744"
+    joinConfiguration:
+      nodeRegistration:
+        name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+        kubeletExtraArgs:
+          cloud-provider: external
+  version: "${KUBERNETES_VERSION}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
+      image: "${IMAGE_ID}"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-md-0"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: GCPMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      instanceType: "${GCP_NODE_MACHINE_TYPE}"
+      image: "${IMAGE_ID}"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+          kubeletExtraArgs:
+            cloud-provider: external
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "${CLUSTER_NAME}-crs-cni"
+data: ${CNI_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: "${CLUSTER_NAME}-crs-cni"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-cni"
+  resources:
+    - name: "${CLUSTER_NAME}-crs-cni"
+      kind: ConfigMap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "${CLUSTER_NAME}-crs-ccm"
+data: ${CCM_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: "${CLUSTER_NAME}-crs-ccm"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      ccm: "${CLUSTER_NAME}-crs-ccm"
+  resources:
+    - name: "${CLUSTER_NAME}-crs-ccm"
+      kind: ConfigMap

--- a/test/e2e/data/infrastructure-gcp/cluster-template-ci-dual-stack-with-ipv6primary.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-ci-dual-stack-with-ipv6primary.yaml
@@ -9,7 +9,13 @@ metadata:
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks: ["192.168.0.0/16"]
+      cidrBlocks:
+      - "fd00:100:64::/48"
+      - "192.168.0.0/16"
+    services:
+      cidrBlocks:
+      - "fd00:100:96::/108"
+      - "10.96.0.0/12"
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: GCPCluster

--- a/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-dual-stack.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-dual-stack.yaml
@@ -1,0 +1,168 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+  labels:
+    cni: "${CLUSTER_NAME}-crs-cni"
+    ccm: "${CLUSTER_NAME}-crs-ccm"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: GCPCluster
+    name: "${CLUSTER_NAME}"
+  controlPlaneRef:
+    kind: KubeadmControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: "${CLUSTER_NAME}-control-plane"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  project: "${GCP_PROJECT}"
+  region: "${GCP_REGION}"
+  network:
+    name: "${GCP_NETWORK_NAME}"
+    internalIpv6PrefixLength: 64
+    stackType: "DualStack"
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  machineTemplate:
+    infrastructureRef:
+      kind: GCPMachineTemplate
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      name: "${CLUSTER_NAME}-control-plane"
+  kubeadmConfigSpec:
+    initConfiguration:
+      nodeRegistration:
+        name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+        kubeletExtraArgs:
+          cloud-provider: external
+    clusterConfiguration:
+      apiServer:
+        timeoutForControlPlane: 20m
+      controllerManager:
+        extraArgs:
+          cloud-provider: external
+          allocate-node-cidrs: "false"
+      kubernetesVersion: "${KUBERNETES_VERSION}"
+    files:
+      - content: |
+          [Global]
+          
+          project-id = "${GCP_PROJECT}"
+          network-name = "${GCP_NETWORK_NAME}"
+          multizone = true
+        owner: root:root
+        path: /etc/kubernetes/cloud.config
+        permissions: "0744"
+    joinConfiguration:
+      nodeRegistration:
+        name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+        kubeletExtraArgs:
+          cloud-provider: external
+  version: "${KUBERNETES_VERSION}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
+      image: "${IMAGE_ID}"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-md-0"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: GCPMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      instanceType: "${GCP_NODE_MACHINE_TYPE}"
+      image: "${IMAGE_ID}"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+          kubeletExtraArgs:
+            cloud-provider: external
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "${CLUSTER_NAME}-crs-cni"
+data: ${CNI_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: "${CLUSTER_NAME}-crs-cni"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-cni"
+  resources:
+    - name: "${CLUSTER_NAME}-crs-cni"
+      kind: ConfigMap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "${CLUSTER_NAME}-crs-ccm"
+data: ${CCM_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: "${CLUSTER_NAME}-crs-ccm"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      ccm: "${CLUSTER_NAME}-crs-ccm"
+  resources:
+    - name: "${CLUSTER_NAME}-crs-ccm"
+      kind: ConfigMap

--- a/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-dual-stack.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-dual-stack.yaml
@@ -9,7 +9,13 @@ metadata:
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks: ["192.168.0.0/16"]
+      cidrBlocks:
+      - "192.168.0.0/16"
+      - "fd00:100:64::/48"
+    services:
+      cidrBlocks:
+      - "10.96.0.0/12"
+      - "fd00:100:96::/108"
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: GCPCluster

--- a/test/e2e/data/infrastructure-gcp/cluster-template-dual-stack-with-public-bootstrap.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-dual-stack-with-public-bootstrap.yaml
@@ -1,0 +1,200 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+  labels:
+    cni: "${CLUSTER_NAME}-crs-cni"
+    ccm: "${CLUSTER_NAME}-crs-ccm"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - "192.168.0.0/16"
+      - "fd00:100:64::/48"
+    services:
+      cidrBlocks:
+      - "10.96.0.0/12"
+      - "fd00:100:96::/108"
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: GCPCluster
+    name: "${CLUSTER_NAME}"
+  controlPlaneRef:
+    kind: KubeadmControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: "${CLUSTER_NAME}-control-plane"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  project: "${GCP_PROJECT}"
+  region: "${GCP_REGION}"
+  network:
+    name: "${GCP_NETWORK_NAME}"
+    autoCreateSubnetworks: false
+    stackType: "DualStack"
+    subnets:
+      # Public subnet for bootstrap/control-plane nodes with external IPv6 access
+      # This allows bootstrap nodes with publicIP: true to get both IPv4 and IPv6 public addresses
+      - name: "${CLUSTER_NAME}-control-plane-subnet"
+        cidrBlock: "10.0.0.0/24"
+        region: "${GCP_REGION}"
+        purpose: PRIVATE_RFC_1918
+        externalIpv6: true
+        description: "Public subnet for control plane nodes with external IPv4 and IPv6 access"
+      # Private subnet for worker nodes with internal IPv6 (ULA)
+      # This uses INTERNAL IPv6 with ULA ranges, required for internal load balancers
+      - name: "${CLUSTER_NAME}-worker-subnet"
+        cidrBlock: "10.0.1.0/24"
+        region: "${GCP_REGION}"
+        purpose: PRIVATE_RFC_1918
+        externalIpv6: false
+        description: "Private subnet for worker nodes with internal IPv6 (ULA)"
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  machineTemplate:
+    infrastructureRef:
+      kind: GCPMachineTemplate
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      name: "${CLUSTER_NAME}-control-plane"
+  kubeadmConfigSpec:
+    initConfiguration:
+      nodeRegistration:
+        name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+        kubeletExtraArgs:
+          cloud-provider: external
+    clusterConfiguration:
+      apiServer:
+        timeoutForControlPlane: 20m
+      controllerManager:
+        extraArgs:
+          cloud-provider: external
+          allocate-node-cidrs: "false"
+      kubernetesVersion: "${KUBERNETES_VERSION}"
+    files:
+      - content: |
+          [Global]
+
+          project-id = "${GCP_PROJECT}"
+          network-name = "${GCP_NETWORK_NAME}"
+          multizone = true
+        owner: root:root
+        path: /etc/kubernetes/cloud.config
+        permissions: "0744"
+    joinConfiguration:
+      nodeRegistration:
+        name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+        kubeletExtraArgs:
+          cloud-provider: external
+  version: "${KUBERNETES_VERSION}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
+      image: "${IMAGE_ID}"
+      # Enable public IP for bootstrap/control-plane nodes
+      # Combined with externalIpv6: true subnet, this gives both IPv4 and IPv6 public access
+      publicIP: true
+      # Assign control-plane nodes to the public subnet
+      subnet: "${CLUSTER_NAME}-control-plane-subnet"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-md-0"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: GCPMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      instanceType: "${GCP_NODE_MACHINE_TYPE}"
+      image: "${IMAGE_ID}"
+      # Worker nodes do NOT get public IPs (defaults to false)
+      # They will use private IPv4 addresses and internal IPv6 (ULA) addresses
+      # Assign worker nodes to the private subnet
+      subnet: "${CLUSTER_NAME}-worker-subnet"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'
+          kubeletExtraArgs:
+            cloud-provider: external
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "${CLUSTER_NAME}-crs-cni"
+data: ${CNI_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: "${CLUSTER_NAME}-crs-cni"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-cni"
+  resources:
+    - name: "${CLUSTER_NAME}-crs-cni"
+      kind: ConfigMap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "${CLUSTER_NAME}-crs-ccm"
+data: ${CCM_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: "${CLUSTER_NAME}-crs-ccm"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      ccm: "${CLUSTER_NAME}-crs-ccm"
+  resources:
+    - name: "${CLUSTER_NAME}-crs-ccm"
+      kind: ConfigMap

--- a/test/e2e/dual_stack_test.go
+++ b/test/e2e/dual_stack_test.go
@@ -1,0 +1,356 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Dual Stack Network Tests", func() {
+	var (
+		ctx                 = context.TODO()
+		specName            = "dual-stack-network"
+		namespace           *corev1.Namespace
+		cancelWatches       context.CancelFunc
+		result              *clusterctl.ApplyClusterTemplateAndWaitResult
+		clusterNamePrefix   string
+		clusterctlLogFolder string
+	)
+
+	BeforeEach(func() {
+		Expect(e2eConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
+		Expect(clusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. clusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(bootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. bootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(os.MkdirAll(artifactFolder, 0o755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
+
+		Expect(e2eConfig.Variables).To(HaveKey(KubernetesVersion))
+		Expect(e2eConfig.Variables).To(HaveKey(CCMPath))
+
+		clusterNamePrefix = fmt.Sprintf("capg-e2e-%s", util.RandomString(6))
+
+		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
+
+		result = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+
+		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
+		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
+	})
+
+	AfterEach(func() {
+		cleanInput := cleanupInput{
+			SpecName:             specName,
+			Cluster:              result.Cluster,
+			ClusterProxy:         bootstrapClusterProxy,
+			ClusterctlConfigPath: clusterctlConfigPath,
+			Namespace:            namespace,
+			CancelWatches:        cancelWatches,
+			IntervalsGetter:      e2eConfig.GetIntervals,
+			SkipCleanup:          skipCleanup,
+			ArtifactFolder:       artifactFolder,
+		}
+
+		dumpSpecResourcesAndCleanup(ctx, cleanInput)
+	})
+
+	Context("Testing StackType with DualStack and AddressPreferencePolicy IPv4Primary", func() {
+		It("Should create a cluster with DualStack network and IPv4 as primary address", func() {
+			clusterName := fmt.Sprintf("%s-ds-ipv4", clusterNamePrefix)
+
+			By("Creating a dual stack cluster with IPv4 primary address preference")
+			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+				ClusterProxy: bootstrapClusterProxy,
+				ConfigCluster: clusterctl.ConfigClusterInput{
+					LogFolder:                clusterctlLogFolder,
+					ClusterctlConfigPath:     clusterctlConfigPath,
+					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+					Flavor:                   "ci-with-dual-stack",
+					Namespace:                namespace.Name,
+					ClusterName:              clusterName,
+					KubernetesVersion:        e2eConfig.MustGetVariable(KubernetesVersion),
+					ControlPlaneMachineCount: ptr.To[int64](1),
+					WorkerMachineCount:       ptr.To[int64](1),
+				},
+				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+			}, result)
+
+			By("Verifying the GCPCluster has DualStack StackType configuration")
+			gcpCluster := &infrav1.GCPCluster{}
+			key := client.ObjectKey{
+				Namespace: namespace.Name,
+				Name:      clusterName,
+			}
+			Expect(bootstrapClusterProxy.GetClient().Get(ctx, key, gcpCluster)).To(Succeed())
+
+			// Verify StackType is DualStack
+			Expect(gcpCluster.Spec.Network.StackType).To(Equal(infrav1.DualStackType),
+				"StackType should be set to DualStack")
+
+			// Verify AddressPreferencePolicy defaults to IPv4Primary when not explicitly set
+			Expect(gcpCluster.Spec.Network.AddressPreferencePolicy).To(Or(
+				Equal(infrav1.IPv4Primary),
+				BeEmpty(), // Empty should default to IPv4Primary
+			), "AddressPreferencePolicy should default to IPv4Primary")
+
+			By("Verifying both IPv4 and IPv6 addresses are allocated in status")
+			// Verify IPv4 address exists
+			Expect(gcpCluster.Status.Network.APIServerAddress).ToNot(BeNil(),
+				"IPv4 APIServerAddress should be allocated for DualStack")
+			ipv4Addr := *gcpCluster.Status.Network.APIServerAddress
+			Expect(ipv4Addr).ToNot(BeEmpty())
+			Expect(isValidIPv4(ipv4Addr)).To(BeTrue(),
+				"APIServerAddress should be a valid IPv4 address, got: %s", ipv4Addr)
+
+			// Verify IPv6 address exists for dual stack
+			Expect(gcpCluster.Status.Network.APIServerIPv6Address).ToNot(BeNil(),
+				"IPv6 APIServerIPv6Address should be allocated for DualStack")
+			ipv6Addr := *gcpCluster.Status.Network.APIServerIPv6Address
+			Expect(ipv6Addr).ToNot(BeEmpty())
+			Expect(isValidIPv6(ipv6Addr)).To(BeTrue(),
+				"APIServerIPv6Address should be a valid IPv6 address, got: %s", ipv6Addr)
+
+			By("Verifying control plane endpoint uses IPv4 address when AddressPreferencePolicy is IPv4Primary")
+			Expect(gcpCluster.Spec.ControlPlaneEndpoint.Host).To(Equal(ipv4Addr),
+				"Control plane endpoint should use IPv4 address when AddressPreferencePolicy is IPv4Primary")
+
+			By("Verifying both IPv4 and IPv6 forwarding rules exist")
+			Expect(gcpCluster.Status.Network.APIServerForwardingRule).ToNot(BeNil(),
+				"IPv4 forwarding rule should exist for DualStack")
+			Expect(*gcpCluster.Status.Network.APIServerForwardingRule).ToNot(BeEmpty())
+
+			Expect(gcpCluster.Status.Network.APIServerIPv6ForwardingRule).ToNot(BeNil(),
+				"IPv6 forwarding rule should exist for DualStack")
+			Expect(*gcpCluster.Status.Network.APIServerIPv6ForwardingRule).ToNot(BeEmpty())
+
+			By("Verifying internal load balancer has both IPv4 and IPv6 addresses")
+			if gcpCluster.Status.Network.APIInternalAddress != nil {
+				internalIPv4 := *gcpCluster.Status.Network.APIInternalAddress
+				Expect(isValidIPv4(internalIPv4)).To(BeTrue(),
+					"Internal IPv4 address should be valid")
+			}
+
+			if gcpCluster.Status.Network.APIInternalIPv6Address != nil {
+				internalIPv6 := *gcpCluster.Status.Network.APIInternalIPv6Address
+				Expect(isValidIPv6(internalIPv6)).To(BeTrue(),
+					"Internal IPv6 address should be valid")
+			}
+		})
+	})
+
+	Context("Testing StackType with DualStack and AddressPreferencePolicy IPv6Primary", func() {
+		It("Should create a cluster with DualStack network and IPv6 as primary address", func() {
+			clusterName := fmt.Sprintf("%s-ds-ipv6", clusterNamePrefix)
+
+			By("Creating a dual stack cluster with IPv6 primary address preference")
+			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+				ClusterProxy: bootstrapClusterProxy,
+				ConfigCluster: clusterctl.ConfigClusterInput{
+					LogFolder:                clusterctlLogFolder,
+					ClusterctlConfigPath:     clusterctlConfigPath,
+					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+					Flavor:                   "ci-dual-stack-with-ipv6primary",
+					Namespace:                namespace.Name,
+					ClusterName:              clusterName,
+					KubernetesVersion:        e2eConfig.MustGetVariable(KubernetesVersion),
+					ControlPlaneMachineCount: ptr.To[int64](1),
+					WorkerMachineCount:       ptr.To[int64](1),
+				},
+				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+			}, result)
+
+			By("Verifying the GCPCluster has DualStack StackType with IPv6Primary AddressPreferencePolicy")
+			gcpCluster := &infrav1.GCPCluster{}
+			key := client.ObjectKey{
+				Namespace: namespace.Name,
+				Name:      clusterName,
+			}
+			Expect(bootstrapClusterProxy.GetClient().Get(ctx, key, gcpCluster)).To(Succeed())
+
+			// Verify StackType is DualStack
+			Expect(gcpCluster.Spec.Network.StackType).To(Equal(infrav1.DualStackType),
+				"StackType should be set to DualStack")
+
+			// Verify AddressPreferencePolicy is IPv6Primary
+			Expect(gcpCluster.Spec.Network.AddressPreferencePolicy).To(Equal(infrav1.IPv6Primary),
+				"AddressPreferencePolicy should be set to IPv6Primary")
+
+			By("Verifying both IPv4 and IPv6 addresses are allocated in status")
+			// Verify IPv4 address exists
+			Expect(gcpCluster.Status.Network.APIServerAddress).ToNot(BeNil(),
+				"IPv4 address should still be allocated in DualStack mode")
+			ipv4Addr := *gcpCluster.Status.Network.APIServerAddress
+			Expect(isValidIPv4(ipv4Addr)).To(BeTrue(),
+				"APIServerAddress should be a valid IPv4 address")
+
+			// Verify IPv6 address exists
+			Expect(gcpCluster.Status.Network.APIServerIPv6Address).ToNot(BeNil(),
+				"IPv6 address should be allocated for DualStack")
+			ipv6Addr := *gcpCluster.Status.Network.APIServerIPv6Address
+			Expect(isValidIPv6(ipv6Addr)).To(BeTrue(),
+				"APIServerIPv6Address should be a valid IPv6 address")
+
+			By("Verifying control plane endpoint uses IPv6 address when AddressPreferencePolicy is IPv6Primary")
+			Expect(gcpCluster.Spec.ControlPlaneEndpoint.Host).To(Equal(ipv6Addr),
+				"Control plane endpoint should use IPv6 address when AddressPreferencePolicy is IPv6Primary")
+
+			By("Verifying both IPv4 and IPv6 forwarding rules exist")
+			Expect(gcpCluster.Status.Network.APIServerForwardingRule).ToNot(BeNil(),
+				"IPv4 forwarding rule should exist")
+			Expect(gcpCluster.Status.Network.APIServerIPv6ForwardingRule).ToNot(BeNil(),
+				"IPv6 forwarding rule should exist")
+		})
+	})
+
+	Context("Testing StackType with IPv4Only (default behavior)", func() {
+		It("Should create a cluster with IPv4Only network (no IPv6 addresses)", func() {
+			clusterName := fmt.Sprintf("%s-ipv4only", clusterNamePrefix)
+
+			By("Creating an IPv4-only cluster using default flavor")
+			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+				ClusterProxy: bootstrapClusterProxy,
+				ConfigCluster: clusterctl.ConfigClusterInput{
+					LogFolder:                clusterctlLogFolder,
+					ClusterctlConfigPath:     clusterctlConfigPath,
+					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+					Flavor:                   clusterctl.DefaultFlavor,
+					Namespace:                namespace.Name,
+					ClusterName:              clusterName,
+					KubernetesVersion:        e2eConfig.MustGetVariable(KubernetesVersion),
+					ControlPlaneMachineCount: ptr.To[int64](1),
+					WorkerMachineCount:       ptr.To[int64](1),
+				},
+				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+			}, result)
+
+			By("Verifying the GCPCluster has IPv4Only StackType")
+			gcpCluster := &infrav1.GCPCluster{}
+			key := client.ObjectKey{
+				Namespace: namespace.Name,
+				Name:      clusterName,
+			}
+			Expect(bootstrapClusterProxy.GetClient().Get(ctx, key, gcpCluster)).To(Succeed())
+
+			// Verify StackType is IPv4Only or defaults to it
+			Expect(gcpCluster.Spec.Network.StackType).To(Or(
+				Equal(infrav1.IPv4OnlyStackType),
+				BeEmpty(), // Empty should default to IPv4Only
+			), "StackType should be IPv4Only or empty (which defaults to IPv4Only)")
+
+			By("Verifying only IPv4 addresses are allocated (no IPv6)")
+			// Verify IPv4 address exists
+			Expect(gcpCluster.Status.Network.APIServerAddress).ToNot(BeNil(),
+				"IPv4 address should be allocated")
+			ipv4Addr := *gcpCluster.Status.Network.APIServerAddress
+			Expect(isValidIPv4(ipv4Addr)).To(BeTrue(),
+				"APIServerAddress should be a valid IPv4 address")
+
+			// Verify IPv6 addresses do NOT exist for IPv4Only
+			Expect(gcpCluster.Status.Network.APIServerIPv6Address).To(Or(
+				BeNil(),
+				PointTo(BeEmpty()),
+			), "IPv6 address should not be set for IPv4Only StackType")
+
+			Expect(gcpCluster.Status.Network.APIServerIPv6ForwardingRule).To(Or(
+				BeNil(),
+				PointTo(BeEmpty()),
+			), "IPv6 forwarding rule should not be set for IPv4Only StackType")
+
+			By("Verifying control plane endpoint uses IPv4 address")
+			Expect(gcpCluster.Spec.ControlPlaneEndpoint.Host).To(Equal(ipv4Addr),
+				"Control plane endpoint should use IPv4 address for IPv4Only")
+
+			By("Verifying AddressPreferencePolicy defaults to IPv4Primary or is not set for IPv4Only")
+			Expect(gcpCluster.Spec.Network.AddressPreferencePolicy).To(Or(
+				Equal(infrav1.IPv4Primary),
+				BeEmpty(),
+			), "AddressPreferencePolicy should be IPv4Primary or empty for IPv4Only")
+		})
+	})
+
+	Context("Creating a control-plane cluster with three control plane nodes and a dual stack network", func() {
+		It("Should create a cluster with 3 control-plane and 1 worker node with a dual stack network", func() {
+			Skip("This test requires a bootstrap cluster that has access to the network where the cluster is being created.")
+
+			clusterName := fmt.Sprintf("%s-dual-stack-ha", clusterNamePrefix)
+			By("Creating a cluster with a dual stack network from GKE bootstrap cluster")
+			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+				ClusterProxy: bootstrapClusterProxy,
+				ConfigCluster: clusterctl.ConfigClusterInput{
+					LogFolder:                clusterctlLogFolder,
+					ClusterctlConfigPath:     clusterctlConfigPath,
+					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+					Flavor:                   "ci-with-dual-stack",
+					Namespace:                namespace.Name,
+					ClusterName:              clusterName,
+					KubernetesVersion:        e2eConfig.MustGetVariable(KubernetesVersion),
+					ControlPlaneMachineCount: ptr.To[int64](3),
+					WorkerMachineCount:       ptr.To[int64](1),
+				},
+				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+			}, result)
+		})
+	})
+})
+
+// isValidIPv4 checks if a string is a valid IPv4 address
+func isValidIPv4(ipStr string) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	// Check if it's an IPv4 address
+	return ip.To4() != nil
+}
+
+// isValidIPv6 checks if a string is a valid IPv6 address
+func isValidIPv6(ipStr string) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	// Check if it's an IPv6 address (not IPv4)
+	return ip.To4() == nil && ip.To16() != nil
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -273,6 +273,33 @@ var _ = Describe("Workload cluster creation", func() {
 		})
 	})
 
+	Context("Creating a control-plane cluster with three control plane nodes and a dual stack network", func() {
+		It("Should create a cluster with 3 control-plane and 1 worker node with a dual stack network", func() {
+			Skip("This test requires a bootstrap cluster that has access to the network where the cluster is being created.")
+
+			clusterName := fmt.Sprintf("%s-dual-stack", clusterNamePrefix)
+			By("Creating a cluster with a dual stack network from GKE bootstrap cluster")
+			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+				ClusterProxy: bootstrapClusterProxy,
+				ConfigCluster: clusterctl.ConfigClusterInput{
+					LogFolder:                clusterctlLogFolder,
+					ClusterctlConfigPath:     clusterctlConfigPath,
+					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+					Flavor:                   "ci-with-dual-stack",
+					Namespace:                namespace.Name,
+					ClusterName:              clusterName,
+					KubernetesVersion:        e2eConfig.MustGetVariable(KubernetesVersion),
+					ControlPlaneMachineCount: ptr.To[int64](3),
+					WorkerMachineCount:       ptr.To[int64](1),
+				},
+				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+			}, result)
+		})
+	})
+
 	Context("Creating a cluster using a cluster class", func() {
 		It("Should create a cluster class and then a cluster based on it", func() {
 			clusterName := fmt.Sprintf("%s-topology", clusterNamePrefix)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -273,33 +273,6 @@ var _ = Describe("Workload cluster creation", func() {
 		})
 	})
 
-	Context("Creating a control-plane cluster with three control plane nodes and a dual stack network", func() {
-		It("Should create a cluster with 3 control-plane and 1 worker node with a dual stack network", func() {
-			Skip("This test requires a bootstrap cluster that has access to the network where the cluster is being created.")
-
-			clusterName := fmt.Sprintf("%s-dual-stack", clusterNamePrefix)
-			By("Creating a cluster with a dual stack network from GKE bootstrap cluster")
-			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
-				ClusterProxy: bootstrapClusterProxy,
-				ConfigCluster: clusterctl.ConfigClusterInput{
-					LogFolder:                clusterctlLogFolder,
-					ClusterctlConfigPath:     clusterctlConfigPath,
-					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
-					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
-					Flavor:                   "ci-with-dual-stack",
-					Namespace:                namespace.Name,
-					ClusterName:              clusterName,
-					KubernetesVersion:        e2eConfig.MustGetVariable(KubernetesVersion),
-					ControlPlaneMachineCount: ptr.To[int64](3),
-					WorkerMachineCount:       ptr.To[int64](1),
-				},
-				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
-				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
-				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
-			}, result)
-		})
-	})
-
 	Context("Creating a cluster using a cluster class", func() {
 		It("Should create a cluster class and then a cluster based on it", func() {
 			clusterName := fmt.Sprintf("%s-topology", clusterNamePrefix)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -264,33 +264,6 @@ var _ = Describe("Workload cluster creation", func() {
 		})
 	})
 
-	Context("Creating a control-plane cluster with three control plane nodes and a dual stack network", func() {
-		It("Should create a cluster with 3 control-plane and 1 worker node with a dual stack network", func() {
-			Skip("This test requires a bootstrap cluster that has access to the network where the cluster is being created.")
-
-			clusterName := fmt.Sprintf("%s-dual-stack", clusterNamePrefix)
-			By("Creating a cluster with a dual stack network from GKE bootstrap cluster")
-			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
-				ClusterProxy: bootstrapClusterProxy,
-				ConfigCluster: clusterctl.ConfigClusterInput{
-					LogFolder:                clusterctlLogFolder,
-					ClusterctlConfigPath:     clusterctlConfigPath,
-					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
-					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
-					Flavor:                   "ci-with-dual-stack",
-					Namespace:                namespace.Name,
-					ClusterName:              clusterName,
-					KubernetesVersion:        e2eConfig.MustGetVariable(KubernetesVersion),
-					ControlPlaneMachineCount: ptr.To[int64](3),
-					WorkerMachineCount:       ptr.To[int64](1),
-				},
-				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
-				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
-				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
-			}, result)
-		})
-	})
-
 	Context("Creating a cluster using a cluster class", func() {
 		It("Should create a cluster class and then a cluster based on it", func() {
 			clusterName := fmt.Sprintf("%s-topology", clusterNamePrefix)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -264,6 +264,33 @@ var _ = Describe("Workload cluster creation", func() {
 		})
 	})
 
+	Context("Creating a control-plane cluster with three control plane nodes and a dual stack network", func() {
+		It("Should create a cluster with 3 control-plane and 1 worker node with a dual stack network", func() {
+			Skip("This test requires a bootstrap cluster that has access to the network where the cluster is being created.")
+
+			clusterName := fmt.Sprintf("%s-dual-stack", clusterNamePrefix)
+			By("Creating a cluster with a dual stack network from GKE bootstrap cluster")
+			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+				ClusterProxy: bootstrapClusterProxy,
+				ConfigCluster: clusterctl.ConfigClusterInput{
+					LogFolder:                clusterctlLogFolder,
+					ClusterctlConfigPath:     clusterctlConfigPath,
+					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+					Flavor:                   "ci-with-dual-stack",
+					Namespace:                namespace.Name,
+					ClusterName:              clusterName,
+					KubernetesVersion:        e2eConfig.MustGetVariable(KubernetesVersion),
+					ControlPlaneMachineCount: ptr.To[int64](3),
+					WorkerMachineCount:       ptr.To[int64](1),
+				},
+				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+			}, result)
+		})
+	})
+
 	Context("Creating a cluster using a cluster class", func() {
 		It("Should create a cluster class and then a cluster based on it", func() {
 			clusterName := fmt.Sprintf("%s-topology", clusterNamePrefix)


### PR DESCRIPTION
api/v1beta/types.go:

Adding support for machines and simple network changes for IPV6 or dual stack work.
- InternalIpv6PrefixLength
- IPv6Address
- StackType

cloud/scope/machine.go:

Adding support for instances and networks to allow dual stack components.

- InstanceNetworkInterfaceSpec
  - InternalIpv6PrefixLength
  - Ipv6AccessConfigs
    - ExternalIPv6
    - ExternalIpv6PrefixLength
    - Type (when present always set to DIRECT_IPV6)
    - Name (always set to External IPv6)
  - IPv6AccessType
  - Ipv6Address
  - StackType

- InstanceSpec
  - PrivateIpv6GoogleAccess

- InstanceNetworkInterfaceAliasIPRangesSpec ** This did not change. The AliasIPs appear to only support IPv4 CIDR or single address format.

cloud/interfaces.go:

Expose a couple of new functions to get StackType and IPvAddress information from the cluster specs. These are only getter functions for the Machine.go to access.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->
/kind feature
/kind api-change

**What this PR does / why we need it**:

This PR will serve as a focal point for adding dual stack support to CAPG.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/1486
https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/478

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Basic Support for Dual stack infrastructure is added to CAPG.

The resources include addresses, firewall rules, instances, vpc, and subnets.
```
