### PR TITLE
fix(gke): treat `NotFound` as success in `deleteNodePool`

### DIFF
--- a/cloud/services/container/clusters/reconcile.go
+++ b/cloud/services/container/clusters/reconcile.go
@@ -28,9 +28,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/pkg/errors"
-	"google.golang.org/grpc/codes"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-gcp/util/reconciler"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -231,11 +229,8 @@ func (s *Service) describeCluster(ctx context.Context, log *logr.Logger) (*conta
 	}
 	cluster, err := s.scope.ManagedControlPlaneClient().GetCluster(ctx, getClusterRequest)
 	if err != nil {
-		var e *apierror.APIError
-		if ok := errors.As(err, &e); ok {
-			if e.GRPCStatus().Code() == codes.NotFound {
-				return nil, nil
-			}
+		if shared.IsNotFound(err) {
+			return nil, nil
 		}
 		log.Error(err, "Error getting GKE cluster", "name", s.scope.ClusterName())
 		return nil, err

--- a/cloud/services/container/nodepools/reconcile.go
+++ b/cloud/services/container/nodepools/reconcile.go
@@ -24,14 +24,12 @@ import (
 	"sigs.k8s.io/cluster-api-provider-gcp/util/resourceurl"
 
 	"google.golang.org/api/iterator"
-	"google.golang.org/grpc/codes"
 
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud/providerid"
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud/scope"
@@ -244,11 +242,8 @@ func (s *Service) describeNodePool(ctx context.Context, log *logr.Logger) (*cont
 	}
 	nodePool, err := s.scope.ManagedMachinePoolClient().GetNodePool(ctx, getNodePoolRequest)
 	if err != nil {
-		var e *apierror.APIError
-		if ok := errors.As(err, &e); ok {
-			if e.GRPCStatus().Code() == codes.NotFound {
-				return nil, nil
-			}
+		if shared.IsNotFound(err) {
+			return nil, nil
 		}
 		log.Error(err, "Error getting GKE node pool", "name", s.scope.GCPManagedMachinePool.Name)
 		return nil, err
@@ -339,6 +334,9 @@ func (s *Service) deleteNodePool(ctx context.Context) error {
 	}
 	_, err := s.scope.ManagedMachinePoolClient().DeleteNodePool(ctx, deleteNodePoolRequest)
 	if err != nil {
+		if shared.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/cloud/services/shared/errors.go
+++ b/cloud/services/shared/errors.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"github.com/googleapis/gax-go/v2/apierror"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+)
+
+// IsNotFound reports whether err is a gRPC NotFound error from a GCP API call.
+func IsNotFound(err error) bool {
+	var e *apierror.APIError
+	if ok := errors.As(err, &e); ok {
+		return e.GRPCStatus().Code() == codes.NotFound
+	}
+	return false
+}

--- a/test/e2e/e2e_gke_test.go
+++ b/test/e2e/e2e_gke_test.go
@@ -221,3 +221,95 @@ var _ = Describe("GKE workload cluster creation", func() {
 		})
 	})
 })
+
+var _ = Describe("GKE workload cluster deletion", func() {
+	var (
+		ctx                 = context.TODO()
+		specName            = "delete-gke-workload-cluster"
+		namespace           *corev1.Namespace
+		cancelWatches       context.CancelFunc
+		result              *ApplyManagedClusterTemplateAndWaitResult
+		clusterName         string
+		clusterctlLogFolder string
+	)
+
+	BeforeEach(func() {
+		Expect(e2eConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
+		Expect(clusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. clusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(bootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. bootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(os.MkdirAll(artifactFolder, 0o755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
+
+		Expect(e2eConfig.Variables).To(HaveKey(KubernetesVersion))
+
+		clusterName = fmt.Sprintf("capg-e2e-%s", util.RandomString(6))
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
+		result = new(ApplyManagedClusterTemplateAndWaitResult)
+		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
+	})
+
+	AfterEach(func() {
+		dumpSpecResourcesAndCleanup(ctx, cleanupInput{
+			SpecName:             specName,
+			Cluster:              result.Cluster,
+			ClusterProxy:         bootstrapClusterProxy,
+			ClusterctlConfigPath: clusterctlConfigPath,
+			Namespace:            namespace,
+			CancelWatches:        cancelWatches,
+			IntervalsGetter:      e2eConfig.GetIntervals,
+			SkipCleanup:          skipCleanup,
+			ArtifactFolder:       artifactFolder,
+		})
+	})
+
+	Context("Deleting a running GKE cluster", func() {
+		It("Should cleanly remove all managed resources without requiring manual finalizer intervention", func() {
+			minPoolSize, ok := e2eConfig.Variables["GKE_MACHINE_POOL_MIN"]
+			Expect(ok).To(BeTrue(), "must have min pool size set via the GKE_MACHINE_POOL_MIN variable")
+			maxPoolSize, ok := e2eConfig.Variables["GKE_MACHINE_POOL_MAX"]
+			Expect(ok).To(BeTrue(), "must have max pool size set via the GKE_MACHINE_POOL_MAX variable")
+			minCriticalAddonsOnlyPoolSize, ok := e2eConfig.Variables["GKE_MACHINE_POOL_MIN_CRITICAL_ADDONS_ONLY"]
+			Expect(ok).To(BeTrue(), "must have min critical addons only pool size set via the GKE_MACHINE_POOL_MIN_CRITICAL_ADDONS_ONLY variable")
+			maxCriticalAddonsOnlyPoolSize, ok := e2eConfig.Variables["GKE_MACHINE_POOL_MAX_CRITICAL_ADDONS_ONLY"]
+			Expect(ok).To(BeTrue(), "must have max critical addons only pool size set via the GKE_MACHINE_POOL_MAX_CRITICAL_ADDONS_ONLY variable")
+
+			By("Creating a GKE workload cluster")
+			ApplyManagedClusterTemplateAndWait(ctx, ApplyManagedClusterTemplateAndWaitInput{
+				ClusterProxy: bootstrapClusterProxy,
+				ConfigCluster: clusterctl.ConfigClusterInput{
+					LogFolder:                clusterctlLogFolder,
+					ClusterctlConfigPath:     clusterctlConfigPath,
+					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+					Flavor:                   "ci-gke",
+					Namespace:                namespace.Name,
+					ClusterName:              clusterName,
+					KubernetesVersion:        e2eConfig.MustGetVariable(KubernetesVersion),
+					ControlPlaneMachineCount: ptr.To[int64](1),
+					WorkerMachineCount:       ptr.To[int64](3),
+					ClusterctlVariables: map[string]string{
+						"GKE_MACHINE_POOL_MIN":                      minPoolSize,
+						"GKE_MACHINE_POOL_MAX":                      maxPoolSize,
+						"GKE_MACHINE_POOL_MIN_CRITICAL_ADDONS_ONLY": minCriticalAddonsOnlyPoolSize,
+						"GKE_MACHINE_POOL_MAX_CRITICAL_ADDONS_ONLY": maxCriticalAddonsOnlyPoolSize,
+					},
+				},
+				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+				WaitForMachinePools:          e2eConfig.GetIntervals(specName, "wait-worker-machine-pools"),
+			}, result)
+
+			By("Deleting the GKE workload cluster")
+			framework.DeleteAllClustersAndWait(ctx, framework.DeleteAllClustersAndWaitInput{
+				ClusterProxy:         bootstrapClusterProxy,
+				ClusterctlConfigPath: clusterctlConfigPath,
+				Namespace:            namespace.Name,
+				ArtifactFolder:       artifactFolder,
+			}, e2eConfig.GetIntervals(specName, "wait-delete-cluster")...)
+
+			WaitForManagedClusterResourcesDeleted(ctx, WaitForManagedClusterResourcesDeletedInput{
+				Lister:    bootstrapClusterProxy.GetClient(),
+				Namespace: namespace.Name,
+			}, e2eConfig.GetIntervals(specName, "wait-delete-cluster")...)
+		})
+	})
+})

--- a/test/e2e/gke.go
+++ b/test/e2e/gke.go
@@ -196,6 +196,51 @@ func GetManagedControlPlaneByCluster(ctx context.Context, input GetManagedContro
 	return nil
 }
 
+// WaitForManagedClusterResourcesDeletedInput is the input type for WaitForManagedClusterResourcesDeleted.
+type WaitForManagedClusterResourcesDeletedInput struct {
+	Lister    framework.Lister
+	Namespace string
+}
+
+// WaitForManagedClusterResourcesDeleted asserts that all CAPG managed cluster objects in the
+// given namespace are fully removed from the API server. This covers the complete deletion
+// cascade: MachinePool, GCPManagedMachinePool, GCPManagedControlPlane, and GCPManagedCluster.
+// Checking each type individually gives a precise failure message identifying which resource
+// type has a stuck finalizer or is otherwise blocked, rather than relying solely on the
+// top-level Cluster resource disappearing.
+func WaitForManagedClusterResourcesDeleted(ctx context.Context, input WaitForManagedClusterResourcesDeletedInput, intervals ...interface{}) {
+	Expect(ctx).NotTo(BeNil(), "ctx is required for WaitForManagedClusterResourcesDeleted")
+	Expect(input.Lister).ToNot(BeNil(), "Invalid argument. input.Lister can't be nil when calling WaitForManagedClusterResourcesDeleted")
+
+	By("Verifying all MachinePool objects are deleted")
+	Eventually(func(g Gomega) {
+		list := &expv1.MachinePoolList{}
+		g.Expect(input.Lister.List(ctx, list, client.InNamespace(input.Namespace))).To(Succeed())
+		g.Expect(list.Items).To(BeEmpty(), "MachinePool objects still present in namespace %q", input.Namespace)
+	}, intervals...).Should(Succeed())
+
+	By("Verifying all GCPManagedMachinePool objects are deleted")
+	Eventually(func(g Gomega) {
+		list := &infrav1exp.GCPManagedMachinePoolList{}
+		g.Expect(input.Lister.List(ctx, list, client.InNamespace(input.Namespace))).To(Succeed())
+		g.Expect(list.Items).To(BeEmpty(), "GCPManagedMachinePool objects still present in namespace %q — possible stuck finalizer", input.Namespace)
+	}, intervals...).Should(Succeed())
+
+	By("Verifying all GCPManagedControlPlane objects are deleted")
+	Eventually(func(g Gomega) {
+		list := &infrav1exp.GCPManagedControlPlaneList{}
+		g.Expect(input.Lister.List(ctx, list, client.InNamespace(input.Namespace))).To(Succeed())
+		g.Expect(list.Items).To(BeEmpty(), "GCPManagedControlPlane objects still present in namespace %q", input.Namespace)
+	}, intervals...).Should(Succeed())
+
+	By("Verifying all GCPManagedCluster objects are deleted")
+	Eventually(func(g Gomega) {
+		list := &infrav1exp.GCPManagedClusterList{}
+		g.Expect(input.Lister.List(ctx, list, client.InNamespace(input.Namespace))).To(Succeed())
+		g.Expect(list.Items).To(BeEmpty(), "GCPManagedCluster objects still present in namespace %q", input.Namespace)
+	}, intervals...).Should(Succeed())
+}
+
 func setDefaults(input *ApplyManagedClusterTemplateAndWaitInput) {
 	if input.WaitForControlPlaneInitialized == nil {
 		input.WaitForControlPlaneInitialized = func(ctx context.Context, input ApplyManagedClusterTemplateAndWaitInput, result *ApplyManagedClusterTemplateAndWaitResult) {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
When a GKE cluster is deleted, GCP automatically removes all its node pools. If CAPG then calls DeleteNodePool for a pool GCP has already cleaned up, the API returns NotFound. Previously this error was propagated back to the controller, which set `GKEMachinePoolDeletingCondition` to `ReconciliationFailed` rather than `Deleted`. The finalizer removal gate in `gcpmanagedmachinepool_controller.go` checks specifically for DeletedReason, so the GCPManagedMachinePool finalizer was never removed — leaving the object stuck in termination indefinitely and requiring a manual kubectl edit to unblock.

The fix mirrors the pattern already used in describeNodePool: treat a NotFound response from DeleteNodePool as a no-op success, allowing the deletion condition to reach DeletedReason on the next reconcile loop when describeNodePool confirms the pool is gone.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1647 

**Special notes for your reviewer**:

As well as the fix, have added a new E2E test that explicitly creates a cluster, deletes it, and then asserts that all managed resources (MachinePool, GCPManagedMachinePool, GCPManagedControlPlane, GCPManagedCluster) are fully removed from the API server within the wait-delete-cluster interval (currently 30m in the default CI config). Per-type assertions are used rather than relying solely on the top-level Cluster object disappearing, so a failure message identifies exactly which resource type is blocked.

Previously, deletion was only exercised in AfterEach cleanup blocks where a timeout would not produce a clear test failure.

**TODOs**:
- [x] squashed commits
- [x] includes documentation - not really necessary as this should be the expected behaviour already
- [x] adds unit tests

**Release note**:
```release-note
fix(gke): ensure finalizers are removed from `GCPManagedMachinePool` (it gets removed), even when the nodepool is automatically deleted
```
