### PR TITLE
⚠️ Move webhooks out of API packages

### DIFF
--- a/api/v1beta1/gcpmachine_types.go
+++ b/api/v1beta1/gcpmachine_types.go
@@ -142,14 +142,6 @@ const (
 	ConfidentialComputePolicyTDX ConfidentialComputePolicy = "IntelTrustedDomainExtensions"
 )
 
-// Confidential VM Technology support depends on the configured machine types.
-// reference: https://cloud.google.com/compute/confidential-vm/docs/os-and-machine-type#machine-type
-var (
-	confidentialMachineSeriesSupportingSev    = []string{"n2d", "c2d", "c3d"}
-	confidentialMachineSeriesSupportingSevsnp = []string{"n2d"}
-	confidentialMachineSeriesSupportingTdx    = []string{"c3"}
-)
-
 // HostMaintenancePolicy represents the desired behavior ase of a host maintenance event.
 type HostMaintenancePolicy string
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ package v1beta1
 
 import (
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	corev1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 )
 

--- a/exp/api/v1beta1/zz_generated.deepcopy.go
+++ b/exp/api/v1beta1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	apiv1beta1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	corev1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 )

--- a/exp/webhooks/doc.go
+++ b/exp/webhooks/doc.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,4 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+// Package webhooks contains the experimental API webhooks implementation.
+package webhooks

--- a/exp/webhooks/gcpmachinepool_webhook.go
+++ b/exp/webhooks/gcpmachinepool_webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -22,6 +22,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -33,22 +34,22 @@ var gcpMachinePoolLog = logf.Log.WithName("gcpmachinepool-resource")
 
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
 func (r *GCPMachinePool) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	validator := new(gcpMachinePoolWebhook)
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
-		WithValidator(validator).
+		For(&expinfrav1.GCPMachinePool{}).
+		WithValidator(r).
 		Complete()
 }
 
-type gcpMachinePoolWebhook struct{}
+// GCPMachinePool implements a validating webhook for GCPMachinePool.
+type GCPMachinePool struct{}
 
 //+kubebuilder:webhook:verbs=update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmachinepool,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=gcpmachinepools,versions=v1beta1,name=validation.gcpmachinepool.infrastructure.cluster.x-k8s.io,admissionReviewVersions=v1
 
-var _ webhook.CustomValidator = &gcpMachinePoolWebhook{}
+var _ webhook.CustomValidator = &GCPMachinePool{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpMachinePoolWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*GCPMachinePool)
+func (*GCPMachinePool) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	r, ok := obj.(*expinfrav1.GCPMachinePool)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a GCPMachinePool but got a %T", obj))
 	}
@@ -61,8 +62,8 @@ func (*gcpMachinePoolWebhook) ValidateCreate(_ context.Context, obj runtime.Obje
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpMachinePoolWebhook) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (admission.Warnings, error) {
-	r, ok := newObj.(*GCPMachinePool)
+func (*GCPMachinePool) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (admission.Warnings, error) {
+	r, ok := newObj.(*expinfrav1.GCPMachinePool)
 	if !ok {
 		return nil, fmt.Errorf("expected a GCPMachinePool object but got %T", r)
 	}
@@ -75,8 +76,8 @@ func (*gcpMachinePoolWebhook) ValidateUpdate(_ context.Context, _, newObj runtim
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpMachinePoolWebhook) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*GCPMachinePool)
+func (*GCPMachinePool) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	r, ok := obj.(*expinfrav1.GCPMachinePool)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a GCPMachinePool but got a %T", obj))
 	}

