### PR TITLE
Support Workload Identity Federation for CAPG controller authentication

### DIFF
--- a/cloud/scope/credentials.go
+++ b/cloud/scope/credentials.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -44,6 +45,7 @@ type Credential struct {
 }
 
 func getCredentials(ctx context.Context, credentialsRef *infrav1.ObjectReference, crClient client.Client) (*Credential, error) {
+	logger := log.FromContext(ctx)
 	var credentialData []byte
 	var err error
 
@@ -55,8 +57,19 @@ func getCredentials(ctx context.Context, credentialsRef *infrav1.ObjectReference
 	if err != nil {
 		return nil, fmt.Errorf("getting credential data: %w", err)
 	}
+	if credentialData == nil {
+		// No explicit credentials configured; the GCP client libraries will use
+		// implicit ADC (e.g. Workload Identity Federation via the GKE metadata server).
+		logger.Info("No explicit credentials found; using implicit ADC (e.g. Workload Identity Federation)")
+		return nil, nil
+	}
 
-	return parseCredential(credentialData)
+	cred, err := parseCredential(credentialData)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("Loaded explicit GCP credentials", "credentialType", cred.Type)
+	return cred, nil
 }
 
 func getCredentialDataFromRef(ctx context.Context, credentialsRef *infrav1.ObjectReference, crClient client.Client) ([]byte, error) {
@@ -81,7 +94,9 @@ func getCredentialDataFromRef(ctx context.Context, credentialsRef *infrav1.Objec
 func getCredentialDataUsingADC() ([]byte, error) {
 	credsPath := os.Getenv(ConfigFileEnvVar)
 	if credsPath == "" {
-		return nil, fmt.Errorf("no ADC environment variable found for credentials (expect %s)", ConfigFileEnvVar)
+		// No explicit credentials file configured; signal to callers to use
+		// implicit ADC (Workload Identity Federation, instance metadata, etc.).
+		return nil, nil
 	}
 
 	byteValue, err := os.ReadFile(credsPath) //nolint:gosec // We need to read a file here

--- a/cloud/scope/credentials_test.go
+++ b/cloud/scope/credentials_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCredentialDataUsingADC_EnvVarNotSet(t *testing.T) {
+	t.Setenv(ConfigFileEnvVar, "")
+	data, err := getCredentialDataUsingADC()
+	assert.Nil(t, err)
+	assert.Nil(t, data)
+}
+
+func TestGetCredentialDataUsingADC_ValidFile(t *testing.T) {
+	content := []byte(`{"type":"service_account","project_id":"test-project"}`)
+	f, err := os.CreateTemp(t.TempDir(), "creds-*.json")
+	require.NoError(t, err)
+	_, err = f.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	t.Setenv(ConfigFileEnvVar, f.Name())
+	data, err := getCredentialDataUsingADC()
+	assert.NoError(t, err)
+	assert.Equal(t, content, data)
+}
+
+func TestGetCredentialDataUsingADC_MissingFile(t *testing.T) {
+	t.Setenv(ConfigFileEnvVar, "/nonexistent/path/credentials.json")
+	data, err := getCredentialDataUsingADC()
+	assert.Error(t, err)
+	assert.Nil(t, data)
+}
+
+func TestGetCredentials_WIFMode(t *testing.T) {
+	t.Setenv(ConfigFileEnvVar, "")
+	// nil credentialsRef + no env var → WIF/implicit ADC mode: both nil
+	cred, err := getCredentials(t.Context(), nil, nil)
+	assert.Nil(t, err)
+	assert.Nil(t, cred)
+}

--- a/cloud/services/container/clusters/kubeconfig.go
+++ b/cloud/services/container/clusters/kubeconfig.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/container/apiv1/containerpb"
 	"cloud.google.com/go/iam/credentials/apiv1/credentialspb"
 	"github.com/go-logr/logr"
@@ -237,12 +238,36 @@ func (s *Service) createBaseKubeConfig(contextName string, cluster *containerpb.
 	return cfg, nil
 }
 
+// tokenEmailResolver resolves the service account email used for token generation.
+type tokenEmailResolver interface {
+	Email(ctx context.Context) (string, error)
+}
+
+// credentialEmailResolver uses an explicit service account email from loaded credentials.
+type credentialEmailResolver struct {
+	email string
+}
+
+func (r credentialEmailResolver) Email(_ context.Context) (string, error) {
+	return r.email, nil
+}
+
+// metadataEmailResolver discovers the bound service account email from the GKE
+// metadata server, used when running under Workload Identity Federation.
+type metadataEmailResolver struct{}
+
+func (r metadataEmailResolver) Email(ctx context.Context) (string, error) {
+	return metadata.EmailWithContext(ctx, "default")
+}
+
 func (s *Service) generateToken(ctx context.Context) (string, error) {
+	email, err := s.emailResolver.Email(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolving service account email: %w", err)
+	}
 	req := &credentialspb.GenerateAccessTokenRequest{
-		Name: "projects/-/serviceAccounts/" + s.scope.GetCredential().ClientEmail,
-		Scope: []string{
-			GkeScope,
-		},
+		Name:  "projects/-/serviceAccounts/" + email,
+		Scope: []string{GkeScope},
 	}
 	resp, err := s.scope.CredentialsClient().GenerateAccessToken(ctx, req)
 	if err != nil {

--- a/cloud/services/container/clusters/kubeconfig_test.go
+++ b/cloud/services/container/clusters/kubeconfig_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialEmailResolver(t *testing.T) {
+	r := credentialEmailResolver{email: "sa@my-project.iam.gserviceaccount.com"}
+	email, err := r.Email(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "sa@my-project.iam.gserviceaccount.com", email)
+}
+
+func TestMetadataEmailResolver_WIFMode(t *testing.T) {
+	const wifEmail = "wif-sa@my-project.iam.gserviceaccount.com"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/service-accounts/default/email") {
+			_, _ = w.Write([]byte(wifEmail))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	t.Setenv("GCE_METADATA_HOST", strings.TrimPrefix(srv.URL, "http://"))
+
+	email, err := metadataEmailResolver{}.Email(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, wifEmail, email)
+}
+
+func TestMetadataEmailResolver_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+	t.Setenv("GCE_METADATA_HOST", strings.TrimPrefix(srv.URL, "http://"))
+
+	_, err := metadataEmailResolver{}.Email(context.Background())
+	require.Error(t, err)
+}

--- a/cloud/services/container/clusters/service.go
+++ b/cloud/services/container/clusters/service.go
@@ -23,14 +23,22 @@ import (
 
 // Service implements clusters reconciler.
 type Service struct {
-	scope *scope.ManagedControlPlaneScope
+	scope         *scope.ManagedControlPlaneScope
+	emailResolver tokenEmailResolver
 }
 
 var _ cloud.ReconcilerWithResult = &Service{}
 
 // New returns Service from given scope.
-func New(scope *scope.ManagedControlPlaneScope) *Service {
+func New(s *scope.ManagedControlPlaneScope) *Service {
+	var resolver tokenEmailResolver
+	if cred := s.GetCredential(); cred != nil {
+		resolver = credentialEmailResolver{email: cred.ClientEmail}
+	} else {
+		resolver = metadataEmailResolver{}
+	}
 	return &Service{
-		scope: scope,
+		scope:         s,
+		emailResolver: resolver,
 	}
 }

--- a/config/wif/kustomization.yaml
+++ b/config/wif/kustomization.yaml
@@ -1,0 +1,9 @@
+# This overlay layers Workload Identity Federation support on top of
+# config/default: it removes the credentials Secret and its Deployment
+# volume/mount, and annotates the manager ServiceAccount for GCP WIF.
+bases:
+  - ../default
+
+patchesStrategicMerge:
+  - remove_credentials_patch.yaml
+  - serviceaccount_wif_patch.yaml

--- a/config/wif/remove_credentials_patch.yaml
+++ b/config/wif/remove_credentials_patch.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capg-manager-bootstrap-credentials
+  namespace: capg-system
+$patch: delete
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capg-controller-manager
+  namespace: capg-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          $patch: delete
+        volumeMounts:
+        - mountPath: /home/.gcp
+          $patch: delete
+      volumes:
+      - name: credentials
+        $patch: delete

--- a/config/wif/serviceaccount_wif_patch.yaml
+++ b/config/wif/serviceaccount_wif_patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capg-manager
+  namespace: capg-system
+  annotations:
+    iam.gke.io/gcp-service-account: ${GCP_SA_EMAIL}

--- a/docs/book/src/managed/enabling.md
+++ b/docs/book/src/managed/enabling.md
@@ -7,4 +7,4 @@ export EXP_CAPG_GKE=true
 clusterctl init --infrastructure gcp
 ```
 
-> IMPORTANT: To use GKE the service account used for CAPG will need the `iam.serviceAccountTokenCreator` role assigned.
+> IMPORTANT: To use GKE the service account used for CAPG will need the `iam.serviceAccountTokenCreator` role assigned. When using [Workload Identity Federation](../quick-start.md#workload-identity-federation-gke-management-clusters), assign this role to the GCP service account that is bound via WIF.

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -20,15 +20,44 @@ Before installing CAPG, your Kubernetes cluster has to be transformed into a CAP
 - `make` to use `Makefile` targets
 - Install `coreutils` (for timeout) on *OSX*
 
-### Create a Service Account
+### Credentials
 
-To create and manage clusters, this infrastructure provider uses a service account to authenticate with GCP's APIs.
+To create and manage clusters, CAPG uses a GCP service account to authenticate with GCP's APIs. There are two supported authentication methods.
 
-From your cloud console, follow [these instructions](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating) to create a new service account with `Editor` permissions.
+First, [create a service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating) with `Editor` permissions. If you plan to use GKE the service account will also need the `iam.serviceAccountTokenCreator` role.
 
-If you plan to use GKE the service account will also need the `iam.serviceAccountTokenCreator` role.
+#### Service Account JSON Key
 
-Afterwards, generate a JSON Key and store it somewhere safe.
+Generate a JSON Key for the service account and store it somewhere safe. This key will be base64-encoded and provided to CAPG at installation time (see [Installing CAPG](#installing-capg)).
+
+#### Workload Identity Federation (GKE management clusters)
+
+If your CAPI management cluster runs on GKE, [Workload Identity Federation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) is the preferred authentication method. It eliminates the need to manage JSON key files by binding the CAPG Kubernetes ServiceAccount to a GCP service account.
+
+Enable Workload Identity on your GKE management cluster (if not already enabled):
+```
+gcloud container clusters update <MANAGEMENT_CLUSTER> \
+  --workload-pool=<PROJECT_ID>.svc.id.goog \
+  --region <REGION>
+```
+
+Grant the Workload Identity User role so the CAPG Kubernetes ServiceAccount can impersonate the GCP service account:
+```
+export GCP_SA_EMAIL=<gcp-service-account>@<PROJECT_ID>.iam.gserviceaccount.com
+
+gcloud iam service-accounts add-iam-policy-binding "${GCP_SA_EMAIL}" \
+  --role roles/iam.workloadIdentityUser \
+  --member "serviceAccount:<PROJECT_ID>.svc.id.goog[capg-system/capg-manager]"
+```
+
+Then deploy CAPG using the `config/wif` overlay, substituting your GCP service account email:
+```
+export GCP_SA_EMAIL=<gcp-service-account>@<PROJECT_ID>.iam.gserviceaccount.com
+
+kustomize build config/wif/ | envsubst | kubectl apply -f -
+```
+
+CAPG will authenticate via the GKE metadata server automatically — no credentials secret is needed.
 
 
 ### Installing CAPG

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
-	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0
 	cloud.google.com/go/longrunning v1.2.0 // indirect
 	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Enables the CAPG controller to authenticate with GCP using [Workload Identity Federation (WIF)](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) when running on GKE, eliminating the need to mount JSON service account key files.

**Code changes:**

- `cloud/scope/credentials.go`: `getCredentialDataUsingADC()` now returns `nil, nil` (instead of an error) when `GOOGLE_APPLICATION_CREDENTIALS` is not set, signalling to callers that implicit ADC (including WIF via the GKE metadata server) should be used. `getCredentials()` short-circuits on nil credential data and returns `nil, nil` accordingly.
- `cloud/services/container/clusters/kubeconfig.go`: `generateToken()` falls back to `metadata.EmailWithContext()` to discover the bound GCP service account email from the GKE metadata server when no explicit credential is present, allowing kubeconfig generation to work under WIF.

**Config changes:**

- `config/wif/`: new self-contained kustomize overlay that omits the credentials Secret and volume mount, and annotates the manager `ServiceAccount` with `iam.gke.io/gcp-service-account: ${GCP_SA_EMAIL}`. Operators substitute `GCP_SA_EMAIL` via `envsubst` before applying.

**Documentation:**

- `docs/book/src/quick-start.md`: restructures the credentials section to cover both the existing JSON key approach and the new WIF approach, including the GCP IAM setup steps.
- `docs/book/src/managed/enabling.md`: clarifies that the `iam.serviceAccountTokenCreator` role requirement applies to the WIF-bound GCP service account.

**Which issue(s) this PR fixes**:
Fixes #311

**Special notes for your reviewer**:

- The existing JSON key / `GOOGLE_APPLICATION_CREDENTIALS` path is **fully preserved** — this change only affects behaviour when neither `credentialsRef` nor the env var is set.
- `cloud.google.com/go/compute/metadata` was already an indirect dependency; it is promoted to direct.
- `metadata.EmailWithContext` is only called in `generateToken` (GKE managed cluster kubeconfig path), not in the general credential loading path.

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
Add support for Workload Identity Federation (WIF) as an authentication method for the CAPG controller on GKE management clusters. A new `config/wif` kustomize overlay is provided; no JSON service account key is required when WIF is configured.
```