### PR TITLE
fix: Address the use of managing default firewall rules

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -276,7 +276,8 @@ type FirewallSpec struct {
 	// +kubebuilder:default:="Managed"
 	DefaultRulesManagement RulesManagementPolicy `json:"defaultRulesManagement,omitempty"`
 
-	// FirewallRules is a list of additional firewall rules to create.
+	// FirewallRules is a list of additional firewall rules to create. FirewallRules has no effect
+	// when a HostProject is specified.
 	// +kubebuilder:validation:MaxItems=50
 	// +optional
 	FirewallRules []FirewallRule `json:"firewallRules,omitempty"`

--- a/cloud/interfaces.go
+++ b/cloud/interfaces.go
@@ -58,7 +58,7 @@ type ClusterGetter interface {
 	NetworkName() string
 	NetworkProject() string
 	IsSharedVpc() bool
-	SkipFirewallRuleCreation() bool
+	SkipFirewallRulesManagement() bool
 	Network() *infrav1.Network
 	AdditionalLabels() infrav1.Labels
 	FailureDomains() []string

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -106,12 +106,11 @@ func (s *ClusterScope) NetworkProject() string {
 	return ptr.Deref(s.GCPCluster.Spec.Network.HostProject, s.Project())
 }
 
-// SkipFirewallRuleCreation returns whether the spec indicates that firewall rules
-// should be created or not. If the RulesManagement for the default firewall rules is
-// set to unmanaged or when the cluster will include a shared VPC, the default firewall
-// rule creation will be skipped.
-func (s *ClusterScope) SkipFirewallRuleCreation() bool {
-	return (s.GCPCluster.Spec.Network.Firewall.DefaultRulesManagement == infrav1.RulesManagementUnmanaged) || s.IsSharedVpc()
+// SkipFirewallRulesManagement returns whether the spec indicates that firewall rules
+// should be created or not. Firewall rules will not be created when the cluster
+// contains a shared VPC network.
+func (s *ClusterScope) SkipFirewallRulesManagement() bool {
+	return s.IsSharedVpc()
 }
 
 // IsSharedVpc returns true If sharedVPC used else , returns false.
@@ -293,7 +292,12 @@ func (s *ClusterScope) SubnetSpecs() []*compute.Subnetwork {
 
 // FirewallRulesSpec returns google compute firewall spec.
 func (s *ClusterScope) FirewallRulesSpec() []*compute.Firewall {
-	return createFirewallRules(s.Name(), s.NetworkLink(), s.GCPCluster.Spec.Network.Firewall.FirewallRules)
+	return createFirewallRules(
+		s.Name(),
+		s.NetworkLink(),
+		s.GCPCluster.Spec.Network.Firewall.DefaultRulesManagement,
+		s.GCPCluster.Spec.Network.Firewall.FirewallRules,
+	)
 }
 
 // ANCHOR_END: ClusterFirewallSpec

--- a/cloud/scope/firewall.go
+++ b/cloud/scope/firewall.go
@@ -11,46 +11,52 @@ import (
 )
 
 // createFirewallRules
-func createFirewallRules(clusterName, networkLink string, userSpecifiedRules []infrav1.FirewallRule) []*compute.Firewall {
-	firewallRules := []*compute.Firewall{
-		{
-			Name:    fmt.Sprintf("allow-%s-healthchecks", clusterName),
-			Network: networkLink,
-			Allowed: []*compute.FirewallAllowed{
-				{
-					IPProtocol: "TCP",
-					Ports: []string{
-						strconv.FormatInt(6443, 10),
+func createFirewallRules(clusterName, networkLink string, policy infrav1.RulesManagementPolicy, userSpecifiedRules []infrav1.FirewallRule) []*compute.Firewall {
+	firewallRules := []*compute.Firewall{}
+
+	// Only when the user explicitly states that it is unmanaged, the rules should be skipped.
+	// When the policy is Managed or missing/empty the rules should be included.
+	if policy != infrav1.RulesManagementUnmanaged {
+		firewallRules = append(firewallRules, []*compute.Firewall{
+			{
+				Name:    fmt.Sprintf("allow-%s-healthchecks", clusterName),
+				Network: networkLink,
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "TCP",
+						Ports: []string{
+							strconv.FormatInt(6443, 10),
+						},
 					},
 				},
-			},
-			Direction: "INGRESS",
-			SourceRanges: []string{
-				"35.191.0.0/16",
-				"130.211.0.0/22",
-			},
-			TargetTags: []string{
-				clusterName + "-control-plane",
-			},
-		},
-		{
-			Name:    fmt.Sprintf("allow-%s-cluster", clusterName),
-			Network: networkLink,
-			Allowed: []*compute.FirewallAllowed{
-				{
-					IPProtocol: "all",
+				Direction: "INGRESS",
+				SourceRanges: []string{
+					"35.191.0.0/16",
+					"130.211.0.0/22",
+				},
+				TargetTags: []string{
+					clusterName + "-control-plane",
 				},
 			},
-			Direction: "INGRESS",
-			SourceTags: []string{
-				clusterName + "-control-plane",
-				clusterName + "-node",
+			{
+				Name:    fmt.Sprintf("allow-%s-cluster", clusterName),
+				Network: networkLink,
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "all",
+					},
+				},
+				Direction: "INGRESS",
+				SourceTags: []string{
+					clusterName + "-control-plane",
+					clusterName + "-node",
+				},
+				TargetTags: []string{
+					clusterName + "-control-plane",
+					clusterName + "-node",
+				},
 			},
-			TargetTags: []string{
-				clusterName + "-control-plane",
-				clusterName + "-node",
-			},
-		},
+		}...)
 	}
 
 	// Add user defined firewall rules.

--- a/cloud/scope/managedcluster.go
+++ b/cloud/scope/managedcluster.go
@@ -129,12 +129,11 @@ func (s *ManagedClusterScope) NetworkProject() string {
 	return ptr.Deref(s.GCPManagedCluster.Spec.Network.HostProject, s.Project())
 }
 
-// SkipFirewallRuleCreation returns whether the spec indicates that firewall rules
-// should be created or not. If the RulesManagement for the default firewall rules is
-// set to unmanaged or when the cluster will include a shared VPC, the default firewall
-// rule creation will be skipped.
-func (s *ManagedClusterScope) SkipFirewallRuleCreation() bool {
-	return (s.GCPManagedCluster.Spec.Network.Firewall.DefaultRulesManagement == infrav1.RulesManagementUnmanaged) || s.IsSharedVpc()
+// SkipFirewallRulesManagement returns whether the spec indicates that firewall rules
+// should be created or not. Firewall rules will not be created when the cluster
+// contains a shared VPC network.
+func (s *ManagedClusterScope) SkipFirewallRulesManagement() bool {
+	return s.IsSharedVpc()
 }
 
 // IsSharedVpc returns true If sharedVPC used else , returns false.
@@ -279,7 +278,12 @@ func (s *ManagedClusterScope) SubnetSpecs() []*compute.Subnetwork {
 
 // FirewallRulesSpec returns google compute firewall spec.
 func (s *ManagedClusterScope) FirewallRulesSpec() []*compute.Firewall {
-	return createFirewallRules(s.Name(), s.NetworkLink(), s.GCPManagedCluster.Spec.Network.Firewall.FirewallRules)
+	return createFirewallRules(
+		s.Name(),
+		s.NetworkLink(),
+		s.GCPManagedCluster.Spec.Network.Firewall.DefaultRulesManagement,
+		s.GCPManagedCluster.Spec.Network.Firewall.FirewallRules,
+	)
 }
 
 // ANCHOR_END: ClusterFirewallSpec

--- a/cloud/services/compute/firewalls/reconcile.go
+++ b/cloud/services/compute/firewalls/reconcile.go
@@ -28,7 +28,7 @@ import (
 // Reconcile reconcile cluster firewall compoenents.
 func (s *Service) Reconcile(ctx context.Context) error {
 	log := log.FromContext(ctx)
-	if s.scope.SkipFirewallRuleCreation() {
+	if s.scope.SkipFirewallRulesManagement() {
 		log.V(2).Info("Ignore Reconciling firewall resources")
 		return nil
 	}
@@ -54,8 +54,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 // Delete delete cluster firewall compoenents.
 func (s *Service) Delete(ctx context.Context) error {
 	log := log.FromContext(ctx)
-	if s.scope.IsSharedVpc() {
-		log.V(2).Info("Shared VPC enabled. Ignore Deleting firewall resources")
+	if s.scope.SkipFirewallRulesManagement() {
+		log.V(2).Info("Ignore Deleting firewall resources")
 		return nil
 	}
 	log.Info("Deleting firewall resources")

--- a/cloud/services/compute/firewalls/reconcile_test.go
+++ b/cloud/services/compute/firewalls/reconcile_test.go
@@ -67,6 +67,9 @@ var fakeGCPCluster = &infrav1.GCPCluster{
 					Purpose:   ptr.To[string]("INTERNAL_HTTPS_LOAD_BALANCER"),
 				},
 			},
+			Firewall: infrav1.FirewallSpec{
+				DefaultRulesManagement: infrav1.RulesManagementManaged,
+			},
 		},
 	},
 	Status: infrav1.GCPClusterStatus{

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclusters.yaml
@@ -202,8 +202,9 @@ spec:
                         - Unmanaged
                         type: string
                       firewallRules:
-                        description: FirewallRules is a list of additional firewall
-                          rules to create.
+                        description: |-
+                          FirewallRules is a list of additional firewall rules to create. FirewallRules has no effect
+                          when a HostProject is specified.
                         items:
                           description: FirewallRule describes a GCP firewall rule.
                           properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpclustertemplates.yaml
@@ -221,8 +221,9 @@ spec:
                                 - Unmanaged
                                 type: string
                               firewallRules:
-                                description: FirewallRules is a list of additional
-                                  firewall rules to create.
+                                description: |-
+                                  FirewallRules is a list of additional firewall rules to create. FirewallRules has no effect
+                                  when a HostProject is specified.
                                 items:
                                   description: FirewallRule describes a GCP firewall
                                     rule.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclusters.yaml
@@ -196,8 +196,9 @@ spec:
                         - Unmanaged
                         type: string
                       firewallRules:
-                        description: FirewallRules is a list of additional firewall
-                          rules to create.
+                        description: |-
+                          FirewallRules is a list of additional firewall rules to create. FirewallRules has no effect
+                          when a HostProject is specified.
                         items:
                           description: FirewallRule describes a GCP firewall rule.
                           properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
@@ -190,8 +190,9 @@ spec:
                                 - Unmanaged
                                 type: string
                               firewallRules:
-                                description: FirewallRules is a list of additional
-                                  firewall rules to create.
+                                description: |-
+                                  FirewallRules is a list of additional firewall rules to create. FirewallRules has no effect
+                                  when a HostProject is specified.
                                 items:
                                   description: FirewallRule describes a GCP firewall
                                     rule.


### PR DESCRIPTION
cloud/scope/firewall.go:
Fix the bug by adding the management policy to the firewall rules creation.

cloud/scope/cluster.go:
cloud/scope/managedcluster.go:
Provide the rules management policy to the firewall rule function.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->
/kind bug

**What this PR does / why we need it**:

The default management policy was used in some regards but was not used when including firewall rules.



### Expected Behaviour table (edit: @damdo)

Default Rules Management | User Provided Rules | Shared VPC | Expected Result
-- | -- | -- | --
Managed | Yes | No | Create Default Rules, Create Custom Rules
Managed | No | No | Create Default
Managed | Yes | Yes | Skip Rules Creation
Managed | No | Yes | Skip Rules Creation
Unmanaged | Yes | No | Create Custom
Unmanaged | No | No | Skip Rules Creation
Unmanaged | Yes | Yes | Skip Rules Creation
Unmanaged | No | Yes | Skip Rules Creation

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