--- a/exp/webhooks/gcpmanagedcluster_webhook.go
+++ b/exp/webhooks/gcpmanagedcluster_webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -34,10 +35,9 @@ import (
 // log is for logging in this package.
 var gcpmanagedclusterlog = logf.Log.WithName("gcpmanagedcluster-resource")
 
-func (r *GCPManagedCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	w := new(gcpManagedClusterWebhook)
+func (w *GCPManagedCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&expinfrav1.GCPManagedCluster{}).
 		WithValidator(w).
 		WithDefaulter(w).
 		Complete()
@@ -45,41 +45,42 @@ func (r *GCPManagedCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedcluster,mutating=true,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=gcpmanagedclusters,verbs=create;update,versions=v1beta1,name=mgcpmanagedcluster.kb.io,admissionReviewVersions=v1
 
-type gcpManagedClusterWebhook struct{}
+// GCPManagedCluster implements a validating and defaulting webhook for GCPManagedCluster.
+type GCPManagedCluster struct{}
 
-var _ webhook.CustomDefaulter = &gcpManagedClusterWebhook{}
+var _ webhook.CustomDefaulter = &GCPManagedCluster{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (*gcpManagedClusterWebhook) Default(_ context.Context, _ runtime.Object) error {
+func (*GCPManagedCluster) Default(_ context.Context, _ runtime.Object) error {
 	return nil
 }
 
 //+kubebuilder:webhook:path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedcluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=gcpmanagedclusters,verbs=create;update,versions=v1beta1,name=vgcpmanagedcluster.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomValidator = &gcpManagedClusterWebhook{}
+var _ webhook.CustomValidator = &GCPManagedCluster{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedClusterWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*GCPManagedCluster)
+func (w *GCPManagedCluster) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	r, ok := obj.(*expinfrav1.GCPManagedCluster)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPManagedCluster object but got %T", r)
 	}
 
 	gcpmanagedclusterlog.Info("validate create", "name", r.Name)
 
-	return r.validate()
+	return w.validate(r)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedClusterWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	r, ok := newObj.(*GCPManagedCluster)
+func (w *GCPManagedCluster) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	r, ok := newObj.(*expinfrav1.GCPManagedCluster)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPManagedCluster object but got %T", r)
 	}
 
 	gcpmanagedclusterlog.Info("validate update", "name", r.Name)
 	var allErrs field.ErrorList
-	old := oldObj.(*GCPManagedCluster)
+	old := oldObj.(*expinfrav1.GCPManagedCluster)
 
 	if !cmp.Equal(r.Spec.Project, old.Spec.Project) {
 		allErrs = append(allErrs,
@@ -106,17 +107,17 @@ func (*gcpManagedClusterWebhook) ValidateUpdate(_ context.Context, oldObj, newOb
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("GCPManagedCluster").GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(expinfrav1.GroupVersion.WithKind("GCPManagedCluster").GroupKind(), r.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedClusterWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (*GCPManagedCluster) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (r *GCPManagedCluster) validate() (admission.Warnings, error) {
+func (w *GCPManagedCluster) validate(r *expinfrav1.GCPManagedCluster) (admission.Warnings, error) {
 	validators := []func() error{
-		r.validateCustomSubnet,
+		func() error { return w.validateCustomSubnet(r) },
 	}
 
 	var errs []error
@@ -129,7 +130,7 @@ func (r *GCPManagedCluster) validate() (admission.Warnings, error) {
 	return nil, kerrors.NewAggregate(errs)
 }
 
-func (r *GCPManagedCluster) validateCustomSubnet() error {
+func (w *GCPManagedCluster) validateCustomSubnet(r *expinfrav1.GCPManagedCluster) error {
 	gcpmanagedclusterlog.Info("validate custom subnet", "name", r.Name)
 	if r.Spec.Network.AutoCreateSubnetworks == nil || *r.Spec.Network.AutoCreateSubnetworks {
 		return nil

--- a/exp/webhooks/gcpmanagedcluster_webhook_test.go
+++ b/exp/webhooks/gcpmanagedcluster_webhook_test.go
@@ -14,25 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"testing"
 
 	. "github.com/onsi/gomega"
 	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 )
 
 func TestGCPManagedClusterValidatingWebhookUpdate(t *testing.T) {
 	tests := []struct {
 		name        string
 		expectError bool
-		spec        GCPManagedClusterSpec
+		spec        expinfrav1.GCPManagedClusterSpec
 	}{
 		{
 			name:        "request to change mutable field additional labels",
 			expectError: false,
-			spec: GCPManagedClusterSpec{
+			spec: expinfrav1.GCPManagedClusterSpec{
 				Project: "old-project",
 				Region:  "us-west1",
 				CredentialsRef: &infrav1.ObjectReference{
@@ -47,7 +48,7 @@ func TestGCPManagedClusterValidatingWebhookUpdate(t *testing.T) {
 		{
 			name:        "request to change immutable field project",
 			expectError: true,
-			spec: GCPManagedClusterSpec{
+			spec: expinfrav1.GCPManagedClusterSpec{
 				Project: "new-project",
 				Region:  "us-west1",
 				CredentialsRef: &infrav1.ObjectReference{
@@ -59,7 +60,7 @@ func TestGCPManagedClusterValidatingWebhookUpdate(t *testing.T) {
 		{
 			name:        "request to change immutable field region",
 			expectError: true,
-			spec: GCPManagedClusterSpec{
+			spec: expinfrav1.GCPManagedClusterSpec{
 				Project: "old-project",
 				Region:  "us-central1",
 				CredentialsRef: &infrav1.ObjectReference{
@@ -71,7 +72,7 @@ func TestGCPManagedClusterValidatingWebhookUpdate(t *testing.T) {
 		{
 			name:        "request to change immutable field credentials ref",
 			expectError: true,
-			spec: GCPManagedClusterSpec{
+			spec: expinfrav1.GCPManagedClusterSpec{
 				Project: "old-project",
 				Region:  "us-central1",
 				CredentialsRef: &infrav1.ObjectReference{
@@ -86,11 +87,11 @@ func TestGCPManagedClusterValidatingWebhookUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			newMC := &GCPManagedCluster{
+			newMC := &expinfrav1.GCPManagedCluster{
 				Spec: tc.spec,
 			}
-			oldMC := &GCPManagedCluster{
-				Spec: GCPManagedClusterSpec{
+			oldMC := &expinfrav1.GCPManagedCluster{
+				Spec: expinfrav1.GCPManagedClusterSpec{
 					Project: "old-project",
 					Region:  "us-west1",
 					CredentialsRef: &infrav1.ObjectReference{
@@ -100,7 +101,7 @@ func TestGCPManagedClusterValidatingWebhookUpdate(t *testing.T) {
 				},
 			}
 
-			warn, err := (&gcpManagedClusterWebhook{}).ValidateUpdate(t.Context(), oldMC, newMC)
+			warn, err := (&GCPManagedCluster{}).ValidateUpdate(t.Context(), oldMC, newMC)
 
 			if tc.expectError {
 				g.Expect(err).To(HaveOccurred())

--- a/exp/webhooks/gcpmanagedclustertemplate_webhook.go
+++ b/exp/webhooks/gcpmanagedclustertemplate_webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -23,6 +23,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -34,22 +35,22 @@ var gmctlog = logf.Log.WithName("gcpclustertemplate-resource")
 
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
 func (r *GCPManagedClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	mctw := new(gcpManagedClusterTemplateWebhook)
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
-		WithValidator(mctw).
+		For(&expinfrav1.GCPManagedClusterTemplate{}).
+		WithValidator(r).
 		Complete()
 }
 
-type gcpManagedClusterTemplateWebhook struct{}
+// GCPManagedClusterTemplate implements a validating webhook for GCPManagedClusterTemplate.
+type GCPManagedClusterTemplate struct{}
 
 //+kubebuilder:webhook:verbs=update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedclustertemplate,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=gcpmanagedclustertemplates,versions=v1beta1,name=vgcpmanagedclustertemplate.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomValidator = &gcpManagedClusterTemplateWebhook{}
+var _ webhook.CustomValidator = &GCPManagedClusterTemplate{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedClusterTemplateWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*GCPManagedClusterTemplate)
+func (*GCPManagedClusterTemplate) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	r, ok := obj.(*expinfrav1.GCPManagedClusterTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a GCPManagedClusterTemplate but got a %T", obj))
 	}
@@ -60,13 +61,13 @@ func (*gcpManagedClusterTemplateWebhook) ValidateCreate(_ context.Context, obj r
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedClusterTemplateWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	old, ok := oldObj.(*GCPManagedClusterTemplate)
+func (*GCPManagedClusterTemplate) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	old, ok := oldObj.(*expinfrav1.GCPManagedClusterTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a GCPManagedClusterTemplate but got a %T", oldObj))
 	}
 
-	r, ok := newObj.(*GCPManagedClusterTemplate)
+	r, ok := newObj.(*expinfrav1.GCPManagedClusterTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a GCPManagedClusterTemplate but got a %T", newObj))
 	}
@@ -81,8 +82,8 @@ func (*gcpManagedClusterTemplateWebhook) ValidateUpdate(_ context.Context, oldOb
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedClusterTemplateWebhook) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*GCPManagedClusterTemplate)
+func (*GCPManagedClusterTemplate) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	r, ok := obj.(*expinfrav1.GCPManagedClusterTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a GCPManagedClusterTemplate but got a %T", obj))
 	}

--- a/exp/webhooks/gcpmanagedcontrolplane_webhook.go
+++ b/exp/webhooks/gcpmanagedcontrolplane_webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-gcp/util/hash"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -42,10 +43,9 @@ const (
 // log is for logging in this package.
 var gcpmanagedcontrolplanelog = logf.Log.WithName("gcpmanagedcontrolplane-resource")
 
-func (r *GCPManagedControlPlane) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	w := new(gcpManagedControlPlaneWebhook)
+func (w *GCPManagedControlPlane) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&expinfrav1.GCPManagedControlPlane{}).
 		WithValidator(w).
 		WithDefaulter(w).
 		Complete()
@@ -53,13 +53,14 @@ func (r *GCPManagedControlPlane) SetupWebhookWithManager(mgr ctrl.Manager) error
 
 //+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedcontrolplane,mutating=true,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=gcpmanagedcontrolplanes,verbs=create;update,versions=v1beta1,name=mgcpmanagedcontrolplane.kb.io,admissionReviewVersions=v1
 
-type gcpManagedControlPlaneWebhook struct{}
+// GCPManagedControlPlane implements a validating and defaulting webhook for GCPManagedControlPlane.
+type GCPManagedControlPlane struct{}
 
-var _ webhook.CustomDefaulter = &gcpManagedControlPlaneWebhook{}
+var _ webhook.CustomDefaulter = &GCPManagedControlPlane{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (*gcpManagedControlPlaneWebhook) Default(_ context.Context, obj runtime.Object) error {
-	r, ok := obj.(*GCPManagedControlPlane)
+func (*GCPManagedControlPlane) Default(_ context.Context, obj runtime.Object) error {
+	r, ok := obj.(*expinfrav1.GCPManagedControlPlane)
 	if !ok {
 		return fmt.Errorf("expected an GCPManagedControlPlane object but got %T", r)
 	}
@@ -82,11 +83,11 @@ func (*gcpManagedControlPlaneWebhook) Default(_ context.Context, obj runtime.Obj
 
 //+kubebuilder:webhook:path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedcontrolplane,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=gcpmanagedcontrolplanes,verbs=create;update,versions=v1beta1,name=vgcpmanagedcontrolplane.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomValidator = &gcpManagedControlPlaneWebhook{}
+var _ webhook.CustomValidator = &GCPManagedControlPlane{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedControlPlaneWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*GCPManagedControlPlane)
+func (*GCPManagedControlPlane) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	r, ok := obj.(*expinfrav1.GCPManagedControlPlane)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPManagedControlPlane object but got %T", r)
 	}
@@ -116,7 +117,7 @@ func (*gcpManagedControlPlaneWebhook) ValidateCreate(_ context.Context, obj runt
 			r.Spec.LoggingService, "can't be set when autopilot is enabled"))
 	}
 
-	if r.Spec.ControlPlaneVersion != nil {
+	if r.Spec.ControlPlaneVersion != nil { //nolint:staticcheck
 		if r.Spec.Version != nil {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "ControlPlaneVersion"),
 				r.Spec.LoggingService, "spec.ControlPlaneVersion and spec.Version cannot be set at the same time: please use spec.Version"))
@@ -129,19 +130,19 @@ func (*gcpManagedControlPlaneWebhook) ValidateCreate(_ context.Context, obj runt
 		return allWarns, nil
 	}
 
-	return allWarns, apierrors.NewInvalid(GroupVersion.WithKind("GCPManagedControlPlane").GroupKind(), r.Name, allErrs)
+	return allWarns, apierrors.NewInvalid(expinfrav1.GroupVersion.WithKind("GCPManagedControlPlane").GroupKind(), r.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedControlPlaneWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	r, ok := newObj.(*GCPManagedControlPlane)
+func (*GCPManagedControlPlane) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	r, ok := newObj.(*expinfrav1.GCPManagedControlPlane)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPManagedControlPlane object but got %T", r)
 	}
 
 	gcpmanagedcontrolplanelog.Info("validate update", "name", r.Name)
 	var allErrs field.ErrorList
-	old := oldObj.(*GCPManagedControlPlane)
+	old := oldObj.(*expinfrav1.GCPManagedControlPlane)
 
 	if !cmp.Equal(r.Spec.ClusterName, old.Spec.ClusterName) {
 		allErrs = append(allErrs,
@@ -181,7 +182,7 @@ func (*gcpManagedControlPlaneWebhook) ValidateUpdate(_ context.Context, oldObj, 
 			r.Spec.LoggingService, "can't be set when autopilot is enabled"))
 	}
 
-	if old.Spec.Version != nil && r.Spec.ControlPlaneVersion != nil {
+	if old.Spec.Version != nil && r.Spec.ControlPlaneVersion != nil { //nolint:staticcheck
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "ControlPlaneVersion"),
 			r.Spec.LoggingService, "spec.ControlPlaneVersion and spec.Version cannot be set at the same time: please use spec.Version"))
 	}
@@ -206,11 +207,11 @@ func (*gcpManagedControlPlaneWebhook) ValidateUpdate(_ context.Context, oldObj, 
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("GCPManagedControlPlane").GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(expinfrav1.GroupVersion.WithKind("GCPManagedControlPlane").GroupKind(), r.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedControlPlaneWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (*GCPManagedControlPlane) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/exp/webhooks/gcpmanagedcontrolplane_webhook_test.go
+++ b/exp/webhooks/gcpmanagedcontrolplane_webhook_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"strings"
@@ -22,11 +22,12 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 )
 
 var (
 	vV1_32_5       = "v1.32.5"
-	releaseChannel = Rapid
+	releaseChannel = expinfrav1.Rapid
 )
 
 func TestGCPManagedControlPlaneDefaultingWebhook(t *testing.T) {
@@ -34,8 +35,8 @@ func TestGCPManagedControlPlaneDefaultingWebhook(t *testing.T) {
 		name         string
 		resourceName string
 		resourceNS   string
-		spec         GCPManagedControlPlaneSpec
-		expectSpec   GCPManagedControlPlaneSpec
+		spec         expinfrav1.GCPManagedControlPlaneSpec
+		expectSpec   expinfrav1.GCPManagedControlPlaneSpec
 		expetError   bool
 		expectHash   bool
 	}{
@@ -43,55 +44,55 @@ func TestGCPManagedControlPlaneDefaultingWebhook(t *testing.T) {
 			name:         "valid cluster name",
 			resourceName: "cluster1",
 			resourceNS:   "default",
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: "default_cluster1",
 			},
-			expectSpec: GCPManagedControlPlaneSpec{ClusterName: "default_cluster1"},
+			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{ClusterName: "default_cluster1"},
 		},
 		{
 			name:         "no cluster name should generate a valid one",
 			resourceName: "cluster1",
 			resourceNS:   "default",
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: "",
 			},
-			expectSpec: GCPManagedControlPlaneSpec{ClusterName: "default-cluster1"},
+			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{ClusterName: "default-cluster1"},
 		},
 		{
 			name:         "invalid cluster name (too long)",
 			resourceName: strings.Repeat("A", maxClusterNameLength+1),
 			resourceNS:   "default",
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: "",
 			},
-			expectSpec: GCPManagedControlPlaneSpec{ClusterName: "capg-"},
+			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{ClusterName: "capg-"},
 			expectHash: true,
 		},
 		{
 			name:         "with kubernetes version",
 			resourceName: "cluster1",
 			resourceNS:   "default",
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: "cluster1_27_1",
 				Version:     &vV1_32_5,
 			},
-			expectSpec: GCPManagedControlPlaneSpec{ClusterName: "cluster1_27_1", Version: &vV1_32_5},
+			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{ClusterName: "cluster1_27_1", Version: &vV1_32_5},
 		},
 		{
 			name:         "with autopilot enabled",
 			resourceName: "cluster1",
 			resourceNS:   "default",
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: "cluster1_autopilot",
 				Version:     &vV1_32_5,
-				GCPManagedControlPlaneClassSpec: GCPManagedControlPlaneClassSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
 				},
 			},
-			expectSpec: GCPManagedControlPlaneSpec{
+			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: "cluster1_autopilot",
 				Version:     &vV1_32_5,
-				GCPManagedControlPlaneClassSpec: GCPManagedControlPlaneClassSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
 				},
 			},
@@ -102,14 +103,14 @@ func TestGCPManagedControlPlaneDefaultingWebhook(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			mcp := &GCPManagedControlPlane{
+			mcp := &expinfrav1.GCPManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      tc.resourceName,
 					Namespace: tc.resourceNS,
 				},
 				Spec: tc.spec,
 			}
-			err := (&gcpManagedControlPlaneWebhook{}).Default(t.Context(), mcp)
+			err := (&GCPManagedControlPlane{}).Default(t.Context(), mcp)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(mcp.Spec).ToNot(BeNil())
@@ -130,13 +131,13 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 		name        string
 		expectError bool
 		expectWarn  bool
-		spec        GCPManagedControlPlaneSpec
+		spec        expinfrav1.GCPManagedControlPlaneSpec
 	}{
 		{
 			name:        "cluster name too long should cause an error",
 			expectError: true,
 			expectWarn:  false,
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: strings.Repeat("A", maxClusterNameLength+1),
 			},
 		},
@@ -144,9 +145,9 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			name:        "autopilot enabled without release channel should cause an error",
 			expectError: true,
 			expectWarn:  false,
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: "",
-				GCPManagedControlPlaneClassSpec: GCPManagedControlPlaneClassSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
 					ReleaseChannel:  nil,
 				},
@@ -156,9 +157,9 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			name:        "autopilot enabled with release channel",
 			expectError: false,
 			expectWarn:  false,
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: "",
-				GCPManagedControlPlaneClassSpec: GCPManagedControlPlaneClassSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
 					ReleaseChannel:  &releaseChannel,
 				},
@@ -168,7 +169,7 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			name:        "using deprecated ControlPlaneVersion should cause a warning",
 			expectError: false,
 			expectWarn:  true,
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName:         "",
 				ControlPlaneVersion: &vV1_32_5,
 			},
@@ -177,7 +178,7 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			name:        "using both ControlPlaneVersion and Version should cause a warning and an error",
 			expectError: true,
 			expectWarn:  false,
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName:         "",
 				ControlPlaneVersion: &vV1_32_5,
 				Version:             &vV1_32_5,
@@ -189,10 +190,10 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			mcp := &GCPManagedControlPlane{
+			mcp := &expinfrav1.GCPManagedControlPlane{
 				Spec: tc.spec,
 			}
-			warn, err := (&gcpManagedControlPlaneWebhook{}).ValidateCreate(t.Context(), mcp)
+			warn, err := (&GCPManagedControlPlane{}).ValidateCreate(t.Context(), mcp)
 
 			if tc.expectError {
 				g.Expect(err).To(HaveOccurred())
@@ -212,21 +213,21 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 	tests := []struct {
 		name        string
 		expectError bool
-		spec        GCPManagedControlPlaneSpec
+		spec        expinfrav1.GCPManagedControlPlaneSpec
 	}{
 		{
 			name:        "request to change cluster name should cause an error",
 			expectError: true,
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: "default_cluster2",
 			},
 		},
 		{
 			name:        "request to change project should cause an error",
 			expectError: true,
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: "default_cluster1",
-				GCPManagedControlPlaneClassSpec: GCPManagedControlPlaneClassSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					Project: "new-project",
 				},
 			},
@@ -234,9 +235,9 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 		{
 			name:        "request to change location should cause an error",
 			expectError: true,
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: "default_cluster1",
-				GCPManagedControlPlaneClassSpec: GCPManagedControlPlaneClassSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					Location: "us-west4",
 				},
 			},
@@ -244,9 +245,9 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 		{
 			name:        "request to enable/disable autopilot should cause an error",
 			expectError: true,
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: "default_cluster1",
-				GCPManagedControlPlaneClassSpec: GCPManagedControlPlaneClassSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
 				},
 			},
@@ -254,11 +255,11 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 		{
 			name:        "request to change network should not cause an error",
 			expectError: false,
-			spec: GCPManagedControlPlaneSpec{
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
 				ClusterName: "default_cluster1",
-				GCPManagedControlPlaneClassSpec: GCPManagedControlPlaneClassSpec{
-					ClusterNetwork: &ClusterNetwork{
-						PrivateCluster: &PrivateCluster{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterNetwork: &expinfrav1.ClusterNetwork{
+						PrivateCluster: &expinfrav1.PrivateCluster{
 							EnablePrivateEndpoint: false,
 						},
 					},
@@ -271,15 +272,15 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			newMCP := &GCPManagedControlPlane{
+			newMCP := &expinfrav1.GCPManagedControlPlane{
 				Spec: tc.spec,
 			}
-			oldMCP := &GCPManagedControlPlane{
-				Spec: GCPManagedControlPlaneSpec{
+			oldMCP := &expinfrav1.GCPManagedControlPlane{
+				Spec: expinfrav1.GCPManagedControlPlaneSpec{
 					ClusterName: "default_cluster1",
-					GCPManagedControlPlaneClassSpec: GCPManagedControlPlaneClassSpec{
-						ClusterNetwork: &ClusterNetwork{
-							PrivateCluster: &PrivateCluster{
+					GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+						ClusterNetwork: &expinfrav1.ClusterNetwork{
+							PrivateCluster: &expinfrav1.PrivateCluster{
 								EnablePrivateEndpoint: true,
 							},
 						},
@@ -287,7 +288,7 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 				},
 			}
 
-			warn, err := (&gcpManagedControlPlaneWebhook{}).ValidateUpdate(t.Context(), oldMCP, newMCP)
+			warn, err := (&GCPManagedControlPlane{}).ValidateUpdate(t.Context(), oldMCP, newMCP)
 
 			if tc.expectError {
 				g.Expect(err).To(HaveOccurred())

--- a/exp/webhooks/gcpmanagedcontrolplanetemplate_webhook.go
+++ b/exp/webhooks/gcpmanagedcontrolplanetemplate_webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -24,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -34,16 +35,18 @@ import (
 // log is for logging in this package.
 var gmcptlog = logf.Log.WithName("gcpmanagedcontrolplane-resource")
 
-func (r *GCPManagedControlPlaneTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	mcptw := &gcpManagedControlPlaneTemplateWebhook{Client: mgr.GetClient()}
+// SetupGCPManagedControlPlaneTemplateWebhookWithManager sets up and registers the webhook with the manager.
+func SetupGCPManagedControlPlaneTemplateWebhookWithManager(mgr ctrl.Manager) error {
+	mcptw := &GCPManagedControlPlaneTemplate{Client: mgr.GetClient()}
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&expinfrav1.GCPManagedControlPlaneTemplate{}).
 		WithDefaulter(mcptw).
 		WithValidator(mcptw).
 		Complete()
 }
 
-type gcpManagedControlPlaneTemplateWebhook struct {
+// GCPManagedControlPlaneTemplate implements a validating and defaulting webhook for GCPManagedControlPlaneTemplate.
+type GCPManagedControlPlaneTemplate struct {
 	Client client.Client
 }
 
@@ -51,13 +54,13 @@ type gcpManagedControlPlaneTemplateWebhook struct {
 //+kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedcontrolplanetemplate,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=gcpmanagedcontrolplanetemplates,versions=v1beta1,name=mgcpmanagedcontrolplanetemplate.kb.io,sideEffects=None,admissionReviewVersions=v1
 
 var (
-	_ webhook.CustomValidator = &gcpManagedControlPlaneTemplateWebhook{}
-	_ webhook.CustomDefaulter = &gcpManagedControlPlaneTemplateWebhook{}
+	_ webhook.CustomValidator = &GCPManagedControlPlaneTemplate{}
+	_ webhook.CustomDefaulter = &GCPManagedControlPlaneTemplate{}
 )
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (mcpw *gcpManagedControlPlaneTemplateWebhook) Default(_ context.Context, obj runtime.Object) error {
-	r, ok := obj.(*GCPManagedControlPlaneTemplate)
+func (mcpw *GCPManagedControlPlaneTemplate) Default(_ context.Context, obj runtime.Object) error {
+	r, ok := obj.(*expinfrav1.GCPManagedControlPlaneTemplate)
 	if !ok {
 		return fmt.Errorf("expected a GCPManagedControlPlaneTemplate object but got %T", r)
 	}
@@ -68,8 +71,8 @@ func (mcpw *gcpManagedControlPlaneTemplateWebhook) Default(_ context.Context, ob
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedControlPlaneTemplateWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*GCPManagedControlPlaneTemplate)
+func (*GCPManagedControlPlaneTemplate) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	r, ok := obj.(*expinfrav1.GCPManagedControlPlaneTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected a GCPManagedControlPlaneTemplate")
 	}
@@ -97,17 +100,17 @@ func (*gcpManagedControlPlaneTemplateWebhook) ValidateCreate(_ context.Context, 
 		return allWarns, nil
 	}
 
-	return allWarns, apierrors.NewInvalid(GroupVersion.WithKind("GCPManagedControlPlaneTemplate").GroupKind(), r.Name, allErrs)
+	return allWarns, apierrors.NewInvalid(expinfrav1.GroupVersion.WithKind("GCPManagedControlPlaneTemplate").GroupKind(), r.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedControlPlaneTemplateWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	old, ok := oldObj.(*GCPManagedControlPlaneTemplate)
+func (*GCPManagedControlPlaneTemplate) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	old, ok := oldObj.(*expinfrav1.GCPManagedControlPlaneTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected a GCPManagedControlPlaneTemplate")
 	}
 
-	r, ok := newObj.(*GCPManagedControlPlaneTemplate)
+	r, ok := newObj.(*expinfrav1.GCPManagedControlPlaneTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected a GCPManagedControlPlaneTemplate")
 	}
@@ -166,12 +169,12 @@ func (*gcpManagedControlPlaneTemplateWebhook) ValidateUpdate(_ context.Context, 
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("GCPManagedControlPlaneTemplate").GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(expinfrav1.GroupVersion.WithKind("GCPManagedControlPlaneTemplate").GroupKind(), r.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedControlPlaneTemplateWebhook) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*GCPManagedControlPlaneTemplate)
+func (*GCPManagedControlPlaneTemplate) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	r, ok := obj.(*expinfrav1.GCPManagedControlPlaneTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected a GCPManagedControlPlaneTemplate")
 	}

--- a/exp/webhooks/gcpmanagedcontrolplanetemplate_webhook_test.go
+++ b/exp/webhooks/gcpmanagedcontrolplanetemplate_webhook_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks

--- a/exp/webhooks/gcpmanagedmachinepool_webhook.go
+++ b/exp/webhooks/gcpmanagedmachinepool_webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -23,6 +23,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	webhookutils "sigs.k8s.io/cluster-api-provider-gcp/util/webhook"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -37,10 +38,9 @@ const (
 // log is for logging in this package.
 var gcpmanagedmachinepoollog = logf.Log.WithName("gcpmanagedmachinepooltemplate-resource")
 
-func (r *GCPManagedMachinePool) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	w := new(gcpManagedMachinePoolWebhook)
+func (w *GCPManagedMachinePool) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&expinfrav1.GCPManagedMachinePool{}).
 		WithValidator(w).
 		WithDefaulter(w).
 		Complete()
@@ -48,18 +48,19 @@ func (r *GCPManagedMachinePool) SetupWebhookWithManager(mgr ctrl.Manager) error 
 
 //+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedmachinepool,mutating=true,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=gcpmanagedmachinepools,verbs=create;update,versions=v1beta1,name=mgcpmanagedmachinepool.kb.io,admissionReviewVersions=v1
 
-type gcpManagedMachinePoolWebhook struct{}
+// GCPManagedMachinePool implements a validating and defaulting webhook for GCPManagedMachinePool.
+type GCPManagedMachinePool struct{}
 
-var _ webhook.CustomDefaulter = &gcpManagedMachinePoolWebhook{}
+var _ webhook.CustomDefaulter = &GCPManagedMachinePool{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (*gcpManagedMachinePoolWebhook) Default(_ context.Context, _ runtime.Object) error {
+func (*GCPManagedMachinePool) Default(_ context.Context, _ runtime.Object) error {
 	return nil
 }
 
 //+kubebuilder:webhook:path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedmachinepool,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=gcpmanagedmachinepools,verbs=create;update,versions=v1beta1,name=vgcpmanagedmachinepool.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomValidator = &gcpManagedMachinePoolWebhook{}
+var _ webhook.CustomValidator = &GCPManagedMachinePool{}
 
 func validateNodePoolName(name string, fldPath *field.Path) *field.Error {
 	if len(name) > maxNodePoolNameLength {
@@ -73,7 +74,7 @@ func validateNodePoolName(name string, fldPath *field.Path) *field.Error {
 	return nil
 }
 
-func validateScaling(scaling *NodePoolAutoScaling, minField, maxField, locationPolicyField *field.Path) field.ErrorList {
+func validateScaling(scaling *expinfrav1.NodePoolAutoScaling, minField, maxField, locationPolicyField *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	// cannot specify autoscaling config if autoscaling is disabled
@@ -108,8 +109,8 @@ func validateScaling(scaling *NodePoolAutoScaling, minField, maxField, locationP
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedMachinePoolWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*GCPManagedMachinePool)
+func (*GCPManagedMachinePool) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	r, ok := obj.(*expinfrav1.GCPManagedMachinePool)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPManagedMachinePool object but got %T", r)
 	}
@@ -168,13 +169,13 @@ func (*gcpManagedMachinePoolWebhook) ValidateCreate(_ context.Context, obj runti
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedMachinePoolWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	old, ok := oldObj.(*GCPManagedMachinePool)
+func (*GCPManagedMachinePool) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	old, ok := oldObj.(*expinfrav1.GCPManagedMachinePool)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPManagedMachinePool object but got %T", old)
 	}
 
-	r, ok := newObj.(*GCPManagedMachinePool)
+	r, ok := newObj.(*expinfrav1.GCPManagedMachinePool)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPManagedMachinePool object but got %T", r)
 	}
@@ -282,10 +283,10 @@ func (*gcpManagedMachinePoolWebhook) ValidateUpdate(_ context.Context, oldObj, n
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("GCPManagedMachinePool").GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(expinfrav1.GroupVersion.WithKind("GCPManagedMachinePool").GroupKind(), r.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedMachinePoolWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (*GCPManagedMachinePool) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/exp/webhooks/gcpmanagedmachinepool_webhook_test.go
+++ b/exp/webhooks/gcpmanagedmachinepool_webhook_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"strings"
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 )
 
 var (
@@ -40,13 +41,13 @@ var (
 func TestGCPManagedMachinePoolValidatingWebhookCreate(t *testing.T) {
 	tests := []struct {
 		name        string
-		spec        GCPManagedMachinePoolSpec
+		spec        expinfrav1.GCPManagedMachinePoolSpec
 		expectError bool
 	}{
 		{
 			name: "valid node pool name",
-			spec: GCPManagedMachinePoolSpec{
-				GCPManagedMachinePoolClassSpec: GCPManagedMachinePoolClassSpec{
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
 					NodePoolName: "nodepool1",
 				},
 			},
@@ -54,8 +55,8 @@ func TestGCPManagedMachinePoolValidatingWebhookCreate(t *testing.T) {
 		},
 		{
 			name: "node pool name is too long",
-			spec: GCPManagedMachinePoolSpec{
-				GCPManagedMachinePoolClassSpec: GCPManagedMachinePoolClassSpec{
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
 					NodePoolName: strings.Repeat("A", maxNodePoolNameLength+1),
 				},
 			},
@@ -63,10 +64,10 @@ func TestGCPManagedMachinePoolValidatingWebhookCreate(t *testing.T) {
 		},
 		{
 			name: "scaling with valid min/max count",
-			spec: GCPManagedMachinePoolSpec{
-				GCPManagedMachinePoolClassSpec: GCPManagedMachinePoolClassSpec{
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
 					NodePoolName: "nodepool1",
-					Scaling: &NodePoolAutoScaling{
+					Scaling: &expinfrav1.NodePoolAutoScaling{
 						MinCount: &minCount,
 						MaxCount: &maxCount,
 					},
@@ -76,10 +77,10 @@ func TestGCPManagedMachinePoolValidatingWebhookCreate(t *testing.T) {
 		},
 		{
 			name: "scaling with invalid min/max count",
-			spec: GCPManagedMachinePoolSpec{
-				GCPManagedMachinePoolClassSpec: GCPManagedMachinePoolClassSpec{
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
 					NodePoolName: "nodepool1",
-					Scaling: &NodePoolAutoScaling{
+					Scaling: &expinfrav1.NodePoolAutoScaling{
 						MinCount: &invalidMinCount,
 						MaxCount: &maxCount,
 					},
@@ -89,10 +90,10 @@ func TestGCPManagedMachinePoolValidatingWebhookCreate(t *testing.T) {
 		},
 		{
 			name: "scaling with max < min count",
-			spec: GCPManagedMachinePoolSpec{
-				GCPManagedMachinePoolClassSpec: GCPManagedMachinePoolClassSpec{
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
 					NodePoolName: "nodepool1",
-					Scaling: &NodePoolAutoScaling{
+					Scaling: &expinfrav1.NodePoolAutoScaling{
 						MinCount: &maxCount,
 						MaxCount: &minCount,
 					},
@@ -102,10 +103,10 @@ func TestGCPManagedMachinePoolValidatingWebhookCreate(t *testing.T) {
 		},
 		{
 			name: "autoscaling disabled and min/max provided",
-			spec: GCPManagedMachinePoolSpec{
-				GCPManagedMachinePoolClassSpec: GCPManagedMachinePoolClassSpec{
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
 					NodePoolName: "nodepool1",
-					Scaling: &NodePoolAutoScaling{
+					Scaling: &expinfrav1.NodePoolAutoScaling{
 						EnableAutoscaling: &enableAutoscaling,
 						MinCount:          &minCount,
 						MaxCount:          &maxCount,
@@ -116,8 +117,8 @@ func TestGCPManagedMachinePoolValidatingWebhookCreate(t *testing.T) {
 		},
 		{
 			name: "valid non-negative values",
-			spec: GCPManagedMachinePoolSpec{
-				GCPManagedMachinePoolClassSpec: GCPManagedMachinePoolClassSpec{
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
 					NodePoolName:   "nodepool1",
 					DiskSizeGb:     &diskSizeGb,
 					MaxPodsPerNode: &maxPods,
@@ -128,8 +129,8 @@ func TestGCPManagedMachinePoolValidatingWebhookCreate(t *testing.T) {
 		},
 		{
 			name: "invalid negative values",
-			spec: GCPManagedMachinePoolSpec{
-				GCPManagedMachinePoolClassSpec: GCPManagedMachinePoolClassSpec{
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
 					NodePoolName:   "nodepool1",
 					DiskSizeGb:     &invalidDiskSizeGb,
 					MaxPodsPerNode: &invalidMaxPods,
@@ -144,10 +145,10 @@ func TestGCPManagedMachinePoolValidatingWebhookCreate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			mmp := &GCPManagedMachinePool{
+			mmp := &expinfrav1.GCPManagedMachinePool{
 				Spec: tc.spec,
 			}
-			warn, err := (&gcpManagedMachinePoolWebhook{}).ValidateCreate(t.Context(), mmp)
+			warn, err := (&GCPManagedMachinePool{}).ValidateCreate(t.Context(), mmp)
 
 			if tc.expectError {
 				g.Expect(err).To(HaveOccurred())
@@ -163,13 +164,13 @@ func TestGCPManagedMachinePoolValidatingWebhookCreate(t *testing.T) {
 func TestGCPManagedMachinePoolValidatingWebhookUpdate(t *testing.T) {
 	tests := []struct {
 		name        string
-		spec        GCPManagedMachinePoolSpec
+		spec        expinfrav1.GCPManagedMachinePoolSpec
 		expectError bool
 	}{
 		{
 			name: "node pool is not mutated",
-			spec: GCPManagedMachinePoolSpec{
-				GCPManagedMachinePoolClassSpec: GCPManagedMachinePoolClassSpec{
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
 					NodePoolName: "nodepool1",
 				},
 			},
@@ -177,8 +178,8 @@ func TestGCPManagedMachinePoolValidatingWebhookUpdate(t *testing.T) {
 		},
 		{
 			name: "mutable fields are mutated",
-			spec: GCPManagedMachinePoolSpec{
-				GCPManagedMachinePoolClassSpec: GCPManagedMachinePoolClassSpec{
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
 					NodePoolName: "nodepool1",
 					AdditionalLabels: infrav1.Labels{
 						"testKey": "testVal",
@@ -189,8 +190,8 @@ func TestGCPManagedMachinePoolValidatingWebhookUpdate(t *testing.T) {
 		},
 		{
 			name: "immutable field disk size is mutated",
-			spec: GCPManagedMachinePoolSpec{
-				GCPManagedMachinePoolClassSpec: GCPManagedMachinePoolClassSpec{
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
 					NodePoolName: "nodepool1",
 					DiskSizeGb:   &diskSizeGb,
 				},
@@ -203,18 +204,18 @@ func TestGCPManagedMachinePoolValidatingWebhookUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			newMMP := &GCPManagedMachinePool{
+			newMMP := &expinfrav1.GCPManagedMachinePool{
 				Spec: tc.spec,
 			}
-			oldMMP := &GCPManagedMachinePool{
-				Spec: GCPManagedMachinePoolSpec{
-					GCPManagedMachinePoolClassSpec: GCPManagedMachinePoolClassSpec{
+			oldMMP := &expinfrav1.GCPManagedMachinePool{
+				Spec: expinfrav1.GCPManagedMachinePoolSpec{
+					GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
 						NodePoolName: "nodepool1",
 					},
 				},
 			}
 
-			warn, err := (&gcpManagedMachinePoolWebhook{}).ValidateUpdate(t.Context(), oldMMP, newMMP)
+			warn, err := (&GCPManagedMachinePool{}).ValidateUpdate(t.Context(), oldMMP, newMMP)
 
 			if tc.expectError {
 				g.Expect(err).To(HaveOccurred())

--- a/exp/webhooks/gcpmanagedmachinepooltemplate_webhook.go
+++ b/exp/webhooks/gcpmanagedmachinepooltemplate_webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -23,6 +23,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -34,24 +35,26 @@ import (
 // log is for logging in this package.
 var gmmplog = logf.Log.WithName("gcpmanagedmachinepool-resource")
 
-func (r *GCPManagedMachinePoolTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	mmptw := &gcpManagedMachinePoolTemplateWebhook{Client: mgr.GetClient()}
+// SetupGCPManagedMachinePoolTemplateWebhookWithManager sets up and registers the webhook with the manager.
+func SetupGCPManagedMachinePoolTemplateWebhookWithManager(mgr ctrl.Manager) error {
+	mmptw := &GCPManagedMachinePoolTemplate{Client: mgr.GetClient()}
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(&expinfrav1.GCPManagedMachinePoolTemplate{}).
 		WithDefaulter(mmptw).
 		WithValidator(mmptw).
 		Complete()
 }
 
-type gcpManagedMachinePoolTemplateWebhook struct {
+// GCPManagedMachinePoolTemplate implements a validating and defaulting webhook for GCPManagedMachinePoolTemplate.
+type GCPManagedMachinePoolTemplate struct {
 	Client client.Client
 }
 
 //+kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmanagedmachinepooltemplate,mutating=true,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=gcpmanagedmachinepooltemplates,versions=v1beta1,name=mgcpmanagedmachinepooltemplate.kb.io,admissionReviewVersions=v1
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (*gcpManagedMachinePoolTemplateWebhook) Default(_ context.Context, obj runtime.Object) error {
-	r, ok := obj.(*GCPManagedMachinePoolTemplate)
+func (*GCPManagedMachinePoolTemplate) Default(_ context.Context, obj runtime.Object) error {
+	r, ok := obj.(*expinfrav1.GCPManagedMachinePoolTemplate)
 	if !ok {
 		return fmt.Errorf("expected a GCPManagedMachinePoolTemplate object but got %T", r)
 	}
@@ -62,8 +65,8 @@ func (*gcpManagedMachinePoolTemplateWebhook) Default(_ context.Context, obj runt
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedMachinePoolTemplateWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*GCPManagedMachinePoolTemplate)
+func (*GCPManagedMachinePoolTemplate) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	r, ok := obj.(*expinfrav1.GCPManagedMachinePoolTemplate)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPManagedMachinePoolTemplate object but got %T", r)
 	}
@@ -122,13 +125,13 @@ func (*gcpManagedMachinePoolTemplateWebhook) ValidateCreate(_ context.Context, o
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedMachinePoolTemplateWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	old, ok := oldObj.(*GCPManagedMachinePoolTemplate)
+func (*GCPManagedMachinePoolTemplate) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	old, ok := oldObj.(*expinfrav1.GCPManagedMachinePoolTemplate)
 	if !ok {
 		return nil, fmt.Errorf("expected a GCPManagedMachinePoolTemplate object but got %T", old)
 	}
 
-	r, ok := newObj.(*GCPManagedMachinePoolTemplate)
+	r, ok := newObj.(*expinfrav1.GCPManagedMachinePoolTemplate)
 	if !ok {
 		return nil, fmt.Errorf("expected a GCPManagedMachinePoolTemplate object but got %T", r)
 	}
@@ -243,6 +246,6 @@ func (*gcpManagedMachinePoolTemplateWebhook) ValidateUpdate(_ context.Context, o
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpManagedMachinePoolTemplateWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (*GCPManagedMachinePoolTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/exp/webhooks/webhook_suite_test.go
+++ b/exp/webhooks/webhook_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -31,6 +31,7 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -78,7 +79,7 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 
 	scheme := runtime.NewScheme()
-	err = AddToScheme(scheme)
+	err = expinfrav1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = admissionv1beta1.AddToScheme(scheme)

--- a/main.go
+++ b/main.go
@@ -40,9 +40,11 @@ import (
 	gkebootstrapv1exp "sigs.k8s.io/cluster-api-provider-gcp/exp/bootstrap/gke/api/v1beta1"
 	gkeboostrapcontrollersv1exp "sigs.k8s.io/cluster-api-provider-gcp/exp/bootstrap/gke/controllers"
 	expcontrollers "sigs.k8s.io/cluster-api-provider-gcp/exp/controllers"
+	expwebhooks "sigs.k8s.io/cluster-api-provider-gcp/exp/webhooks"
 	"sigs.k8s.io/cluster-api-provider-gcp/feature"
 	"sigs.k8s.io/cluster-api-provider-gcp/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-gcp/version"
+	gcpwebhooks "sigs.k8s.io/cluster-api-provider-gcp/webhooks"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	capifeature "sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util/flags"
@@ -263,23 +265,23 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) error {
 }
 
 func setupWebhooks(mgr ctrl.Manager) error {
-	if err := (&infrav1beta1.GCPCluster{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&gcpwebhooks.GCPCluster{}).SetupWebhookWithManager(mgr); err != nil {
 		return fmt.Errorf("setting up GCPCluster webhook: %w", err)
 	}
-	if err := (&infrav1beta1.GCPClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&gcpwebhooks.GCPClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		return fmt.Errorf("setting up GCPClusterTemplate webhook: %w", err)
 	}
-	if err := (&infrav1beta1.GCPMachine{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&gcpwebhooks.GCPMachine{}).SetupWebhookWithManager(mgr); err != nil {
 		return fmt.Errorf("setting up GCPMachine webhook: %w", err)
 	}
-	if err := (&infrav1beta1.GCPMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&gcpwebhooks.GCPMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		return fmt.Errorf("setting up GCPMachineTemplate webhook: %w", err)
 	}
 
 	if feature.Gates.Enabled(capifeature.MachinePool) {
 		setupLog.Info("Enabling GCPMachinePool webhooks")
 
-		if err := (&infrav1exp.GCPMachinePool{}).SetupWebhookWithManager(mgr); err != nil {
+		if err := (&expwebhooks.GCPMachinePool{}).SetupWebhookWithManager(mgr); err != nil {
 			return fmt.Errorf("creating GCPMachinePool webhook: %w", err)
 		}
 	}
@@ -287,22 +289,22 @@ func setupWebhooks(mgr ctrl.Manager) error {
 	if feature.Gates.Enabled(feature.GKE) {
 		setupLog.Info("Enabling GKE webhooks")
 
-		if err := (&infrav1exp.GCPManagedCluster{}).SetupWebhookWithManager(mgr); err != nil {
+		if err := (&expwebhooks.GCPManagedCluster{}).SetupWebhookWithManager(mgr); err != nil {
 			return fmt.Errorf("setting up GCPManagedCluster webhook: %w", err)
 		}
-		if err := (&infrav1exp.GCPManagedClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+		if err := (&expwebhooks.GCPManagedClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 			return fmt.Errorf("setting up GCPManagedClusterTemplate webhook: %w", err)
 		}
-		if err := (&infrav1exp.GCPManagedControlPlane{}).SetupWebhookWithManager(mgr); err != nil {
+		if err := (&expwebhooks.GCPManagedControlPlane{}).SetupWebhookWithManager(mgr); err != nil {
 			return fmt.Errorf("setting up GCPManagedControlPlane webhook: %w", err)
 		}
-		if err := (&infrav1exp.GCPManagedControlPlaneTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+		if err := expwebhooks.SetupGCPManagedControlPlaneTemplateWebhookWithManager(mgr); err != nil {
 			return fmt.Errorf("setting up GCPManagedControlPlaneTemplate webhook: %w", err)
 		}
-		if err := (&infrav1exp.GCPManagedMachinePool{}).SetupWebhookWithManager(mgr); err != nil {
+		if err := (&expwebhooks.GCPManagedMachinePool{}).SetupWebhookWithManager(mgr); err != nil {
 			return fmt.Errorf("setting up GCPManagedMachinePool webhook: %w", err)
 		}
-		if err := (&infrav1exp.GCPManagedMachinePoolTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+		if err := expwebhooks.SetupGCPManagedMachinePoolTemplateWebhookWithManager(mgr); err != nil {
 			return fmt.Errorf("setting up GCPManagedMachinePoolTemplate webhook: %w", err)
 		}
 	}

--- a/webhooks/doc.go
+++ b/webhooks/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks contains the core API webhooks implementation.
+package webhooks

--- a/webhooks/gcpcluster_webhook.go
+++ b/webhooks/gcpcluster_webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -24,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -35,44 +36,44 @@ var clusterlog = logf.Log.WithName("gcpcluster-resource")
 
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
 func (c *GCPCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	w := new(gcpClusterWebhook)
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(c).
-		WithValidator(w).
-		WithDefaulter(w).
+		For(&infrav1.GCPCluster{}).
+		WithValidator(c).
+		WithDefaulter(c).
 		Complete()
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-gcpcluster,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=gcpclusters,versions=v1beta1,name=validation.gcpcluster.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-gcpcluster,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=gcpclusters,versions=v1beta1,name=default.gcpcluster.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
-type gcpClusterWebhook struct{}
+// GCPCluster implements a validating and defaulting webhook for GCPCluster.
+type GCPCluster struct{}
 
 var (
-	_ webhook.CustomValidator = &gcpClusterWebhook{}
-	_ webhook.CustomDefaulter = &gcpClusterWebhook{}
+	_ webhook.CustomValidator = &GCPCluster{}
+	_ webhook.CustomDefaulter = &GCPCluster{}
 )
 
 // Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
-func (*gcpClusterWebhook) Default(_ context.Context, _ runtime.Object) error {
+func (*GCPCluster) Default(_ context.Context, _ runtime.Object) error {
 	return nil
 }
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (*gcpClusterWebhook) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (*GCPCluster) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (*gcpClusterWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	c, ok := newObj.(*GCPCluster)
+func (*GCPCluster) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	c, ok := newObj.(*infrav1.GCPCluster)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPCluster object but got %T", c)
 	}
 
 	clusterlog.Info("validate update", "name", c.Name)
 	var allErrs field.ErrorList
-	old := oldObj.(*GCPCluster)
+	old := oldObj.(*infrav1.GCPCluster)
 
 	if !reflect.DeepEqual(c.Spec.Project, old.Spec.Project) {
 		allErrs = append(allErrs,
@@ -118,7 +119,7 @@ func (*gcpClusterWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runti
 
 	for i, firewallRule := range c.Spec.Network.Firewall.FirewallRules {
 		for j, allowRule := range firewallRule.Allowed {
-			if allowRule.IPProtocol != FirewallProtocolTCP && allowRule.IPProtocol != FirewallProtocolUDP &&
+			if allowRule.IPProtocol != infrav1.FirewallProtocolTCP && allowRule.IPProtocol != infrav1.FirewallProtocolUDP &&
 				len(allowRule.Ports) > 0 {
 				allErrs = append(allErrs,
 					field.Invalid(field.NewPath("spec", "Network", "Firewall",
@@ -130,7 +131,7 @@ func (*gcpClusterWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runti
 			}
 		}
 		for j, denyRule := range firewallRule.Denied {
-			if denyRule.IPProtocol != FirewallProtocolTCP && denyRule.IPProtocol != FirewallProtocolUDP &&
+			if denyRule.IPProtocol != infrav1.FirewallProtocolTCP && denyRule.IPProtocol != infrav1.FirewallProtocolUDP &&
 				len(denyRule.Ports) > 0 {
 				allErrs = append(allErrs,
 					field.Invalid(field.NewPath("spec", "Network", "Firewall",
@@ -147,10 +148,10 @@ func (*gcpClusterWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runti
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("GCPCluster").GroupKind(), c.Name, allErrs)
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("GCPCluster").GroupKind(), c.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
-func (*gcpClusterWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (*GCPCluster) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/webhooks/gcpcluster_webhook_test.go
+++ b/webhooks/gcpcluster_webhook_test.go
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 )
 
 func TestGCPCluster_ValidateUpdate(t *testing.T) {
@@ -27,22 +28,22 @@ func TestGCPCluster_ValidateUpdate(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		newCluster *GCPCluster
-		oldCluster *GCPCluster
+		newCluster *infrav1.GCPCluster
+		oldCluster *infrav1.GCPCluster
 		wantErr    bool
 	}{
 		{
 			name: "GCPCluster with MTU field is within the limits of more than 1300 and less than 8896",
-			newCluster: &GCPCluster{
-				Spec: GCPClusterSpec{
-					Network: NetworkSpec{
+			newCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
 						Mtu: int64(1500),
 					},
 				},
 			},
-			oldCluster: &GCPCluster{
-				Spec: GCPClusterSpec{
-					Network: NetworkSpec{
+			oldCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
 						Mtu: int64(1400),
 					},
 				},
@@ -51,16 +52,16 @@ func TestGCPCluster_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "GCPCluster with MTU field more than 8896",
-			newCluster: &GCPCluster{
-				Spec: GCPClusterSpec{
-					Network: NetworkSpec{
+			newCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
 						Mtu: int64(10000),
 					},
 				},
 			},
-			oldCluster: &GCPCluster{
-				Spec: GCPClusterSpec{
-					Network: NetworkSpec{
+			oldCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
 						Mtu: int64(1500),
 					},
 				},
@@ -69,16 +70,16 @@ func TestGCPCluster_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "GCPCluster with MTU field less than 8896",
-			newCluster: &GCPCluster{
-				Spec: GCPClusterSpec{
-					Network: NetworkSpec{
+			newCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
 						Mtu: int64(1250),
 					},
 				},
 			},
-			oldCluster: &GCPCluster{
-				Spec: GCPClusterSpec{
-					Network: NetworkSpec{
+			oldCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
 						Mtu: int64(1500),
 					},
 				},
@@ -87,16 +88,16 @@ func TestGCPCluster_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "GCPCluster with Firewall with Allowed field wrong protocol for ports",
-			newCluster: &GCPCluster{
-				Spec: GCPClusterSpec{
-					Network: NetworkSpec{
+			newCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
 						Mtu: int64(1500),
-						Firewall: FirewallSpec{
-							FirewallRules: []FirewallRule{
+						Firewall: infrav1.FirewallSpec{
+							FirewallRules: []infrav1.FirewallRule{
 								{
-									Allowed: []FirewallDescriptor{
+									Allowed: []infrav1.FirewallDescriptor{
 										{
-											IPProtocol: FirewallProtocolESP,
+											IPProtocol: infrav1.FirewallProtocolESP,
 											Ports:      []string{"1234"},
 										},
 									},
@@ -106,16 +107,16 @@ func TestGCPCluster_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			oldCluster: &GCPCluster{
-				Spec: GCPClusterSpec{
-					Network: NetworkSpec{
+			oldCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
 						Mtu: int64(1500),
-						Firewall: FirewallSpec{
-							FirewallRules: []FirewallRule{
+						Firewall: infrav1.FirewallSpec{
+							FirewallRules: []infrav1.FirewallRule{
 								{
-									Allowed: []FirewallDescriptor{
+									Allowed: []infrav1.FirewallDescriptor{
 										{
-											IPProtocol: FirewallProtocolESP,
+											IPProtocol: infrav1.FirewallProtocolESP,
 											Ports:      []string{"1234"},
 										},
 									},
@@ -129,16 +130,16 @@ func TestGCPCluster_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "GCPCluster with Firewall with Denied field wrong protocol for ports",
-			newCluster: &GCPCluster{
-				Spec: GCPClusterSpec{
-					Network: NetworkSpec{
+			newCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
 						Mtu: int64(1500),
-						Firewall: FirewallSpec{
-							FirewallRules: []FirewallRule{
+						Firewall: infrav1.FirewallSpec{
+							FirewallRules: []infrav1.FirewallRule{
 								{
-									Denied: []FirewallDescriptor{
+									Denied: []infrav1.FirewallDescriptor{
 										{
-											IPProtocol: FirewallProtocolESP,
+											IPProtocol: infrav1.FirewallProtocolESP,
 											Ports:      []string{"1234"},
 										},
 									},
@@ -148,16 +149,16 @@ func TestGCPCluster_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			oldCluster: &GCPCluster{
-				Spec: GCPClusterSpec{
-					Network: NetworkSpec{
+			oldCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
 						Mtu: int64(1500),
-						Firewall: FirewallSpec{
-							FirewallRules: []FirewallRule{
+						Firewall: infrav1.FirewallSpec{
+							FirewallRules: []infrav1.FirewallRule{
 								{
-									Denied: []FirewallDescriptor{
+									Denied: []infrav1.FirewallDescriptor{
 										{
-											IPProtocol: FirewallProtocolESP,
+											IPProtocol: infrav1.FirewallProtocolESP,
 											Ports:      []string{"1234"},
 										},
 									},
@@ -171,16 +172,16 @@ func TestGCPCluster_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "GCPCluster with Firewall with Allowed field correct protocol for ports",
-			newCluster: &GCPCluster{
-				Spec: GCPClusterSpec{
-					Network: NetworkSpec{
+			newCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
 						Mtu: int64(1500),
-						Firewall: FirewallSpec{
-							FirewallRules: []FirewallRule{
+						Firewall: infrav1.FirewallSpec{
+							FirewallRules: []infrav1.FirewallRule{
 								{
-									Allowed: []FirewallDescriptor{
+									Allowed: []infrav1.FirewallDescriptor{
 										{
-											IPProtocol: FirewallProtocolTCP,
+											IPProtocol: infrav1.FirewallProtocolTCP,
 											Ports:      []string{"1234"},
 										},
 									},
@@ -190,16 +191,16 @@ func TestGCPCluster_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			oldCluster: &GCPCluster{
-				Spec: GCPClusterSpec{
-					Network: NetworkSpec{
+			oldCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
 						Mtu: int64(1500),
-						Firewall: FirewallSpec{
-							FirewallRules: []FirewallRule{
+						Firewall: infrav1.FirewallSpec{
+							FirewallRules: []infrav1.FirewallRule{
 								{
-									Allowed: []FirewallDescriptor{
+									Allowed: []infrav1.FirewallDescriptor{
 										{
-											IPProtocol: FirewallProtocolTCP,
+											IPProtocol: infrav1.FirewallProtocolTCP,
 											Ports:      []string{"1234"},
 										},
 									},
@@ -215,7 +216,7 @@ func TestGCPCluster_ValidateUpdate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			warn, err := (&gcpClusterWebhook{}).ValidateUpdate(t.Context(), test.oldCluster, test.newCluster)
+			warn, err := (&GCPCluster{}).ValidateUpdate(t.Context(), test.oldCluster, test.newCluster)
 			if test.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/webhooks/gcpclustertemplate_webhook.go
+++ b/webhooks/gcpclustertemplate_webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -23,48 +23,49 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 func (r *GCPClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	w := new(gcpClusterTemplateWebhook)
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
-		WithValidator(w).
-		WithDefaulter(w).
+		For(&infrav1.GCPClusterTemplate{}).
+		WithValidator(r).
+		WithDefaulter(r).
 		Complete()
 }
 
 //+kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-gcpclustertemplate,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=gcpclustertemplates,versions=v1beta1,name=default.gcpclustertemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 //+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-gcpclustertemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=gcpclustertemplates,versions=v1beta1,name=validation.gcpclustertemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
-type gcpClusterTemplateWebhook struct{}
+// GCPClusterTemplate implements a validating and defaulting webhook for GCPClusterTemplate.
+type GCPClusterTemplate struct{}
 
 var (
-	_ webhook.CustomDefaulter = &gcpClusterTemplateWebhook{}
-	_ webhook.CustomValidator = &gcpClusterTemplateWebhook{}
+	_ webhook.CustomDefaulter = &GCPClusterTemplate{}
+	_ webhook.CustomValidator = &GCPClusterTemplate{}
 )
 
 // Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
-func (*gcpClusterTemplateWebhook) Default(_ context.Context, _ runtime.Object) error {
+func (*GCPClusterTemplate) Default(_ context.Context, _ runtime.Object) error {
 	return nil
 }
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (*gcpClusterTemplateWebhook) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (*GCPClusterTemplate) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (*gcpClusterTemplateWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	r, ok := newObj.(*GCPClusterTemplate)
+func (*GCPClusterTemplate) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	r, ok := newObj.(*infrav1.GCPClusterTemplate)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPClusterTemplate object but got %T", r)
 	}
 
-	old, ok := oldObj.(*GCPClusterTemplate)
+	old, ok := oldObj.(*infrav1.GCPClusterTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected an GCPClusterTemplate but got a %T", oldObj))
 	}
@@ -76,6 +77,6 @@ func (*gcpClusterTemplateWebhook) ValidateUpdate(_ context.Context, oldObj, newO
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
-func (*gcpClusterTemplateWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (*GCPClusterTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/webhooks/gcpclustertemplate_webhook_test.go
+++ b/webhooks/gcpclustertemplate_webhook_test.go
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 )
 
 func TestGCPClusterTemplate_ValidateUpdate(t *testing.T) {
@@ -27,26 +28,26 @@ func TestGCPClusterTemplate_ValidateUpdate(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		newTemplate *GCPClusterTemplate
-		oldTemplate *GCPClusterTemplate
+		newTemplate *infrav1.GCPClusterTemplate
+		oldTemplate *infrav1.GCPClusterTemplate
 		wantErr     bool
 	}{
 		{
 			name: "GCPClusterTemplated with immutable spec",
-			newTemplate: &GCPClusterTemplate{
-				Spec: GCPClusterTemplateSpec{
-					Template: GCPClusterTemplateResource{
-						Spec: GCPClusterSpec{
+			newTemplate: &infrav1.GCPClusterTemplate{
+				Spec: infrav1.GCPClusterTemplateSpec{
+					Template: infrav1.GCPClusterTemplateResource{
+						Spec: infrav1.GCPClusterSpec{
 							Project: "test-gcp-cluster",
 							Region:  "ap-south-1",
 						},
 					},
 				},
 			},
-			oldTemplate: &GCPClusterTemplate{
-				Spec: GCPClusterTemplateSpec{
-					Template: GCPClusterTemplateResource{
-						Spec: GCPClusterSpec{
+			oldTemplate: &infrav1.GCPClusterTemplate{
+				Spec: infrav1.GCPClusterTemplateSpec{
+					Template: infrav1.GCPClusterTemplateResource{
+						Spec: infrav1.GCPClusterSpec{
 							Project: "test-gcp-cluster",
 							Region:  "ap-south-1",
 						},
@@ -57,20 +58,20 @@ func TestGCPClusterTemplate_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "GCPClusterTemplated with mutable spec",
-			newTemplate: &GCPClusterTemplate{
-				Spec: GCPClusterTemplateSpec{
-					Template: GCPClusterTemplateResource{
-						Spec: GCPClusterSpec{
+			newTemplate: &infrav1.GCPClusterTemplate{
+				Spec: infrav1.GCPClusterTemplateSpec{
+					Template: infrav1.GCPClusterTemplateResource{
+						Spec: infrav1.GCPClusterSpec{
 							Project: "test-gcp-cluster",
 							Region:  "ap-south-1",
 						},
 					},
 				},
 			},
-			oldTemplate: &GCPClusterTemplate{
-				Spec: GCPClusterTemplateSpec{
-					Template: GCPClusterTemplateResource{
-						Spec: GCPClusterSpec{
+			oldTemplate: &infrav1.GCPClusterTemplate{
+				Spec: infrav1.GCPClusterTemplateSpec{
+					Template: infrav1.GCPClusterTemplateResource{
+						Spec: infrav1.GCPClusterSpec{
 							Project: "test-gcp-cluster",
 							Region:  "ap-east-1",
 						},
@@ -83,7 +84,7 @@ func TestGCPClusterTemplate_ValidateUpdate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			warn, err := (&gcpClusterTemplateWebhook{}).ValidateUpdate(t.Context(), test.oldTemplate, test.newTemplate)
+			warn, err := (&GCPClusterTemplate{}).ValidateUpdate(t.Context(), test.oldTemplate, test.newTemplate)
 			if test.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/webhooks/gcpmachine_webhook.go
+++ b/webhooks/gcpmachine_webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -28,37 +28,42 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// log is for logging in this package.
-var _ = logf.Log.WithName("gcpmachine-resource")
+// Confidential VM Technology support depends on the configured machine types.
+// reference: https://cloud.google.com/compute/confidential-vm/docs/os-and-machine-type#machine-type
+var (
+	confidentialMachineSeriesSupportingSev    = []string{"n2d", "c2d", "c3d"}
+	confidentialMachineSeriesSupportingSevsnp = []string{"n2d"}
+	confidentialMachineSeriesSupportingTdx    = []string{"c3"}
+)
 
 func (m *GCPMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	w := new(gcpMachineWebhook)
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(m).
-		WithValidator(w).
-		WithDefaulter(w).
+		For(&infrav1.GCPMachine{}).
+		WithValidator(m).
+		WithDefaulter(m).
 		Complete()
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmachine,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=gcpmachines,versions=v1beta1,name=validation.gcpmachine.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmachine,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=gcpmachines,versions=v1beta1,name=default.gcpmachine.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
-type gcpMachineWebhook struct{}
+// GCPMachine implements a validating and defaulting webhook for GCPMachine.
+type GCPMachine struct{}
 
 var (
-	_ webhook.CustomValidator = &gcpMachineWebhook{}
-	_ webhook.CustomDefaulter = &gcpMachineWebhook{}
+	_ webhook.CustomValidator = &GCPMachine{}
+	_ webhook.CustomDefaulter = &GCPMachine{}
 )
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpMachineWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	m, ok := obj.(*GCPMachine)
+func (*GCPMachine) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	m, ok := obj.(*infrav1.GCPMachine)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPMachine object but got %T", m)
 	}
@@ -72,21 +77,21 @@ func (*gcpMachineWebhook) ValidateCreate(_ context.Context, obj runtime.Object) 
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpMachineWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	m, ok := newObj.(*GCPMachine)
+func (*GCPMachine) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	m, ok := newObj.(*infrav1.GCPMachine)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPMachine object but got %T", m)
 	}
 
 	newGCPMachine, err := runtime.DefaultUnstructuredConverter.ToUnstructured(m)
 	if err != nil {
-		return nil, apierrors.NewInvalid(GroupVersion.WithKind("GCPMachine").GroupKind(), m.Name, field.ErrorList{
+		return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("GCPMachine").GroupKind(), m.Name, field.ErrorList{
 			field.InternalError(nil, errors.Wrap(err, "failed to convert new GCPMachine to unstructured object")),
 		})
 	}
 	oldGCPMachine, err := runtime.DefaultUnstructuredConverter.ToUnstructured(oldObj)
 	if err != nil {
-		return nil, apierrors.NewInvalid(GroupVersion.WithKind("GCPMachine").GroupKind(), m.Name, field.ErrorList{
+		return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("GCPMachine").GroupKind(), m.Name, field.ErrorList{
 			field.InternalError(nil, errors.Wrap(err, "failed to convert old GCPMachine to unstructured object")),
 		})
 	}
@@ -107,7 +112,7 @@ func (*gcpMachineWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runti
 	delete(newGCPMachineSpec, "additionalNetworkTags")
 
 	if !reflect.DeepEqual(oldGCPMachineSpec, newGCPMachineSpec) {
-		return nil, apierrors.NewInvalid(GroupVersion.WithKind("GCPMachine").GroupKind(), m.Name, field.ErrorList{
+		return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("GCPMachine").GroupKind(), m.Name, field.ErrorList{
 			field.Forbidden(field.NewPath("spec"), "cannot be modified"),
 		})
 	}
@@ -116,32 +121,32 @@ func (*gcpMachineWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runti
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpMachineWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (*GCPMachine) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // Default implements webhookutil.defaulter so a webhook will be registered for the type.
-func (*gcpMachineWebhook) Default(_ context.Context, _ runtime.Object) error {
+func (*GCPMachine) Default(_ context.Context, _ runtime.Object) error {
 	return nil
 }
 
-func validateConfidentialCompute(spec GCPMachineSpec) error {
-	if spec.ConfidentialCompute != nil && *spec.ConfidentialCompute != ConfidentialComputePolicyDisabled {
-		if spec.OnHostMaintenance == nil || *spec.OnHostMaintenance == HostMaintenancePolicyMigrate {
-			return fmt.Errorf("ConfidentialCompute require OnHostMaintenance to be set to %s, the current value is: %s", HostMaintenancePolicyTerminate, HostMaintenancePolicyMigrate)
+func validateConfidentialCompute(spec infrav1.GCPMachineSpec) error {
+	if spec.ConfidentialCompute != nil && *spec.ConfidentialCompute != infrav1.ConfidentialComputePolicyDisabled {
+		if spec.OnHostMaintenance == nil || *spec.OnHostMaintenance == infrav1.HostMaintenancePolicyMigrate {
+			return fmt.Errorf("ConfidentialCompute require OnHostMaintenance to be set to %s, the current value is: %s", infrav1.HostMaintenancePolicyTerminate, infrav1.HostMaintenancePolicyMigrate)
 		}
 
 		machineSeries := strings.Split(spec.InstanceType, "-")[0]
 		switch *spec.ConfidentialCompute {
-		case ConfidentialComputePolicyEnabled, ConfidentialComputePolicySEV:
+		case infrav1.ConfidentialComputePolicyEnabled, infrav1.ConfidentialComputePolicySEV:
 			if !slices.Contains(confidentialMachineSeriesSupportingSev, machineSeries) {
 				return fmt.Errorf("ConfidentialCompute %s requires any of the following machine series: %s. %s was found instead", *spec.ConfidentialCompute, strings.Join(confidentialMachineSeriesSupportingSev, ", "), spec.InstanceType)
 			}
-		case ConfidentialComputePolicySEVSNP:
+		case infrav1.ConfidentialComputePolicySEVSNP:
 			if !slices.Contains(confidentialMachineSeriesSupportingSevsnp, machineSeries) {
 				return fmt.Errorf("ConfidentialCompute %s requires any of the following machine series: %s. %s was found instead", *spec.ConfidentialCompute, strings.Join(confidentialMachineSeriesSupportingSevsnp, ", "), spec.InstanceType)
 			}
-		case ConfidentialComputePolicyTDX:
+		case infrav1.ConfidentialComputePolicyTDX:
 			if !slices.Contains(confidentialMachineSeriesSupportingTdx, machineSeries) {
 				return fmt.Errorf("ConfidentialCompute %s requires any of the following machine series: %s. %s was found instead", *spec.ConfidentialCompute, strings.Join(confidentialMachineSeriesSupportingTdx, ", "), spec.InstanceType)
 			}
@@ -152,13 +157,13 @@ func validateConfidentialCompute(spec GCPMachineSpec) error {
 	return nil
 }
 
-func checkKeyType(key *CustomerEncryptionKey) error {
+func checkKeyType(key *infrav1.CustomerEncryptionKey) error {
 	switch key.KeyType {
-	case CustomerManagedKey:
+	case infrav1.CustomerManagedKey:
 		if key.ManagedKey == nil || key.SuppliedKey != nil {
 			return errors.New("CustomerEncryptionKey KeyType of Managed requires only ManagedKey to be set")
 		}
-	case CustomerSuppliedKey:
+	case infrav1.CustomerSuppliedKey:
 		if key.SuppliedKey == nil || key.ManagedKey != nil {
 			return errors.New("CustomerEncryptionKey KeyType of Supplied requires only SuppliedKey to be set")
 		}
@@ -171,7 +176,7 @@ func checkKeyType(key *CustomerEncryptionKey) error {
 	return nil
 }
 
-func validateCustomerEncryptionKey(spec GCPMachineSpec) error {
+func validateCustomerEncryptionKey(spec infrav1.GCPMachineSpec) error {
 	if spec.RootDiskEncryptionKey != nil {
 		if err := checkKeyType(spec.RootDiskEncryptionKey); err != nil {
 			return err

--- a/webhooks/gcpmachine_webhook_test.go
+++ b/webhooks/gcpmachine_webhook_test.go
@@ -14,32 +14,33 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 )
 
 func TestGCPMachine_ValidateCreate(t *testing.T) {
 	g := NewWithT(t)
-	confidentialComputeEnabled := ConfidentialComputePolicyEnabled
-	confidentialComputeSEV := ConfidentialComputePolicySEV
-	confidentialComputeSEVSNP := ConfidentialComputePolicySEVSNP
-	confidentialComputeTDX := ConfidentialComputePolicyTDX
-	confidentialComputeFooBar := ConfidentialComputePolicy("foobar")
-	onHostMaintenanceTerminate := HostMaintenancePolicyTerminate
-	onHostMaintenanceMigrate := HostMaintenancePolicyMigrate
+	confidentialComputeEnabled := infrav1.ConfidentialComputePolicyEnabled
+	confidentialComputeSEV := infrav1.ConfidentialComputePolicySEV
+	confidentialComputeSEVSNP := infrav1.ConfidentialComputePolicySEVSNP
+	confidentialComputeTDX := infrav1.ConfidentialComputePolicyTDX
+	confidentialComputeFooBar := infrav1.ConfidentialComputePolicy("foobar")
+	onHostMaintenanceTerminate := infrav1.HostMaintenancePolicyTerminate
+	onHostMaintenanceMigrate := infrav1.HostMaintenancePolicyMigrate
 	tests := []struct {
 		name string
-		*GCPMachine
+		*infrav1.GCPMachine
 		wantErr bool
 	}{
 		{
 			name: "GCPMachined with OnHostMaintenance set to Terminate - valid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:      "n2d-standard-4",
 					OnHostMaintenance: &onHostMaintenanceTerminate,
 				},
@@ -48,8 +49,8 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachined with ConfidentialCompute enabled and OnHostMaintenance set to Terminate - valid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:        "n2d-standard-4",
 					OnHostMaintenance:   &onHostMaintenanceTerminate,
 					ConfidentialCompute: &confidentialComputeEnabled,
@@ -59,8 +60,8 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachined with ConfidentialCompute enabled and OnHostMaintenance set to Migrate - invalid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:        "n2d-standard-4",
 					OnHostMaintenance:   &onHostMaintenanceMigrate,
 					ConfidentialCompute: &confidentialComputeEnabled,
@@ -70,8 +71,8 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachined with ConfidentialCompute enabled and default OnHostMaintenance (Migrate) - invalid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:        "n2d-standard-4",
 					ConfidentialCompute: &confidentialComputeEnabled,
 				},
@@ -80,8 +81,8 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachined with ConfidentialCompute enabled and unsupported instance type - invalid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:        "e2-standard-4",
 					ConfidentialCompute: &confidentialComputeEnabled,
 					OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -91,8 +92,8 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with ConfidentialCompute AMDEncryptedVirtualization and supported instance type - valid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:        "c3d-standard-4",
 					ConfidentialCompute: &confidentialComputeSEV,
 					OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -102,8 +103,8 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with ConfidentialCompute AMDEncryptedVirtualization and unsupported instance type - invalid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:        "e2-standard-4",
 					ConfidentialCompute: &confidentialComputeSEV,
 					OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -113,8 +114,8 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with ConfidentialCompute AMDEncryptedVirtualization and OnHostMaintenance Migrate - invalid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:        "c2d-standard-4",
 					ConfidentialCompute: &confidentialComputeSEV,
 					OnHostMaintenance:   &onHostMaintenanceMigrate,
@@ -124,8 +125,8 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and supported instance type - valid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:        "n2d-standard-4",
 					ConfidentialCompute: &confidentialComputeSEVSNP,
 					OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -135,8 +136,8 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and unsupported instance type - invalid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:        "e2-standard-4",
 					ConfidentialCompute: &confidentialComputeSEVSNP,
 					OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -146,8 +147,8 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and OnHostMaintenance Migrate - invalid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:        "n2d-standard-4",
 					ConfidentialCompute: &confidentialComputeSEVSNP,
 					OnHostMaintenance:   &onHostMaintenanceMigrate,
@@ -157,8 +158,8 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with ConfidentialCompute foobar - invalid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:        "n2d-standard-4",
 					ConfidentialCompute: &confidentialComputeFooBar,
 					OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -168,8 +169,8 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with explicit TDX ConfidentialInstanceType and supported machine type - valid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:        "c3-standard-4",
 					ConfidentialCompute: &confidentialComputeTDX,
 					OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -179,8 +180,8 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with explicit TDX ConfidentialInstanceType and unsupported machine type - invalid",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
 					InstanceType:        "c3d-standard-4",
 					ConfidentialCompute: &confidentialComputeTDX,
 					OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -190,11 +191,11 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with RootDiskEncryptionKey KeyType Managed and Managed field set",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
-					RootDiskEncryptionKey: &CustomerEncryptionKey{
-						KeyType: CustomerManagedKey,
-						ManagedKey: &ManagedKey{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
+					RootDiskEncryptionKey: &infrav1.CustomerEncryptionKey{
+						KeyType: infrav1.CustomerManagedKey,
+						ManagedKey: &infrav1.ManagedKey{
 							KMSKeyName: "projects/my-project/locations/us-central1/keyRings/us-central1/cryptoKeys/some-key",
 						},
 					},
@@ -204,10 +205,10 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with RootDiskEncryptionKey KeyType Managed and Managed field not set",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
-					RootDiskEncryptionKey: &CustomerEncryptionKey{
-						KeyType: CustomerManagedKey,
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
+					RootDiskEncryptionKey: &infrav1.CustomerEncryptionKey{
+						KeyType: infrav1.CustomerManagedKey,
 					},
 				},
 			},
@@ -215,10 +216,10 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with RootDiskEncryptionKey KeyType Supplied and Supplied field not set",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
-					RootDiskEncryptionKey: &CustomerEncryptionKey{
-						KeyType: CustomerSuppliedKey,
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
+					RootDiskEncryptionKey: &infrav1.CustomerEncryptionKey{
+						KeyType: infrav1.CustomerSuppliedKey,
 					},
 				},
 			},
@@ -226,12 +227,12 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with AdditionalDisk Encryption KeyType Managed and Managed field not set",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
-					AdditionalDisks: []AttachedDiskSpec{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
+					AdditionalDisks: []infrav1.AttachedDiskSpec{
 						{
-							EncryptionKey: &CustomerEncryptionKey{
-								KeyType: CustomerManagedKey,
+							EncryptionKey: &infrav1.CustomerEncryptionKey{
+								KeyType: infrav1.CustomerManagedKey,
 							},
 						},
 					},
@@ -241,11 +242,11 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with RootDiskEncryptionKey KeyType Supplied and one Supplied field set",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
-					RootDiskEncryptionKey: &CustomerEncryptionKey{
-						KeyType: CustomerSuppliedKey,
-						SuppliedKey: &SuppliedKey{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
+					RootDiskEncryptionKey: &infrav1.CustomerEncryptionKey{
+						KeyType: infrav1.CustomerSuppliedKey,
+						SuppliedKey: &infrav1.SuppliedKey{
 							RawKey: []byte("SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="),
 						},
 					},
@@ -255,11 +256,11 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with RootDiskEncryptionKey KeyType Supplied and both Supplied fields set",
-			GCPMachine: &GCPMachine{
-				Spec: GCPMachineSpec{
-					RootDiskEncryptionKey: &CustomerEncryptionKey{
-						KeyType: CustomerSuppliedKey,
-						SuppliedKey: &SuppliedKey{
+			GCPMachine: &infrav1.GCPMachine{
+				Spec: infrav1.GCPMachineSpec{
+					RootDiskEncryptionKey: &infrav1.CustomerEncryptionKey{
+						KeyType: infrav1.CustomerSuppliedKey,
+						SuppliedKey: &infrav1.SuppliedKey{
 							RawKey:          []byte("SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="),
 							RSAEncryptedKey: []byte("SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="),
 						},
@@ -272,7 +273,7 @@ func TestGCPMachine_ValidateCreate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			warn, err := (&gcpMachineWebhook{}).ValidateCreate(t.Context(), test.GCPMachine)
+			warn, err := (&GCPMachine{}).ValidateCreate(t.Context(), test.GCPMachine)
 			if test.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/webhooks/gcpmachinetemplate_webhook.go
+++ b/webhooks/gcpmachinetemplate_webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -25,8 +25,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -34,28 +34,25 @@ import (
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=gcpmachinetemplates,versions=v1beta1,name=validation.gcpmachinetemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-gcpmachinetemplate,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=gcpmachinetemplates,versions=v1beta1,name=default.gcpmachinetemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
 
-// log is for logging in this package.
-var _ = logf.Log.WithName("gcpmachinetemplate-resource")
-
 func (r *GCPMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	w := new(gcpMachineTemplateWebhook)
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
-		WithValidator(w).
-		WithDefaulter(w).
+		For(&infrav1.GCPMachineTemplate{}).
+		WithValidator(r).
+		WithDefaulter(r).
 		Complete()
 }
 
-type gcpMachineTemplateWebhook struct{}
+// GCPMachineTemplate implements a validating and defaulting webhook for GCPMachineTemplate.
+type GCPMachineTemplate struct{}
 
 var (
-	_ webhook.CustomValidator = &gcpMachineTemplateWebhook{}
-	_ webhook.CustomDefaulter = &gcpMachineTemplateWebhook{}
+	_ webhook.CustomValidator = &GCPMachineTemplate{}
+	_ webhook.CustomDefaulter = &GCPMachineTemplate{}
 )
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpMachineTemplateWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*GCPMachineTemplate)
+func (*GCPMachineTemplate) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	r, ok := obj.(*infrav1.GCPMachineTemplate)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPMachineTemplate object but got %T", r)
 	}
@@ -66,21 +63,21 @@ func (*gcpMachineTemplateWebhook) ValidateCreate(_ context.Context, obj runtime.
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpMachineTemplateWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	r, ok := newObj.(*GCPMachineTemplate)
+func (*GCPMachineTemplate) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	r, ok := newObj.(*infrav1.GCPMachineTemplate)
 	if !ok {
 		return nil, fmt.Errorf("expected an GCPMachineTemplate object but got %T", r)
 	}
 
 	newGCPMachineTemplate, err := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	if err != nil {
-		return nil, apierrors.NewInvalid(GroupVersion.WithKind("GCPMachineTemplate").GroupKind(), r.Name, field.ErrorList{
+		return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("GCPMachineTemplate").GroupKind(), r.Name, field.ErrorList{
 			field.InternalError(nil, errors.Wrap(err, "failed to convert new GCPMachineTemplate to unstructured object")),
 		})
 	}
 	oldGCPMachineTemplate, err := runtime.DefaultUnstructuredConverter.ToUnstructured(oldObj)
 	if err != nil {
-		return nil, apierrors.NewInvalid(GroupVersion.WithKind("GCPMachineTemplate").GroupKind(), r.Name, field.ErrorList{
+		return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("GCPMachineTemplate").GroupKind(), r.Name, field.ErrorList{
 			field.InternalError(nil, errors.Wrap(err, "failed to convert old GCPMachineTemplate to unstructured object")),
 		})
 	}
@@ -101,7 +98,7 @@ func (*gcpMachineTemplateWebhook) ValidateUpdate(_ context.Context, oldObj, newO
 	delete(newGCPMachineTemplateSpec, "additionalNetworkTags")
 
 	if !reflect.DeepEqual(oldGCPMachineTemplateSpec, newGCPMachineTemplateSpec) {
-		return nil, apierrors.NewInvalid(GroupVersion.WithKind("GCPMachineTemplate").GroupKind(), r.Name, field.ErrorList{
+		return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("GCPMachineTemplate").GroupKind(), r.Name, field.ErrorList{
 			field.Forbidden(field.NewPath("spec"), "cannot be modified"),
 		})
 	}
@@ -110,11 +107,11 @@ func (*gcpMachineTemplateWebhook) ValidateUpdate(_ context.Context, oldObj, newO
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (*gcpMachineTemplateWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (*GCPMachineTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // Default implements webhookutil.defaulter so a webhook will be registered for the type.
-func (*gcpMachineTemplateWebhook) Default(_ context.Context, _ runtime.Object) error {
+func (*GCPMachineTemplate) Default(_ context.Context, _ runtime.Object) error {
 	return nil
 }

--- a/webhooks/gcpmachinetemplate_webhook_test.go
+++ b/webhooks/gcpmachinetemplate_webhook_test.go
@@ -14,33 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 )
 
 func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 	g := NewWithT(t)
-	confidentialComputeEnabled := ConfidentialComputePolicyEnabled
-	confidentialComputeSEV := ConfidentialComputePolicySEV
-	confidentialComputeSEVSNP := ConfidentialComputePolicySEVSNP
-	confidentialComputeTDX := ConfidentialComputePolicyTDX
-	onHostMaintenanceTerminate := HostMaintenancePolicyTerminate
-	onHostMaintenanceMigrate := HostMaintenancePolicyMigrate
+	confidentialComputeEnabled := infrav1.ConfidentialComputePolicyEnabled
+	confidentialComputeSEV := infrav1.ConfidentialComputePolicySEV
+	confidentialComputeSEVSNP := infrav1.ConfidentialComputePolicySEVSNP
+	confidentialComputeTDX := infrav1.ConfidentialComputePolicyTDX
+	onHostMaintenanceTerminate := infrav1.HostMaintenancePolicyTerminate
+	onHostMaintenanceMigrate := infrav1.HostMaintenancePolicyMigrate
 	tests := []struct {
 		name     string
-		template *GCPMachineTemplate
+		template *infrav1.GCPMachineTemplate
 		wantErr  bool
 	}{
 		{
 			name: "GCPMachineTemplate with OnHostMaintenance set to Terminate - valid",
-			template: &GCPMachineTemplate{
-				Spec: GCPMachineTemplateSpec{
-					Template: GCPMachineTemplateResource{
-						Spec: GCPMachineSpec{
+			template: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
 							InstanceType:      "n2d-standard-4",
 							OnHostMaintenance: &onHostMaintenanceTerminate,
 						},
@@ -51,10 +52,10 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachineTemplate with ConfidentialCompute enabled and OnHostMaintenance set to Terminate - valid",
-			template: &GCPMachineTemplate{
-				Spec: GCPMachineTemplateSpec{
-					Template: GCPMachineTemplateResource{
-						Spec: GCPMachineSpec{
+			template: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
 							InstanceType:        "n2d-standard-4",
 							ConfidentialCompute: &confidentialComputeEnabled,
 							OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -66,10 +67,10 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachineTemplate with ConfidentialCompute enabled and OnHostMaintenance set to Migrate - invalid",
-			template: &GCPMachineTemplate{
-				Spec: GCPMachineTemplateSpec{
-					Template: GCPMachineTemplateResource{
-						Spec: GCPMachineSpec{
+			template: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
 							InstanceType:        "n2d-standard-4",
 							ConfidentialCompute: &confidentialComputeEnabled,
 							OnHostMaintenance:   &onHostMaintenanceMigrate,
@@ -81,10 +82,10 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachineTemplate with ConfidentialCompute enabled and default OnHostMaintenance (Migrate) - invalid",
-			template: &GCPMachineTemplate{
-				Spec: GCPMachineTemplateSpec{
-					Template: GCPMachineTemplateResource{
-						Spec: GCPMachineSpec{
+			template: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
 							InstanceType:        "n2d-standard-4",
 							ConfidentialCompute: &confidentialComputeEnabled,
 						},
@@ -95,10 +96,10 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachineTemplate with ConfidentialCompute enabled and unsupported instance type - invalid",
-			template: &GCPMachineTemplate{
-				Spec: GCPMachineTemplateSpec{
-					Template: GCPMachineTemplateResource{
-						Spec: GCPMachineSpec{
+			template: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
 							InstanceType:        "e2-standard-4",
 							ConfidentialCompute: &confidentialComputeEnabled,
 							OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -110,10 +111,10 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachineTemplate with ConfidentialCompute AMDEncryptedVirtualization and unsupported instance type - invalid",
-			template: &GCPMachineTemplate{
-				Spec: GCPMachineTemplateSpec{
-					Template: GCPMachineTemplateResource{
-						Spec: GCPMachineSpec{
+			template: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
 							InstanceType:        "e2-standard-4",
 							ConfidentialCompute: &confidentialComputeSEV,
 							OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -125,10 +126,10 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachineTemplate with ConfidentialCompute AMDEncryptedVirtualization and supported instance type - valid",
-			template: &GCPMachineTemplate{
-				Spec: GCPMachineTemplateSpec{
-					Template: GCPMachineTemplateResource{
-						Spec: GCPMachineSpec{
+			template: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
 							InstanceType:        "c2d-standard-4",
 							ConfidentialCompute: &confidentialComputeSEV,
 							OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -140,10 +141,10 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachineTemplate with ConfidentialCompute AMDEncryptedVirtualization and OnHostMaintenance Migrate - invalid",
-			template: &GCPMachineTemplate{
-				Spec: GCPMachineTemplateSpec{
-					Template: GCPMachineTemplateResource{
-						Spec: GCPMachineSpec{
+			template: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
 							InstanceType:        "c2d-standard-4",
 							ConfidentialCompute: &confidentialComputeSEV,
 							OnHostMaintenance:   &onHostMaintenanceMigrate,
@@ -155,10 +156,10 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachineTemplate with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and unsupported instance type - invalid",
-			template: &GCPMachineTemplate{
-				Spec: GCPMachineTemplateSpec{
-					Template: GCPMachineTemplateResource{
-						Spec: GCPMachineSpec{
+			template: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
 							InstanceType:        "c2d-standard-4",
 							ConfidentialCompute: &confidentialComputeSEVSNP,
 							OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -170,10 +171,10 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachineTemplate with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and supported instance type - valid",
-			template: &GCPMachineTemplate{
-				Spec: GCPMachineTemplateSpec{
-					Template: GCPMachineTemplateResource{
-						Spec: GCPMachineSpec{
+			template: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
 							InstanceType:        "n2d-standard-4",
 							ConfidentialCompute: &confidentialComputeSEVSNP,
 							OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -185,10 +186,10 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachineTemplate with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and OnHostMaintenance Migrate - invalid",
-			template: &GCPMachineTemplate{
-				Spec: GCPMachineTemplateSpec{
-					Template: GCPMachineTemplateResource{
-						Spec: GCPMachineSpec{
+			template: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
 							InstanceType:        "c2d-standard-4",
 							ConfidentialCompute: &confidentialComputeSEVSNP,
 							OnHostMaintenance:   &onHostMaintenanceMigrate,
@@ -200,10 +201,10 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with explicit TDX ConfidentialInstanceType and supported machine type - valid",
-			template: &GCPMachineTemplate{
-				Spec: GCPMachineTemplateSpec{
-					Template: GCPMachineTemplateResource{
-						Spec: GCPMachineSpec{
+			template: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
 							InstanceType:        "c3-standard-4",
 							ConfidentialCompute: &confidentialComputeTDX,
 							OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -215,10 +216,10 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "GCPMachine with explicit TDX ConfidentialInstanceType and unsupported machine type - invalid",
-			template: &GCPMachineTemplate{
-				Spec: GCPMachineTemplateSpec{
-					Template: GCPMachineTemplateResource{
-						Spec: GCPMachineSpec{
+			template: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
 							InstanceType:        "c3d-standard-4",
 							ConfidentialCompute: &confidentialComputeTDX,
 							OnHostMaintenance:   &onHostMaintenanceTerminate,
@@ -232,7 +233,7 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			warn, err := (&gcpMachineTemplateWebhook{}).ValidateCreate(t.Context(), test.template)
+			warn, err := (&GCPMachineTemplate{}).ValidateCreate(t.Context(), test.template)
 			if test.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

The primary purpose of this change is to reduce the impact of incompatible changes to controller-runtime on packages which import CAPG API packages. This change removes webhooks from the api package, and their associated c-r dependencies.

This change deliberately follows the webhook pattern used in the cluster-api repo. In general this means all webhooks move from api packages into a corresponding webhooks package. Each API type which implements a webhook gets a corresponding type in the webhooks package which implements SetupWebhookWithManager. Internal callers are updated to use the new webhook types. Corresponding webhook tests have been moved to the webhooks package.

The only impact on exported symbols is that api types no longer have a SetupWebhookWithManager method.

An explicit goal of this change is to minimise code change during code motion. Where possible, code has not been changed at all, just moved.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

While technically a breaking API change, it is not expected that external callers will call SetupWebhookWithManager in practice.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
action required
If you are importing CAPG APIs and are using SetupWebhookWithManager you'll need to update your call sites.
SetupWebhookWithManager methods have been removed from all api packages for all exported types. Callers importing CAPG as a Go library can no longer use these methods.
```
