### PR TITLE
fix: expose ClusterName in GCPManagedControlPlaneTemplate

### DIFF
--- a/cloud/services/container/clusters/reconcile_test.go
+++ b/cloud/services/container/clusters/reconcile_test.go
@@ -50,8 +50,8 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 						Project:        "test-project",
 						Location:       "us-central1",
 						ReleaseChannel: ptr.To(infrav1exp.Stable),
+						ClusterName:    "test-cluster",
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{
@@ -78,8 +78,8 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 						Project:        "test-project",
 						Location:       "us-central1",
 						ReleaseChannel: ptr.To(infrav1exp.Rapid),
+						ClusterName:    "test-cluster",
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{
@@ -100,11 +100,11 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 			controlPlane: &infrav1exp.GCPManagedControlPlane{
 				Spec: infrav1exp.GCPManagedControlPlaneSpec{
 					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:     "test-project",
+						Location:    "us-central1",
+						ClusterName: "test-cluster",
 					},
-					ClusterName: "test-cluster",
-					Version:     ptr.To("1.28.0"),
+					Version: ptr.To("1.28.0"),
 				},
 			},
 			existingCluster: &containerpb.Cluster{
@@ -123,10 +123,10 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 			controlPlane: &infrav1exp.GCPManagedControlPlane{
 				Spec: infrav1exp.GCPManagedControlPlaneSpec{
 					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:     "test-project",
+						Location:    "us-central1",
+						ClusterName: "test-cluster",
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{},
@@ -148,10 +148,10 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 			controlPlane: &infrav1exp.GCPManagedControlPlane{
 				Spec: infrav1exp.GCPManagedControlPlaneSpec{
 					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:     "test-project",
+						Location:    "us-central1",
+						ClusterName: "test-cluster",
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{
@@ -180,8 +180,8 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 								{CidrBlock: "10.0.0.0/8", DisplayName: "internal"},
 							},
 						},
+						ClusterName: "test-cluster",
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{},
@@ -218,8 +218,8 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 								{CidrBlock: "192.168.0.0/16"},
 							},
 						},
+						ClusterName: "test-cluster",
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{

--- a/cloud/services/container/clusters/reconcile_test.go
+++ b/cloud/services/container/clusters/reconcile_test.go
@@ -50,8 +50,8 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 						Project:        "test-project",
 						Location:       "us-central1",
 						ReleaseChannel: ptr.To(infrav1exp.Stable),
+						ClusterName:    "test-cluster",
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{
@@ -78,8 +78,8 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 						Project:        "test-project",
 						Location:       "us-central1",
 						ReleaseChannel: ptr.To(infrav1exp.Rapid),
+						ClusterName:    "test-cluster",
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{
@@ -100,11 +100,11 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 			controlPlane: &infrav1exp.GCPManagedControlPlane{
 				Spec: infrav1exp.GCPManagedControlPlaneSpec{
 					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:     "test-project",
+						Location:    "us-central1",
+						ClusterName: "test-cluster",
 					},
-					ClusterName: "test-cluster",
-					Version:     ptr.To("1.28.0"),
+					Version: ptr.To("1.28.0"),
 				},
 			},
 			existingCluster: &containerpb.Cluster{
@@ -123,11 +123,11 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 			controlPlane: &infrav1exp.GCPManagedControlPlane{
 				Spec: infrav1exp.GCPManagedControlPlaneSpec{
 					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
+						ClusterName:       "test-cluster",
 						Project:           "test-project",
 						Location:          "us-central1",
 						MonitoringService: ptr.To(infrav1exp.MonitoringService("none")),
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{
@@ -149,10 +149,10 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 			controlPlane: &infrav1exp.GCPManagedControlPlane{
 				Spec: infrav1exp.GCPManagedControlPlaneSpec{
 					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:     "test-project",
+						Location:    "us-central1",
+						ClusterName: "test-cluster",
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{},
@@ -174,10 +174,10 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 			controlPlane: &infrav1exp.GCPManagedControlPlane{
 				Spec: infrav1exp.GCPManagedControlPlaneSpec{
 					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
-						Project:  "test-project",
-						Location: "us-central1",
+						Project:     "test-project",
+						Location:    "us-central1",
+						ClusterName: "test-cluster",
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{
@@ -206,8 +206,8 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 								{CidrBlock: "10.0.0.0/8", DisplayName: "internal"},
 							},
 						},
+						ClusterName: "test-cluster",
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{},
@@ -237,13 +237,13 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 			controlPlane: &infrav1exp.GCPManagedControlPlane{
 				Spec: infrav1exp.GCPManagedControlPlaneSpec{
 					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
-						Project:  "test-project",
-						Location: "us-central1",
+						ClusterName: "test-cluster",
+						Project:     "test-project",
+						Location:    "us-central1",
 						ClusterNetwork: &infrav1exp.ClusterNetwork{
 							GatewayAPIChannel: ptr.To(infrav1exp.GatewayAPIChannelStandard),
 						},
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{
@@ -269,13 +269,13 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 			controlPlane: &infrav1exp.GCPManagedControlPlane{
 				Spec: infrav1exp.GCPManagedControlPlaneSpec{
 					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
-						Project:  "test-project",
-						Location: "us-central1",
+						ClusterName: "test-cluster",
+						Project:     "test-project",
+						Location:    "us-central1",
 						ClusterNetwork: &infrav1exp.ClusterNetwork{
 							GatewayAPIChannel: ptr.To(infrav1exp.GatewayAPIChannelStandard),
 						},
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{
@@ -298,13 +298,13 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 			controlPlane: &infrav1exp.GCPManagedControlPlane{
 				Spec: infrav1exp.GCPManagedControlPlaneSpec{
 					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
-						Project:  "test-project",
-						Location: "us-central1",
+						ClusterName: "test-cluster",
+						Project:     "test-project",
+						Location:    "us-central1",
 						ClusterNetwork: &infrav1exp.ClusterNetwork{
 							GatewayAPIChannel: ptr.To(infrav1exp.GatewayAPIChannelDisabled),
 						},
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{},
@@ -328,8 +328,8 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 								{CidrBlock: "192.168.0.0/16"},
 							},
 						},
+						ClusterName: "test-cluster",
 					},
-					ClusterName: "test-cluster",
 				},
 			},
 			existingCluster: &containerpb.Cluster{

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanetemplates.yaml
@@ -61,6 +61,12 @@ spec:
                         - disabled
                         - project_singleton_policy_enforce
                         type: string
+                      clusterName:
+                        description: |-
+                          ClusterName allows you to specify the name of the GKE cluster.
+                          If you don't specify a name then a default name will be created
+                          based on the namespace and name of the managed control plane.
+                        type: string
                       clusterNetwork:
                         description: ClusterNetwork define the cluster network.
                         properties:

--- a/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
+++ b/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
@@ -141,12 +141,6 @@ type ClusterSecurity struct {
 type GCPManagedControlPlaneSpec struct {
 	GCPManagedControlPlaneClassSpec `json:",inline"`
 
-	// ClusterName allows you to specify the name of the GKE cluster.
-	// If you don't specify a name then a default name will be created
-	// based on the namespace and name of the managed control plane.
-	// +optional
-	ClusterName string `json:"clusterName,omitempty"`
-
 	// Description describe the cluster.
 	// +optional
 	Description string `json:"description,omitempty"`

--- a/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
+++ b/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
@@ -157,12 +157,6 @@ type ClusterSecurity struct {
 type GCPManagedControlPlaneSpec struct {
 	GCPManagedControlPlaneClassSpec `json:",inline"`
 
-	// ClusterName allows you to specify the name of the GKE cluster.
-	// If you don't specify a name then a default name will be created
-	// based on the namespace and name of the managed control plane.
-	// +optional
-	ClusterName string `json:"clusterName,omitempty"`
-
 	// Description describe the cluster.
 	// +optional
 	Description string `json:"description,omitempty"`

--- a/exp/api/v1beta1/types_class.go
+++ b/exp/api/v1beta1/types_class.go
@@ -29,6 +29,12 @@ type GCPManagedControlPlaneClassSpec struct {
 	// +optional
 	MachineTemplate *GCPManagedControlPlaneTemplateMachineTemplate `json:"machineTemplate,omitempty"`
 
+	// ClusterName allows you to specify the name of the GKE cluster.
+	// If you don't specify a name then a default name will be created
+	// based on the namespace and name of the managed control plane.
+	// +optional
+	ClusterName string `json:"clusterName,omitempty"`
+
 	// ClusterNetwork define the cluster network.
 	// +optional
 	ClusterNetwork *ClusterNetwork `json:"clusterNetwork,omitempty"`

--- a/exp/webhooks/gcpmanagedcontrolplane_webhook_test.go
+++ b/exp/webhooks/gcpmanagedcontrolplane_webhook_test.go
@@ -45,27 +45,45 @@ func TestGCPManagedControlPlaneDefaultingWebhook(t *testing.T) {
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
+				},
 			},
-			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{ClusterName: "default_cluster1"},
+			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
+				},
+			},
 		},
 		{
 			name:         "no cluster name should generate a valid one",
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "",
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "",
+				},
 			},
-			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{ClusterName: "default-cluster1"},
+			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default-cluster1",
+				},
+			},
 		},
 		{
 			name:         "invalid cluster name (too long)",
 			resourceName: strings.Repeat("A", maxClusterNameLength+1),
 			resourceNS:   "default",
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "",
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "",
+				},
 			},
-			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{ClusterName: "capg-"},
+			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "capg-",
+				},
+			},
 			expectHash: true,
 		},
 		{
@@ -73,27 +91,34 @@ func TestGCPManagedControlPlaneDefaultingWebhook(t *testing.T) {
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "cluster1_27_1",
-				Version:     &vV1_32_5,
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "cluster1_27_1",
+				},
+				Version: &vV1_32_5,
 			},
-			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{ClusterName: "cluster1_27_1", Version: &vV1_32_5},
+			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "cluster1_27_1",
+				},
+				Version: &vV1_32_5,
+			},
 		},
 		{
 			name:         "with autopilot enabled",
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "cluster1_autopilot",
-				Version:     &vV1_32_5,
+				Version: &vV1_32_5,
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
+					ClusterName:     "cluster1_autopilot",
 				},
 			},
 			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "cluster1_autopilot",
-				Version:     &vV1_32_5,
+				Version: &vV1_32_5,
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
+					ClusterName:     "cluster1_autopilot",
 				},
 			},
 		},
@@ -138,7 +163,9 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			expectError: true,
 			expectWarn:  false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: strings.Repeat("A", maxClusterNameLength+1),
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: strings.Repeat("A", maxClusterNameLength+1),
+				},
 			},
 		},
 		{
@@ -146,10 +173,10 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			expectError: true,
 			expectWarn:  false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
 					ReleaseChannel:  nil,
+					ClusterName:     "",
 				},
 			},
 		},
