### PR TITLE
🐛 Fix GCPManagedClusterTemplate,GCPManagedControlPlaneTemplate and GCPManagedMachinePoolTemplate short names

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedclustertemplates.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: GCPManagedClusterTemplateList
     plural: gcpmanagedclustertemplates
     shortNames:
-    - amct
+    - gcpmct
     singular: gcpmanagedclustertemplate
   scope: Namespaced
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanetemplates.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: GCPManagedControlPlaneTemplateList
     plural: gcpmanagedcontrolplanetemplates
     shortNames:
-    - amcpt
+    - gcpmcpt
     singular: gcpmanagedcontrolplanetemplate
   scope: Namespaced
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedmachinepooltemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedmachinepooltemplates.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: GCPManagedMachinePoolTemplateList
     plural: gcpmanagedmachinepooltemplates
     shortNames:
-    - ammpt
+    - gcpmmpt
     singular: gcpmanagedmachinepooltemplate
   scope: Namespaced
   versions:

--- a/exp/api/v1beta1/gcpmanagedclustertemplate_types.go
+++ b/exp/api/v1beta1/gcpmanagedclustertemplate_types.go
@@ -26,7 +26,7 @@ type GCPManagedClusterTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=gcpmanagedclustertemplates,scope=Namespaced,categories=cluster-api,shortName=amct
+// +kubebuilder:resource:path=gcpmanagedclustertemplates,scope=Namespaced,categories=cluster-api,shortName=gcpmct
 // +kubebuilder:storageversion
 
 // GCPManagedClusterTemplate is the Schema for the GCPManagedClusterTemplates API.

--- a/exp/api/v1beta1/gcpmanagedcontrolplanetemplate_types.go
+++ b/exp/api/v1beta1/gcpmanagedcontrolplanetemplate_types.go
@@ -26,7 +26,7 @@ type GCPManagedControlPlaneTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=gcpmanagedcontrolplanetemplates,scope=Namespaced,categories=cluster-api,shortName=amcpt
+// +kubebuilder:resource:path=gcpmanagedcontrolplanetemplates,scope=Namespaced,categories=cluster-api,shortName=gcpmcpt
 // +kubebuilder:storageversion
 
 // GCPManagedControlPlaneTemplate is the Schema for the GCPManagedControlPlaneTemplates API.

--- a/exp/api/v1beta1/gcpmanagedmachinepooltemplate_types.go
+++ b/exp/api/v1beta1/gcpmanagedmachinepooltemplate_types.go
@@ -26,7 +26,7 @@ type GCPManagedMachinePoolTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=gcpmanagedmachinepooltemplates,scope=Namespaced,categories=cluster-api,shortName=ammpt
+// +kubebuilder:resource:path=gcpmanagedmachinepooltemplates,scope=Namespaced,categories=cluster-api,shortName=gcpmmpt
 // +kubebuilder:storageversion
 
 // GCPManagedMachinePoolTemplate is the Schema for the GCPManagedMachinePoolTemplates API.


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Fix GCPManagedClusterTemplate, GCPManagedControlPlaneTemplate and  GCPManagedMachinePoolTemplate short names. The current short names conflict with CAPZ, making it impossible to install the latest CAPG version on the same management cluster as CAPZ.

CAPZ shortName definition: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/api/v1beta1/azuremanagedclustertemplate_types.go#L29

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
action required
The short names for GCPManagedClusterTemplate, GCPManagedControlPlaneTemplate, and GCPManagedMachinePoolTemplate have changed from amct, amcpt, and ammpt to gcpmct, gcpmcpt, and gcpmmpt, respectively. If you have any automation that relies on the short names, they will need to be updated accordingly.
```
