### PR TITLE
CORS-4304: Add support for custom instance types

### DIFF
--- a/api/v1beta1/gcpmachine_types.go
+++ b/api/v1beta1/gcpmachine_types.go
@@ -258,6 +258,19 @@ type GCPMachineSpec struct {
 	// InstanceType is the type of instance to create. Example: n1.standard-2
 	InstanceType string `json:"instanceType"`
 
+	// CPUs is the number of CPUs for the custom machine type.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=64
+	// +kubebuilder:validation:XValidation:rule="self % 2 == 0 || self == 1",message="CPUs must be 1 or an even number 64 or less"
+	// +optional
+	CPUs int `json:"cpus,omitempty"`
+
+	// MemoryMb is the amount memory in GB for the custom machine type.
+	// +kubebuilder:validation:Minimum=2
+	// +kubebuilder:validation:Maximum=512
+	// +optional
+	MemoryGB int `json:"memoryGB,omitempty"`
+
 	// Subnet is a reference to the subnetwork to use for this instance. If not specified,
 	// the first subnetwork retrieved from the Cluster Region and Network is picked.
 	// +optional

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -409,10 +409,16 @@ func instanceGuestAcceleratorsSpec(guestAccelerators []infrav1.Accelerator) []*c
 func (m *MachineScope) InstanceSpec(log logr.Logger) *compute.Instance {
 	ctx := context.TODO()
 
+	machineType := path.Join("zones", m.Zone(), "machineTypes", m.GCPMachine.Spec.InstanceType)
+	if m.GCPMachine.Spec.CPUs > 0 && m.GCPMachine.Spec.MemoryGB > 1 {
+		memoryMb := m.GCPMachine.Spec.MemoryGB * 1024
+		machineType = fmt.Sprintf("%s-%d-%d", machineType, m.GCPMachine.Spec.CPUs, memoryMb)
+	}
+
 	instance := &compute.Instance{
 		Name:        m.Name(),
 		Zone:        m.Zone(),
-		MachineType: path.Join("zones", m.Zone(), "machineTypes", m.GCPMachine.Spec.InstanceType),
+		MachineType: machineType,
 		Tags: &compute.Tags{
 			Items: append(
 				m.GCPMachine.Spec.AdditionalNetworkTags,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
@@ -234,6 +234,14 @@ spec:
                 - AMDEncryptedVirtualizationNestedPaging
                 - IntelTrustedDomainExtensions
                 type: string
+              cpus:
+                description: CPUs is the number of CPUs for the custom machine type.
+                maximum: 64
+                minimum: 1
+                type: integer
+                x-kubernetes-validations:
+                - message: CPUs must be 1 or an even number 64 or less
+                  rule: self % 2 == 0 || self == 1
               guestAccelerators:
                 description: |-
                   GuestAccelerators is a list of the type and count of accelerator cards
@@ -281,6 +289,12 @@ spec:
                 - Enabled
                 - Disabled
                 type: string
+              memoryGB:
+                description: MemoryMb is the amount memory in GB for the custom machine
+                  type.
+                maximum: 512
+                minimum: 2
+                type: integer
               onHostMaintenance:
                 description: |-
                   OnHostMaintenance determines the behavior when a maintenance event occurs that might cause the instance to reboot.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
@@ -249,6 +249,15 @@ spec:
                         - AMDEncryptedVirtualizationNestedPaging
                         - IntelTrustedDomainExtensions
                         type: string
+                      cpus:
+                        description: CPUs is the number of CPUs for the custom machine
+                          type.
+                        maximum: 64
+                        minimum: 1
+                        type: integer
+                        x-kubernetes-validations:
+                        - message: CPUs must be 1 or an even number 64 or less
+                          rule: self % 2 == 0 || self == 1
                       guestAccelerators:
                         description: |-
                           GuestAccelerators is a list of the type and count of accelerator cards
@@ -296,6 +305,12 @@ spec:
                         - Enabled
                         - Disabled
                         type: string
+                      memoryGB:
+                        description: MemoryMb is the amount memory in GB for the custom
+                          machine type.
+                        maximum: 512
+                        minimum: 2
+                        type: integer
                       onHostMaintenance:
                         description: |-
                           OnHostMaintenance determines the behavior when a maintenance event occurs that might cause the instance to reboot.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind feature
/kind api-change

**What this PR does / why we need it**:

With the addition of N4A instances comes the ability to customize instance types (again). To support this feature the number of cpus and memory in Gb is listed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://issues.redhat.com/browse/CORS-4304

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
With the addition of N4A instances comes the ability to customize instance types (again). To support this feature the number of cpus and memory in Gb is listed. Below is a snippet from the GCP Instance in the Compute Package:

	// To create acustom
	// machine type, provide a URL to a machine type in the following format,
	// where CPUS is 1 or an even number up to 32 (2,
	// 4, 6, ... 24, etc), and MEMORY is the total
	// memory for this instance. Memory must be a multiple of 256 MB and must
	// be supplied in MB (e.g. 5 GB of memory is 5120
	// MB):
	//
	// zones/zone/machineTypes/custom-CPUS-MEMORY

The support is added here to change Gb to Mb (this helps ensure that it will be a multiple of 256 as well as smaller numbers to validate/verify.
```