@@ -158,10 +185,10 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			expectError: false,
 			expectWarn:  false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
 					ReleaseChannel:  &releaseChannel,
+					ClusterName:     "",
 				},
 			},
 		},
@@ -170,8 +197,10 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			expectError: false,
 			expectWarn:  true,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName:         "",
 				ControlPlaneVersion: &vV1_32_5,
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "",
+				},
 			},
 		},
 		{
@@ -179,7 +208,9 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			expectError: true,
 			expectWarn:  false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName:         "",
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "",
+				},
 				ControlPlaneVersion: &vV1_32_5,
 				Version:             &vV1_32_5,
 			},
@@ -219,16 +250,18 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 			name:        "request to change cluster name should cause an error",
 			expectError: true,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster2",
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster2",
+				},
 			},
 		},
 		{
 			name:        "request to change project should cause an error",
 			expectError: true,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
-					Project: "new-project",
+					Project:     "new-project",
+					ClusterName: "default_cluster1",
 				},
 			},
 		},
@@ -236,9 +269,9 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 			name:        "request to change location should cause an error",
 			expectError: true,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
-					Location: "us-west4",
+					Location:    "us-west4",
+					ClusterName: "default_cluster1",
 				},
 			},
 		},
@@ -246,9 +279,9 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 			name:        "request to enable/disable autopilot should cause an error",
 			expectError: true,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
