### PR TITLE
chore: harden git workflows

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,6 +3,7 @@ name: Codespell
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
 
 permissions: {}
 
@@ -11,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
         with:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened]
     paths: "docs/**"
 
 permissions: {}
@@ -19,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
 
 permissions: {}
 
@@ -15,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:

--- a/.github/workflows/pr-gh-workflow-approve.yaml
+++ b/.github/workflows/pr-gh-workflow-approve.yaml
@@ -7,6 +7,8 @@ on:
       - labeled
       - reopened
       - synchronize
+      
+permissions: {}
 
 jobs:
   approve:


### PR DESCRIPTION
 What type of PR is this?
/kind cleanup

What this PR does / why we need it:

Hardens the security of GitHub Actions workflows by:

 - Adding `persist-credentials: false` to all checkout steps that do not require git credentials after checkout
 - Adding `permissions: {}` at workflow level where missing
 - Adding `types: [opened, edited, synchronize, reopened]` to `pull_request` triggers to avoid running on every trivial PR event

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

No image versions were changed in this PR. All changes are limited to GitHub Actions workflow security hardening. The `persist-credentials: false` changes are safe as verified step-by-step as no workflow requires git credentials after checkout except the dependabot workflow which intentionally retains `persist-credentials: true`.

TODOs:

 - [ ] squashed commits
 - [ ] includes documentation
 - [ ] adds unit tests

```release-note
NONE
```
