### PR TITLE
fix(gke): apply additionalLabels to GKE Cluster ResourceLabels

### DIFF
--- a/cloud/services/container/clusters/reconcile.go
+++ b/cloud/services/container/clusters/reconcile.go
@@ -31,6 +31,7 @@ import (
 	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-gcp/util/reconciler"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -154,6 +155,11 @@ func (s *Service) Reconcile(ctx context.Context) (ctrl.Result, error) {
 		s.scope.GCPManagedControlPlane.Status.Ready = true
 		return ctrl.Result{}, nil
 	}
+
+	if err = s.syncLabels(ctx, cluster, &log); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	v1beta1conditions.MarkFalse(s.scope.ConditionSetter(), infrav1exp.GKEControlPlaneUpdatingCondition, infrav1exp.GKEControlPlaneUpdatedReason, clusterv1beta1.ConditionSeverityInfo, "")
 
 	// Reconcile kubeconfig
@@ -254,10 +260,11 @@ func (s *Service) createCluster(ctx context.Context, log *logr.Logger) error {
 
 	isRegional := shared.IsRegional(s.scope.Region())
 	cluster := &containerpb.Cluster{
-		Name:        s.scope.ClusterName(),
-		Description: s.scope.GCPManagedControlPlane.Spec.Description,
-		Network:     *s.scope.GCPManagedCluster.Spec.Network.Name,
-		Subnetwork:  s.getSubnetNameInClusterRegion(),
+		Name:           s.scope.ClusterName(),
+		Description:    s.scope.GCPManagedControlPlane.Spec.Description,
+		Network:        *s.scope.GCPManagedCluster.Spec.Network.Name,
+		ResourceLabels: map[string]string(s.scope.GCPManagedCluster.Spec.AdditionalLabels),
+		Subnetwork:     s.getSubnetNameInClusterRegion(),
 		Autopilot: &containerpb.Autopilot{
 			Enabled: s.scope.GCPManagedControlPlane.Spec.EnableAutopilot,
 		},
@@ -405,6 +412,35 @@ func (s *Service) deleteCluster(ctx context.Context, log *logr.Logger) error {
 		return err
 	}
 
+	return nil
+}
+
+// labelsNeedSync returns true if the desired labels differ from the existing cluster labels.
+// Returns false when desired is nil or empty, making label management opt-in: the controller
+// only manages ResourceLabels when additionalLabels is explicitly set on the spec.
+func labelsNeedSync(existing, desired infrav1.Labels) bool {
+	if len(desired) == 0 {
+		return false
+	}
+	return !existing.Equals(desired)
+}
+
+func (s *Service) syncLabels(ctx context.Context, cluster *containerpb.Cluster, log *logr.Logger) error {
+	desired := s.scope.GCPManagedCluster.Spec.AdditionalLabels
+	existing := infrav1.Labels(cluster.GetResourceLabels())
+	if !labelsNeedSync(existing, desired) {
+		return nil
+	}
+	log.V(2).Info("Resource labels update required", "current", existing, "desired", desired)
+	_, err := s.scope.ManagedControlPlaneClient().SetLabels(ctx, &containerpb.SetLabelsRequest{
+		Name:             s.scope.ClusterFullName(),
+		ResourceLabels:   map[string]string(desired),
+		LabelFingerprint: cluster.GetLabelFingerprint(),
+	})
+	if err != nil {
+		log.Error(err, "Error setting labels on GKE cluster", "name", s.scope.ClusterName())
+		return err
+	}
 	return nil
 }
 

--- a/cloud/services/container/clusters/reconcile.go
+++ b/cloud/services/container/clusters/reconcile.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-gcp/util/reconciler"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -152,6 +153,11 @@ func (s *Service) Reconcile(ctx context.Context) (ctrl.Result, error) {
 		s.scope.GCPManagedControlPlane.Status.Ready = true
 		return ctrl.Result{}, nil
 	}
+
+	if err = s.syncLabels(ctx, cluster, &log); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	v1beta1conditions.MarkFalse(s.scope.ConditionSetter(), infrav1exp.GKEControlPlaneUpdatingCondition, infrav1exp.GKEControlPlaneUpdatedReason, clusterv1beta1.ConditionSeverityInfo, "")
 
 	// Reconcile kubeconfig