+					ClusterName:     "default_cluster1",
 				},
 			},
 		},
@@ -256,8 +289,8 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 			name:        "request to change network should not cause an error",
 			expectError: false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
 					ClusterNetwork: &expinfrav1.ClusterNetwork{
 						PrivateCluster: &expinfrav1.PrivateCluster{
 							EnablePrivateEndpoint: false,
@@ -277,8 +310,8 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 			}
 			oldMCP := &expinfrav1.GCPManagedControlPlane{
 				Spec: expinfrav1.GCPManagedControlPlaneSpec{
-					ClusterName: "default_cluster1",
 					GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+						ClusterName: "default_cluster1",
 						ClusterNetwork: &expinfrav1.ClusterNetwork{
 							PrivateCluster: &expinfrav1.PrivateCluster{
 								EnablePrivateEndpoint: true,

--- a/exp/webhooks/gcpmanagedcontrolplane_webhook_test.go
+++ b/exp/webhooks/gcpmanagedcontrolplane_webhook_test.go
@@ -46,27 +46,45 @@ func TestGCPManagedControlPlaneDefaultingWebhook(t *testing.T) {
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
+				},
 			},
-			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{ClusterName: "default_cluster1"},
+			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
+				},
+			},
 		},
 		{
 			name:         "no cluster name should generate a valid one",
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "",
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "",
+				},
 			},
-			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{ClusterName: "default-cluster1"},
+			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default-cluster1",
+				},
+			},
 		},
 		{
 			name:         "invalid cluster name (too long)",
 			resourceName: strings.Repeat("A", maxClusterNameLength+1),
 			resourceNS:   "default",
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "",
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "",
+				},
 			},
-			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{ClusterName: "capg-"},
+			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "capg-",
+				},
+			},
 			expectHash: true,
 		},
 		{
@@ -74,27 +92,34 @@ func TestGCPManagedControlPlaneDefaultingWebhook(t *testing.T) {
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "cluster1_27_1",
-				Version:     &vV1_32_5,
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "cluster1_27_1",
+				},
+				Version: &vV1_32_5,
 			},
-			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{ClusterName: "cluster1_27_1", Version: &vV1_32_5},
+			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "cluster1_27_1",
+				},
+				Version: &vV1_32_5,
+			},
 		},
 		{
 			name:         "with autopilot enabled",
 			resourceName: "cluster1",
 			resourceNS:   "default",
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "cluster1_autopilot",
-				Version:     &vV1_32_5,
+				Version: &vV1_32_5,
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
+					ClusterName:     "cluster1_autopilot",
 				},
 			},
 			expectSpec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "cluster1_autopilot",
-				Version:     &vV1_32_5,
+				Version: &vV1_32_5,
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
+					ClusterName:     "cluster1_autopilot",
 				},
 			},
 		},
@@ -139,7 +164,9 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			expectError: true,
 			expectWarn:  false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: strings.Repeat("A", maxClusterNameLength+1),
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: strings.Repeat("A", maxClusterNameLength+1),
+				},
 			},
 		},
 		{
@@ -147,10 +174,10 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			expectError: true,
 			expectWarn:  false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
 					ReleaseChannel:  nil,
+					ClusterName:     "",
 				},
 			},
 		},