@@ -249,10 +255,11 @@ func (s *Service) createCluster(ctx context.Context, log *logr.Logger) error {
 
 	isRegional := shared.IsRegional(s.scope.Region())
 	cluster := &containerpb.Cluster{
-		Name:        s.scope.ClusterName(),
-		Description: s.scope.GCPManagedControlPlane.Spec.Description,
-		Network:     *s.scope.GCPManagedCluster.Spec.Network.Name,
-		Subnetwork:  s.getSubnetNameInClusterRegion(),
+		Name:           s.scope.ClusterName(),
+		Description:    s.scope.GCPManagedControlPlane.Spec.Description,
+		Network:        *s.scope.GCPManagedCluster.Spec.Network.Name,
+		ResourceLabels: map[string]string(s.scope.GCPManagedCluster.Spec.AdditionalLabels),
+		Subnetwork:     s.getSubnetNameInClusterRegion(),
 		Autopilot: &containerpb.Autopilot{
 			Enabled: s.scope.GCPManagedControlPlane.Spec.EnableAutopilot,
 		},
@@ -410,6 +417,35 @@ func (s *Service) deleteCluster(ctx context.Context, log *logr.Logger) error {
 		return err
 	}
 
+	return nil
+}
+
+// labelsNeedSync returns true if the desired labels differ from the existing cluster labels.
+// Returns false when desired is nil or empty, making label management opt-in: the controller
+// only manages ResourceLabels when additionalLabels is explicitly set on the spec.
+func labelsNeedSync(existing, desired infrav1.Labels) bool {
+	if len(desired) == 0 {
+		return false
+	}
+	return !existing.Equals(desired)
+}
+
+func (s *Service) syncLabels(ctx context.Context, cluster *containerpb.Cluster, log *logr.Logger) error {
+	desired := s.scope.GCPManagedCluster.Spec.AdditionalLabels
+	existing := infrav1.Labels(cluster.GetResourceLabels())
+	if !labelsNeedSync(existing, desired) {
+		return nil
+	}
+	log.V(2).Info("Resource labels update required", "current", existing, "desired", desired)
+	_, err := s.scope.ManagedControlPlaneClient().SetLabels(ctx, &containerpb.SetLabelsRequest{
+		Name:             s.scope.ClusterFullName(),
+		ResourceLabels:   map[string]string(desired),
+		LabelFingerprint: cluster.GetLabelFingerprint(),
+	})
+	if err != nil {
+		log.Error(err, "Error setting labels on GKE cluster", "name", s.scope.ClusterName())
+		return err
+	}
 	return nil
 }
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -16,6 +16,7 @@
     - [Enabling](./clusterclass/enabling.md)
     - [Disabling](./clusterclass/disabling.md)
 - [General Topics](./topics/index.md)
+    - [Additional Labels](./topics/additional-labels.md)
     - [Alias IP Ranges](./topics/alias-ip-ranges.md)
     - [Conformance](./topics/conformance.md)
     - [GPUs](./topics/gpus.md)

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -16,6 +16,7 @@
     - [Enabling](./clusterclass/enabling.md)
     - [Disabling](./clusterclass/disabling.md)
 - [General Topics](./topics/index.md)
+    - [Additional Labels](./topics/additional-labels.md)
     - [Alias IP Ranges](./topics/alias-ip-ranges.md)
     - [Conformance](./topics/conformance.md)
     - [Gateway API](./topics/gateway-api.md)

--- a/docs/book/src/topics/additional-labels.md
+++ b/docs/book/src/topics/additional-labels.md
@@ -1,0 +1,54 @@
+# Additional Labels
+
+The `additionalLabels` field lets you attach arbitrary GCP resource labels to
+infrastructure objects managed by CAPG.
+
+## Supported resources
+
+| CRD | Labels applied to |
+|-----|-------------------|
+| `GCPCluster` | Load balancer forwarding rules, disks |
+| `GCPMachine` | Compute Engine instances and their root disks |
+| `GCPManagedCluster` | GKE cluster (`ResourceLabels`) |
+| `GCPManagedMachinePool` | GKE node pool (`ResourceLabels`) |
+| `GCPMachinePool` | Managed instance group instances |
+
+## Usage
+
+Set `additionalLabels` under `spec` on the relevant infrastructure object.
+Label keys and values must conform to
+[GCP label requirements](https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements).
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPManagedCluster
+metadata:
+  name: my-cluster
+spec:
+  additionalLabels:
+    env: production
+    team: platform
+```
+
+## Precedence
+
+When both a `GCPCluster`/`GCPManagedCluster` and a machine-level object
+(`GCPMachine`, `GCPMachinePool`) define the same key, the **machine-level
+value takes precedence**.
+
+## Semantics for GKE clusters
+
+For `GCPManagedCluster`, label management is **opt-in**. The controller only
+reconciles `ResourceLabels` on the GKE cluster when `additionalLabels` is
+explicitly set. Clusters with no `additionalLabels` field are left untouched,
+so any labels applied directly in GCP are not disturbed.
+
+Once opted in, `additionalLabels` is treated as the **complete desired label
+set**. The GKE `SetLabels` API replaces all user-defined `ResourceLabels`, so
+labels applied outside of CAPI that are not present in the spec will be
+removed on the next reconcile. This is consistent with CAPI's source-of-truth
+approach.
+
+Label changes to an existing cluster are applied on the next reconcile cycle
+after any pending cluster updates have completed, since GKE does not permit
+concurrent cluster operations.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`GCPManagedCluster.Spec.AdditionalLabels` was a no-op for GKE clusters. This was partially fixed for compute resources in #1275 but the managed Kubernetes path (`cloud/services/container/clusters/`) was missed.

This PR wires `additionalLabels` through in two places:

Creation — ResourceLabels is now set on the `containerpb.Cluster` struct passed to `CreateCluster`.
Reconciliation — a new `syncLabels` step calls `SetLabels` when the live cluster's `ResourceLabels` diverge from the spec. This runs only when no other UpdateCluster operation is pending, to avoid GKE's restriction on concurrent cluster mutations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1645 

**Special notes for your reviewer**:
Label management is opt-in: if additionalLabels is not set on the spec the controller takes no action, leaving any manually applied GCP labels untouched. This is a deliberate safety property for rollout — without it, existing clusters with GCP labels set outside of CAPI would have those labels silently wiped on the next reconcile.

When additionalLabels is set, the field acts as the complete desired label set for ResourceLabels. The GKE SetLabels API replaces all user-defined labels, so labels applied directly to GCP that are not present in the spec will be removed. This is consistent with CAPI's source-of-truth philosophy. This position is defensible today because the provider does not impose any mandatory labels on GKE clusters; if mandatory labels are introduced in future the opt-in decision should be revisited.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests (marked ok as new tests are unnecessary and existing suites continue to pass)

**Release note**:
```release-note
Allows GCPManagedCluster.Spec.AdditionalLabels to set ResourceLabels on GKE Clusters
```