@@ -159,10 +186,10 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			expectError: false,
 			expectWarn:  false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
 					ReleaseChannel:  &releaseChannel,
+					ClusterName:     "",
 				},
 			},
 		},
@@ -171,8 +198,8 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			expectError: true,
 			expectWarn:  false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName:     "",
 					EnableAutopilot: true,
 					ReleaseChannel:  &releaseChannel,
 					ClusterNetwork: &expinfrav1.ClusterNetwork{
@@ -186,8 +213,8 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			expectError: false,
 			expectWarn:  false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "",
 					ClusterNetwork: &expinfrav1.ClusterNetwork{
 						GatewayAPIChannel: &gatewayAPIChannelStandard,
 					},
@@ -199,8 +226,10 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			expectError: false,
 			expectWarn:  true,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName:         "",
 				ControlPlaneVersion: &vV1_32_5,
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "",
+				},
 			},
 		},
 		{
@@ -208,7 +237,9 @@ func TestGCPManagedControlPlaneValidatingWebhookCreate(t *testing.T) {
 			expectError: true,
 			expectWarn:  false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName:         "",
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "",
+				},
 				ControlPlaneVersion: &vV1_32_5,
 				Version:             &vV1_32_5,
 			},
@@ -249,16 +280,18 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 			name:        "request to change cluster name should cause an error",
 			expectError: true,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster2",
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster2",
+				},
 			},
 		},
 		{
 			name:        "request to change project should cause an error",
 			expectError: true,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
-					Project: "new-project",
+					Project:     "new-project",
+					ClusterName: "default_cluster1",
 				},
 			},
 		},
@@ -266,9 +299,9 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 			name:        "request to change location should cause an error",
 			expectError: true,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
-					Location: "us-west4",
+					Location:    "us-west4",
+					ClusterName: "default_cluster1",
 				},
 			},
 		},
@@ -276,9 +309,9 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 			name:        "request to enable/disable autopilot should cause an error",
 			expectError: true,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
 					EnableAutopilot: true,
+					ClusterName:     "default_cluster1",
 				},
 			},
 		},
@@ -286,8 +319,8 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 			name:        "request to change network should not cause an error",
 			expectError: false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
 					ClusterNetwork: &expinfrav1.ClusterNetwork{
 						PrivateCluster: &expinfrav1.PrivateCluster{
 							EnablePrivateEndpoint: false,
@@ -300,8 +333,8 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 			name:        "request to change gateway api channel should not cause an error",
 			expectError: false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
 					ClusterNetwork: &expinfrav1.ClusterNetwork{
 						PrivateCluster: &expinfrav1.PrivateCluster{
 							EnablePrivateEndpoint: true,
@@ -315,8 +348,8 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 			name:        "request to set gateway api channel on an autopilot cluster should cause an error",
 			expectError: true,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName:     "default_cluster1",
 					EnableAutopilot: true,
 					ClusterNetwork: &expinfrav1.ClusterNetwork{
 						GatewayAPIChannel: &gatewayAPIChannelStandard,
@@ -324,8 +357,8 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 				},
 			},
 			oldSpec: &expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName:     "default_cluster1",
 					EnableAutopilot: true,
 				},
 			},
@@ -340,8 +373,8 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 				Spec: tc.spec,
 			}
 			oldSpec := expinfrav1.GCPManagedControlPlaneSpec{
-				ClusterName: "default_cluster1",
 				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
 					ClusterNetwork: &expinfrav1.ClusterNetwork{
 						PrivateCluster: &expinfrav1.PrivateCluster{
 							EnablePrivateEndpoint: true,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind bug

**What this PR does / why we need it**:

This PR exposes the `clusterName` field on GCPManagedControlPlaneTemplate so that it can be configured using ClusterClasses.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: expose `clusterName` field on GCPManagedControlPlaneTemplate so that it can be configured using ClusterClasses
```
