### PR TITLE
Stop `GCPManagedNodePool` scaling being blocked by multiple factors

### DIFF
--- a/cloud/scope/clients.go
+++ b/cloud/scope/clients.go
@@ -210,6 +210,24 @@ func newInstanceGroupManagerClient(ctx context.Context, credentialsRef *infrav1.
 	return instanceGroupManagersClient, nil
 }
 
+func newInstanceTemplatesRESTClient(ctx context.Context, credentialsRef *infrav1.ObjectReference, crClient client.Client, endpoints *infrav1.ServiceEndpoints) (*computerest.InstanceTemplatesClient, error) {
+	opts, err := defaultClientOptions(ctx, credentialsRef, crClient)
+	if err != nil {
+		return nil, fmt.Errorf("getting default gcp client options: %w", err)
+	}
+
+	if endpoints != nil && endpoints.ComputeServiceEndpoint != "" {
+		opts = append(opts, option.WithEndpoint(endpoints.ComputeServiceEndpoint))
+	}
+
+	instanceTemplatesClient, err := computerest.NewInstanceTemplatesRESTClient(ctx, opts...)
+	if err != nil {
+		return nil, errors.Errorf("failed to create gcp instance templates rest client: %v", err)
+	}
+
+	return instanceTemplatesClient, nil
+}
+
 func newTagBindingsClient(ctx context.Context, credentialsRef *infrav1.ObjectReference, crClient client.Client, location string, endpoints *infrav1.ServiceEndpoints) (*resourcemanager.TagBindingsClient, error) {
 	opts, err := defaultClientOptions(ctx, credentialsRef, crClient)
 

--- a/cloud/scope/managedmachinepool.go
+++ b/cloud/scope/managedmachinepool.go
@@ -43,6 +43,7 @@ import (
 type ManagedMachinePoolScopeParams struct {
 	ManagedClusterClient        *container.ClusterManagerClient
 	InstanceGroupManagersClient *compute.InstanceGroupManagersClient
+	InstanceTemplatesClient     *compute.InstanceTemplatesClient
 	Client                      client.Client
 	Cluster                     *clusterv1.Cluster
 	MachinePool                 *clusterv1.MachinePool
@@ -84,6 +85,13 @@ func NewManagedMachinePoolScope(ctx context.Context, params ManagedMachinePoolSc
 		}
 		params.InstanceGroupManagersClient = instanceGroupManagersClient
 	}
+	if params.InstanceTemplatesClient == nil {
+		instanceTemplatesClient, err := newInstanceTemplatesRESTClient(ctx, params.GCPManagedCluster.Spec.CredentialsRef, params.Client, params.GCPManagedCluster.Spec.ServiceEndpoints)
+		if err != nil {
+			return nil, errors.Errorf("failed to create gcp instance templates client: %v", err)
+		}
+		params.InstanceTemplatesClient = instanceTemplatesClient
+	}
 
 	helper, err := v1beta1patch.NewHelper(params.GCPManagedMachinePool, params.Client)
 	if err != nil {
@@ -91,14 +99,15 @@ func NewManagedMachinePoolScope(ctx context.Context, params ManagedMachinePoolSc
 	}
 
 	return &ManagedMachinePoolScope{
-		client:                 params.Client,
-		Cluster:                params.Cluster,
-		MachinePool:            params.MachinePool,
-		GCPManagedControlPlane: params.GCPManagedControlPlane,
-		GCPManagedMachinePool:  params.GCPManagedMachinePool,
-		mcClient:               params.ManagedClusterClient,
-		migClient:              params.InstanceGroupManagersClient,
-		patchHelper:            helper,
+		client:                  params.Client,
+		Cluster:                 params.Cluster,
+		MachinePool:             params.MachinePool,
+		GCPManagedControlPlane:  params.GCPManagedControlPlane,
+		GCPManagedMachinePool:   params.GCPManagedMachinePool,
+		mcClient:                params.ManagedClusterClient,
+		migClient:               params.InstanceGroupManagersClient,
+		instanceTemplatesClient: params.InstanceTemplatesClient,
+		patchHelper:             helper,
 	}, nil
 }
 
@@ -107,13 +116,14 @@ type ManagedMachinePoolScope struct {
 	client      client.Client
 	patchHelper *v1beta1patch.Helper
 
-	Cluster                *clusterv1.Cluster
-	MachinePool            *clusterv1.MachinePool
-	GCPManagedCluster      *infrav1exp.GCPManagedCluster
-	GCPManagedControlPlane *infrav1exp.GCPManagedControlPlane
-	GCPManagedMachinePool  *infrav1exp.GCPManagedMachinePool
-	mcClient               *container.ClusterManagerClient
-	migClient              *compute.InstanceGroupManagersClient
+	Cluster                 *clusterv1.Cluster
+	MachinePool             *clusterv1.MachinePool
+	GCPManagedCluster       *infrav1exp.GCPManagedCluster
+	GCPManagedControlPlane  *infrav1exp.GCPManagedControlPlane
+	GCPManagedMachinePool   *infrav1exp.GCPManagedMachinePool
+	mcClient                *container.ClusterManagerClient
+	migClient               *compute.InstanceGroupManagersClient
+	instanceTemplatesClient *compute.InstanceTemplatesClient
 }
 
 // PatchObject persists the managed control plane configuration and status.
@@ -133,6 +143,7 @@ func (s *ManagedMachinePoolScope) PatchObject(ctx context.Context) error {
 func (s *ManagedMachinePoolScope) Close(ctx context.Context) error {
 	s.mcClient.Close()
 	s.migClient.Close()
+	s.instanceTemplatesClient.Close()
 	return s.PatchObject(ctx)
 }
 
@@ -149,6 +160,11 @@ func (s *ManagedMachinePoolScope) ManagedMachinePoolClient() *container.ClusterM
 // InstanceGroupManagersClient returns a client used to interact with GCP MIG.
 func (s *ManagedMachinePoolScope) InstanceGroupManagersClient() *compute.InstanceGroupManagersClient {
 	return s.migClient
+}
+
+// InstanceTemplatesClient returns a client used to interact with GCE instance templates.
+func (s *ManagedMachinePoolScope) InstanceTemplatesClient() *compute.InstanceTemplatesClient {
+	return s.instanceTemplatesClient
 }
 
 // NodePoolVersion returns the k8s version of the node pool.

--- a/cloud/services/container/nodepools/reconcile.go
+++ b/cloud/services/container/nodepools/reconcile.go
@@ -403,11 +403,15 @@ func (s *Service) checkDiffAndPrepareUpdateConfig(existingNodePool *containerpb.
 			Tags: desiredNetworkTags,
 		}
 	}
-	// LinuxNodeConfig
-	desiredLinuxNodeConfig := infrav1exp.ConvertToSdkLinuxNodeConfig(s.scope.GCPManagedMachinePool.Spec.LinuxNodeConfig)
-	if !cmp.Equal(desiredLinuxNodeConfig, existingNodePool.GetConfig().GetLinuxNodeConfig(), cmpopts.IgnoreUnexported(containerpb.LinuxNodeConfig{})) {
-		needUpdate = true
-		updateNodePoolRequest.LinuxNodeConfig = desiredLinuxNodeConfig
+	// LinuxNodeConfig — only compare when the user has set it. ConvertToSdkLinuxNodeConfig
+	// returns a non-nil pointer even for nil input, which always differs from the nil
+	// GKE returns for pools with no linux node config, producing a spurious update loop.
+	if s.scope.GCPManagedMachinePool.Spec.LinuxNodeConfig != nil {
+		desiredLinuxNodeConfig := infrav1exp.ConvertToSdkLinuxNodeConfig(s.scope.GCPManagedMachinePool.Spec.LinuxNodeConfig)
+		if !cmp.Equal(desiredLinuxNodeConfig, existingNodePool.GetConfig().GetLinuxNodeConfig(), cmpopts.IgnoreUnexported(containerpb.LinuxNodeConfig{})) {
+			needUpdate = true
+			updateNodePoolRequest.LinuxNodeConfig = desiredLinuxNodeConfig
+		}
 	}
 
 	return needUpdate, &updateNodePoolRequest

--- a/cloud/services/container/nodepools/reconcile.go
+++ b/cloud/services/container/nodepools/reconcile.go
@@ -430,11 +430,16 @@ func (s *Service) checkDiffAndPrepareUpdateAutoscaling(existingNodePool *contain
 
 func (s *Service) checkDiffAndPrepareUpdateSize(existingNodePool *containerpb.NodePool) (bool, *containerpb.SetNodePoolSizeRequest) {
 	needUpdate := false
-	desiredAutoscaling := infrav1exp.ConvertToSdkAutoscaling(s.scope.GCPManagedMachinePool.Spec.Scaling)
 
-	if desiredAutoscaling.GetEnabled() {
-		// Do not update node pool size if autoscaling is enabled.
-		return false, nil
+	// Only skip size update if autoscaling is explicitly configured and enabled.
+	// ConvertToSdkAutoscaling returns {Enabled: true} when passed nil, so without this
+	// guard any node pool with no Spec.Scaling set would have manual size updates silently
+	// suppressed.
+	if s.scope.GCPManagedMachinePool.Spec.Scaling != nil {
+		desiredAutoscaling := infrav1exp.ConvertToSdkAutoscaling(s.scope.GCPManagedMachinePool.Spec.Scaling)
+		if desiredAutoscaling.GetEnabled() {
+			return false, nil
+		}
 	}
 
 	setNodePoolSizeRequest := containerpb.SetNodePoolSizeRequest{

--- a/cloud/services/container/nodepools/reconcile.go
+++ b/cloud/services/container/nodepools/reconcile.go
@@ -142,7 +142,17 @@ func (s *Service) Reconcile(ctx context.Context) (ctrl.Result, error) {
 		return ctrl.Result{}, nil
 	}
 
-	needUpdateConfig, nodePoolUpdateConfigRequest := s.checkDiffAndPrepareUpdateConfig(nodePool)
+	// Fetch instance template labels for AdditionalLabels sync. GKE does not echo
+	// NodeConfig.ResourceLabels in GetNodePool responses; the instance template's
+	// properties.labels is the authoritative source of what labels GKE stamps onto
+	// every node in the pool. On error we proceed without label sync for this cycle.
+	templateLabels, err := s.fetchInstanceTemplateLabels(ctx, nodePool)
+	if err != nil {
+		log.Error(err, "Failed to read instance template labels, skipping AdditionalLabels sync this cycle")
+		templateLabels = nil
+	}
+
+	needUpdateConfig, nodePoolUpdateConfigRequest := s.checkDiffAndPrepareUpdateConfig(nodePool, templateLabels)
 	if needUpdateConfig {
 		log.Info("Node pool config update required", "request", nodePoolUpdateConfigRequest)
 		err = s.updateNodePoolConfig(ctx, nodePoolUpdateConfigRequest)
@@ -281,6 +291,47 @@ func (s *Service) getInstances(ctx context.Context, nodePool *containerpb.NodePo
 	return instances, nil
 }
 
+// fetchInstanceTemplateLabels returns the properties.labels from the instance template
+// used by the first instance group in the node pool. These are the labels GKE stamps
+// onto every node in the pool and are the authoritative source for AdditionalLabels sync.
+// Returns nil if the node pool has no instance groups yet.
+func (s *Service) fetchInstanceTemplateLabels(ctx context.Context, nodePool *containerpb.NodePool) (map[string]string, error) {
+	urls := nodePool.GetInstanceGroupUrls()
+	if len(urls) == 0 {
+		return nil, nil
+	}
+	igURL, err := resourceurl.Parse(urls[0])
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing instance group url")
+	}
+	mig, err := s.scope.InstanceGroupManagersClient().Get(ctx, &computepb.GetInstanceGroupManagerRequest{
+		InstanceGroupManager: igURL.Name,
+		Project:              igURL.Project,
+		Zone:                 igURL.Location,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "getting instance group manager")
+	}
+	// Instance template URL format:
+	// https://www.googleapis.com/compute/v1/projects/{project}/global/instanceTemplates/{name}
+	templateURL := mig.GetInstanceTemplate()
+	if templateURL == "" {
+		return nil, nil
+	}
+	parts := strings.SplitN(strings.TrimPrefix(templateURL, "https://www.googleapis.com/compute/v1/projects/"), "/", 4)
+	if len(parts) != 4 {
+		return nil, errors.Errorf("unexpected instance template url format: %s", templateURL)
+	}
+	tmpl, err := s.scope.InstanceTemplatesClient().Get(ctx, &computepb.GetInstanceTemplateRequest{
+		Project:          parts[0],
+		InstanceTemplate: parts[3],
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "getting instance template")
+	}
+	return tmpl.GetProperties().GetLabels(), nil
+}
+
 func (s *Service) createNodePool(ctx context.Context, log *logr.Logger) error {
 	log.V(2).Info("Running pre-flight checks on machine pool before creation")
 	if err := shared.ManagedMachinePoolPreflightCheck(s.scope.GCPManagedMachinePool, s.scope.MachinePool, s.scope.Region()); err != nil {
@@ -343,7 +394,7 @@ func (s *Service) deleteNodePool(ctx context.Context) error {
 	return nil
 }
 
-func (s *Service) checkDiffAndPrepareUpdateConfig(existingNodePool *containerpb.NodePool) (bool, *containerpb.UpdateNodePoolRequest) {
+func (s *Service) checkDiffAndPrepareUpdateConfig(existingNodePool *containerpb.NodePool, existingTemplateLabels map[string]string) (bool, *containerpb.UpdateNodePoolRequest) {
 	needUpdate := false
 	updateNodePoolRequest := containerpb.UpdateNodePoolRequest{
 		Name: s.scope.NodePoolFullName(),
@@ -380,11 +431,20 @@ func (s *Service) checkDiffAndPrepareUpdateConfig(existingNodePool *containerpb.
 		needUpdate = true
 		updateNodePoolRequest.ImageType = desiredNodePool.GetConfig().GetImageType()
 	}
-	// Additional resource labels
-	if !cmp.Equal(desiredNodePool.GetConfig().GetResourceLabels(), existingNodePool.GetConfig().GetResourceLabels()) {
-		needUpdate = true
-		updateNodePoolRequest.ResourceLabels = &containerpb.ResourceLabels{
-			Labels: desiredNodePool.GetConfig().GetResourceLabels(),
+	// Resource labels (AdditionalLabels) — GKE does not echo NodeConfig.ResourceLabels in
+	// GetNodePool responses, so we compare against the instance template's properties.labels
+	// instead (see fetchInstanceTemplateLabels). We use a subset check: all desired labels
+	// must be present with the correct value; GKE-internal labels on the template are ignored.
+	if existingTemplateLabels != nil {
+		desiredResourceLabels := scope.NodePoolResourceLabels(s.scope.GCPManagedMachinePool.Spec.AdditionalLabels, s.scope.GCPManagedControlPlane.Spec.ClusterName)
+		for k, v := range desiredResourceLabels {
+			if existingTemplateLabels[k] != v {
+				needUpdate = true
+				updateNodePoolRequest.ResourceLabels = &containerpb.ResourceLabels{
+					Labels: desiredResourceLabels,
+				}
+				break
+			}
 		}
 	}
 	// Locations

--- a/cloud/services/container/nodepools/reconcile.go
+++ b/cloud/services/container/nodepools/reconcile.go
@@ -152,20 +152,26 @@ func (s *Service) Reconcile(ctx context.Context) (ctrl.Result, error) {
 		templateLabels = nil
 	}
 
+	// Run all checks before applying any update so that a persistent diff in one
+	// category cannot permanently starve updates in another. GKE only allows one
+	// concurrent operation per node pool, so we apply one per cycle (with requeue)
+	// in priority order: size first (user-initiated scaling is most time-sensitive),
+	// then autoscaling config, then general config.
+	needUpdateSize, setNodePoolSizeRequest := s.checkDiffAndPrepareUpdateSize(nodePool)
+	needUpdateAutoscaling, setNodePoolAutoscalingRequest := s.checkDiffAndPrepareUpdateAutoscaling(nodePool)
 	needUpdateConfig, nodePoolUpdateConfigRequest := s.checkDiffAndPrepareUpdateConfig(nodePool, templateLabels)
-	if needUpdateConfig {
-		log.Info("Node pool config update required", "request", nodePoolUpdateConfigRequest)
-		err = s.updateNodePoolConfig(ctx, nodePoolUpdateConfigRequest)
+
+	if needUpdateSize {
+		log.Info("Size update required")
+		err = s.updateNodePoolSize(ctx, setNodePoolSizeRequest)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("node pool config update (either version/labels/taints/locations/image type/network tag/linux node config or all) failed: %w", err)
+			return ctrl.Result{}, err
 		}
-		log.Info("Node pool config updating in progress")
-		s.scope.GCPManagedMachinePool.Status.Ready = true
+		log.Info("Node pool size updating in progress")
 		v1beta1conditions.MarkTrue(s.scope.ConditionSetter(), infrav1exp.GKEMachinePoolUpdatingCondition)
 		return ctrl.Result{RequeueAfter: reconciler.DefaultRetryTime}, nil
 	}
 
-	needUpdateAutoscaling, setNodePoolAutoscalingRequest := s.checkDiffAndPrepareUpdateAutoscaling(nodePool)
 	if needUpdateAutoscaling {
 		log.Info("Auto scaling update required")
 		err = s.updateNodePoolAutoscaling(ctx, setNodePoolAutoscalingRequest)
@@ -177,14 +183,14 @@ func (s *Service) Reconcile(ctx context.Context) (ctrl.Result, error) {
 		return ctrl.Result{RequeueAfter: reconciler.DefaultRetryTime}, nil
 	}
 
-	needUpdateSize, setNodePoolSizeRequest := s.checkDiffAndPrepareUpdateSize(nodePool)
-	if needUpdateSize {
-		log.Info("Size update required")
-		err = s.updateNodePoolSize(ctx, setNodePoolSizeRequest)
+	if needUpdateConfig {
+		log.Info("Node pool config update required", "request", nodePoolUpdateConfigRequest)
+		err = s.updateNodePoolConfig(ctx, nodePoolUpdateConfigRequest)
 		if err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("node pool config update (either version/labels/taints/locations/image type/network tag/linux node config or all) failed: %w", err)
 		}
-		log.Info("Node pool size updating in progress")
+		log.Info("Node pool config updating in progress")
+		s.scope.GCPManagedMachinePool.Status.Ready = true
 		v1beta1conditions.MarkTrue(s.scope.ConditionSetter(), infrav1exp.GKEMachinePoolUpdatingCondition)
 		return ctrl.Result{RequeueAfter: reconciler.DefaultRetryTime}, nil
 	}

--- a/cloud/services/container/nodepools/reconcile.go
+++ b/cloud/services/container/nodepools/reconcile.go
@@ -401,11 +401,15 @@ func (s *Service) checkDiffAndPrepareUpdateConfig(existingNodePool *containerpb.
 			Tags: desiredNetworkTags,
 		}
 	}
-	// LinuxNodeConfig
-	desiredLinuxNodeConfig := infrav1exp.ConvertToSdkLinuxNodeConfig(s.scope.GCPManagedMachinePool.Spec.LinuxNodeConfig)
-	if !cmp.Equal(desiredLinuxNodeConfig, existingNodePool.GetConfig().GetLinuxNodeConfig(), cmpopts.IgnoreUnexported(containerpb.LinuxNodeConfig{})) {
-		needUpdate = true
-		updateNodePoolRequest.LinuxNodeConfig = desiredLinuxNodeConfig
+	// LinuxNodeConfig — only compare when the user has set it. ConvertToSdkLinuxNodeConfig
+	// returns a non-nil pointer even for nil input, which always differs from the nil
+	// GKE returns for pools with no linux node config, producing a spurious update loop.
+	if s.scope.GCPManagedMachinePool.Spec.LinuxNodeConfig != nil {
+		desiredLinuxNodeConfig := infrav1exp.ConvertToSdkLinuxNodeConfig(s.scope.GCPManagedMachinePool.Spec.LinuxNodeConfig)
+		if !cmp.Equal(desiredLinuxNodeConfig, existingNodePool.GetConfig().GetLinuxNodeConfig(), cmpopts.IgnoreUnexported(containerpb.LinuxNodeConfig{})) {
+			needUpdate = true
+			updateNodePoolRequest.LinuxNodeConfig = desiredLinuxNodeConfig
+		}
 	}
 
 	return needUpdate, &updateNodePoolRequest

--- a/cloud/services/container/nodepools/reconcile.go
+++ b/cloud/services/container/nodepools/reconcile.go
@@ -428,11 +428,16 @@ func (s *Service) checkDiffAndPrepareUpdateAutoscaling(existingNodePool *contain
 
 func (s *Service) checkDiffAndPrepareUpdateSize(existingNodePool *containerpb.NodePool) (bool, *containerpb.SetNodePoolSizeRequest) {
 	needUpdate := false
-	desiredAutoscaling := infrav1exp.ConvertToSdkAutoscaling(s.scope.GCPManagedMachinePool.Spec.Scaling)
 
-	if desiredAutoscaling.GetEnabled() {
-		// Do not update node pool size if autoscaling is enabled.
-		return false, nil
+	// Only skip size update if autoscaling is explicitly configured and enabled.
+	// ConvertToSdkAutoscaling returns {Enabled: true} when passed nil, so without this
+	// guard any node pool with no Spec.Scaling set would have manual size updates silently
+	// suppressed.
+	if s.scope.GCPManagedMachinePool.Spec.Scaling != nil {
+		desiredAutoscaling := infrav1exp.ConvertToSdkAutoscaling(s.scope.GCPManagedMachinePool.Spec.Scaling)
+		if desiredAutoscaling.GetEnabled() {
+			return false, nil
+		}
 	}
 
 	setNodePoolSizeRequest := containerpb.SetNodePoolSizeRequest{

--- a/cloud/services/container/nodepools/reconcile_test.go
+++ b/cloud/services/container/nodepools/reconcile_test.go
@@ -1,0 +1,400 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodepools
+
+import (
+	"testing"
+
+	"cloud.google.com/go/container/apiv1/containerpb"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-gcp/cloud/scope"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
+)
+
+func newTestService(machinePool *infrav1exp.GCPManagedMachinePool, mp *clusterv1.MachinePool, controlPlane *infrav1exp.GCPManagedControlPlane) *Service {
+	s := new(scope.ManagedMachinePoolScope)
+	s.GCPManagedMachinePool = machinePool
+	s.MachinePool = mp
+	s.GCPManagedControlPlane = controlPlane
+	return &Service{scope: s}
+}
+
+func defaultControlPlane() *infrav1exp.GCPManagedControlPlane {
+	return &infrav1exp.GCPManagedControlPlane{
+		Spec: infrav1exp.GCPManagedControlPlaneSpec{
+			GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
+				Project:     "test-project",
+				Location:    "us-central1-a",
+				ClusterName: "test-cluster",
+			},
+		},
+	}
+}
+
+func defaultMachinePool() *clusterv1.MachinePool {
+	return &clusterv1.MachinePool{
+		Spec: clusterv1.MachinePoolSpec{
+			Replicas: ptr.To(int32(3)),
+		},
+	}
+}
+
+func defaultGCPManagedMachinePool() *infrav1exp.GCPManagedMachinePool {
+	return &infrav1exp.GCPManagedMachinePool{}
+}
+
+func TestCheckDiffAndPrepareUpdateConfig(t *testing.T) {
+	tests := []struct {
+		name                   string
+		machinePool            *infrav1exp.GCPManagedMachinePool
+		mp                     *clusterv1.MachinePool
+		existingNodePool       *containerpb.NodePool
+		existingTemplateLabels map[string]string
+		wantNeedUpdate         bool
+		validateUpdateFunc     func(t *testing.T, req *containerpb.UpdateNodePoolRequest)
+	}{
+		{
+			name:        "no diff when everything matches",
+			machinePool: defaultGCPManagedMachinePool(),
+			mp:          defaultMachinePool(),
+			existingNodePool: &containerpb.NodePool{
+				Config: &containerpb.NodeConfig{},
+			},
+			wantNeedUpdate: false,
+		},
+		{
+			name: "no diff when desired resource labels already present in instance template",
+			machinePool: &infrav1exp.GCPManagedMachinePool{
+				Spec: infrav1exp.GCPManagedMachinePoolSpec{
+					GCPManagedMachinePoolClassSpec: infrav1exp.GCPManagedMachinePoolClassSpec{
+						AdditionalLabels: infrav1.Labels{"user-label": "value"},
+					},
+				},
+			},
+			mp: defaultMachinePool(),
+			existingNodePool: &containerpb.NodePool{
+				Config: &containerpb.NodeConfig{},
+			},
+			// Template already has both the user label and the CAPG ownership label.
+			existingTemplateLabels: map[string]string{
+				"user-label":                "value",
+				"capg-cluster-test-cluster": "owned",
+				"goog-gke-node":             "",
+			},
+			wantNeedUpdate: false,
+		},
+		{
+			name: "diff on resource labels triggers update when label missing from template",
+			machinePool: &infrav1exp.GCPManagedMachinePool{
+				Spec: infrav1exp.GCPManagedMachinePoolSpec{
+					GCPManagedMachinePoolClassSpec: infrav1exp.GCPManagedMachinePoolClassSpec{
+						AdditionalLabels: infrav1.Labels{"user-label": "value"},
+					},
+				},
+			},
+			mp: defaultMachinePool(),
+			existingNodePool: &containerpb.NodePool{
+				Config: &containerpb.NodeConfig{},
+			},
+			// Template is missing the desired user-label.
+			existingTemplateLabels: map[string]string{
+				"capg-cluster-test-cluster": "owned",
+			},
+			wantNeedUpdate: true,
+			validateUpdateFunc: func(t *testing.T, req *containerpb.UpdateNodePoolRequest) {
+				t.Helper()
+				if req.GetResourceLabels().GetLabels()["user-label"] != "value" {
+					t.Errorf("expected resource label user-label=value, got %v", req.GetResourceLabels().GetLabels())
+				}
+			},
+		},
+		{
+			name: "no resource label update when template labels unavailable",
+			machinePool: &infrav1exp.GCPManagedMachinePool{
+				Spec: infrav1exp.GCPManagedMachinePoolSpec{
+					GCPManagedMachinePoolClassSpec: infrav1exp.GCPManagedMachinePoolClassSpec{
+						AdditionalLabels: infrav1.Labels{"user-label": "value"},
+					},
+				},
+			},
+			mp: defaultMachinePool(),
+			existingNodePool: &containerpb.NodePool{
+				Config: &containerpb.NodeConfig{},
+			},
+			existingTemplateLabels: nil,
+			wantNeedUpdate:         false,
+		},
+		{
+			name: "diff on Kubernetes labels triggers update",
+			machinePool: &infrav1exp.GCPManagedMachinePool{
+				Spec: infrav1exp.GCPManagedMachinePoolSpec{
+					GCPManagedMachinePoolClassSpec: infrav1exp.GCPManagedMachinePoolClassSpec{
+						KubernetesLabels: infrav1.Labels{"env": "prod"},
+					},
+				},
+			},
+			mp: defaultMachinePool(),
+			existingNodePool: &containerpb.NodePool{
+				Config: &containerpb.NodeConfig{
+					Labels: map[string]string{"env": "staging"},
+				},
+			},
+			wantNeedUpdate: true,
+			validateUpdateFunc: func(t *testing.T, req *containerpb.UpdateNodePoolRequest) {
+				t.Helper()
+				if req.GetLabels().GetLabels()["env"] != "prod" {
+					t.Errorf("expected label env=prod, got %v", req.GetLabels().GetLabels())
+				}
+			},
+		},
+		{
+			name: "no diff on image type when case differs (case-insensitive match)",
+			machinePool: &infrav1exp.GCPManagedMachinePool{
+				Spec: infrav1exp.GCPManagedMachinePoolSpec{
+					GCPManagedMachinePoolClassSpec: infrav1exp.GCPManagedMachinePoolClassSpec{
+						ImageType: ptr.To("cos_containerd"),
+					},
+				},
+			},
+			mp: defaultMachinePool(),
+			existingNodePool: &containerpb.NodePool{
+				Config: &containerpb.NodeConfig{
+					ImageType: "COS_CONTAINERD",
+				},
+			},
+			wantNeedUpdate: false,
+		},
+		{
+			name: "diff on image type triggers update",
+			machinePool: &infrav1exp.GCPManagedMachinePool{
+				Spec: infrav1exp.GCPManagedMachinePoolSpec{
+					GCPManagedMachinePoolClassSpec: infrav1exp.GCPManagedMachinePoolClassSpec{
+						ImageType: ptr.To("ubuntu_containerd"),
+					},
+				},
+			},
+			mp: defaultMachinePool(),
+			existingNodePool: &containerpb.NodePool{
+				Config: &containerpb.NodeConfig{
+					ImageType: "COS_CONTAINERD",
+				},
+			},
+			wantNeedUpdate: true,
+			validateUpdateFunc: func(t *testing.T, req *containerpb.UpdateNodePoolRequest) {
+				t.Helper()
+				if req.GetImageType() != "ubuntu_containerd" {
+					t.Errorf("expected image type ubuntu_containerd, got %v", req.GetImageType())
+				}
+			},
+		},
+		{
+			name: "diff on network tags triggers update",
+			machinePool: &infrav1exp.GCPManagedMachinePool{
+				Spec: infrav1exp.GCPManagedMachinePoolSpec{
+					GCPManagedMachinePoolClassSpec: infrav1exp.GCPManagedMachinePoolClassSpec{
+						NodeNetwork: infrav1exp.NodeNetworkConfig{
+							Tags: []string{"tag-a", "tag-b"},
+						},
+					},
+				},
+			},
+			mp: defaultMachinePool(),
+			existingNodePool: &containerpb.NodePool{
+				Config: &containerpb.NodeConfig{
+					Tags: []string{"tag-a"},
+				},
+			},
+			wantNeedUpdate: true,
+			validateUpdateFunc: func(t *testing.T, req *containerpb.UpdateNodePoolRequest) {
+				t.Helper()
+				if len(req.GetTags().GetTags()) != 2 {
+					t.Errorf("expected 2 tags, got %v", req.GetTags().GetTags())
+				}
+			},
+		},
+		{
+			name: "diff on node locations triggers update",
+			machinePool: &infrav1exp.GCPManagedMachinePool{
+				Spec: infrav1exp.GCPManagedMachinePoolSpec{
+					GCPManagedMachinePoolClassSpec: infrav1exp.GCPManagedMachinePoolClassSpec{
+						NodeLocations: []string{"us-central1-a", "us-central1-b"},
+					},
+				},
+			},
+			mp: defaultMachinePool(),
+			existingNodePool: &containerpb.NodePool{
+				Config:    &containerpb.NodeConfig{},
+				Locations: []string{"us-central1-a"},
+			},
+			wantNeedUpdate: true,
+			validateUpdateFunc: func(t *testing.T, req *containerpb.UpdateNodePoolRequest) {
+				t.Helper()
+				if len(req.GetLocations()) != 2 {
+					t.Errorf("expected 2 locations, got %v", req.GetLocations())
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newTestService(tt.machinePool, tt.mp, defaultControlPlane())
+			needUpdate, req := svc.checkDiffAndPrepareUpdateConfig(tt.existingNodePool, tt.existingTemplateLabels)
+			if needUpdate != tt.wantNeedUpdate {
+				t.Errorf("checkDiffAndPrepareUpdateConfig() needUpdate = %v, want %v", needUpdate, tt.wantNeedUpdate)
+			}
+			if tt.validateUpdateFunc != nil {
+				tt.validateUpdateFunc(t, req)
+			}
+		})
+	}
+}
+
+func TestCheckDiffAndPrepareUpdateSize(t *testing.T) {
+	tests := []struct {
+		name             string
+		machinePool      *infrav1exp.GCPManagedMachinePool
+		mp               *clusterv1.MachinePool
+		controlPlane     *infrav1exp.GCPManagedControlPlane
+		existingNodePool *containerpb.NodePool
+		wantNeedUpdate   bool
+		wantNodeCount    int32
+	}{
+		{
+			name:         "no diff when replica count matches",
+			machinePool:  defaultGCPManagedMachinePool(),
+			mp:           &clusterv1.MachinePool{Spec: clusterv1.MachinePoolSpec{Replicas: ptr.To(int32(3))}},
+			controlPlane: defaultControlPlane(),
+			existingNodePool: &containerpb.NodePool{
+				InitialNodeCount: 3,
+				Locations:        []string{"us-central1-a"},
+			},
+			wantNeedUpdate: false,
+		},
+		{
+			name:         "diff detected when replica count increases",
+			machinePool:  defaultGCPManagedMachinePool(),
+			mp:           &clusterv1.MachinePool{Spec: clusterv1.MachinePoolSpec{Replicas: ptr.To(int32(5))}},
+			controlPlane: defaultControlPlane(),
+			existingNodePool: &containerpb.NodePool{
+				InitialNodeCount: 3,
+				Locations:        []string{"us-central1-a"},
+			},
+			wantNeedUpdate: true,
+			wantNodeCount:  5,
+		},
+		{
+			name:         "diff detected when replica count decreases",
+			machinePool:  defaultGCPManagedMachinePool(),
+			mp:           &clusterv1.MachinePool{Spec: clusterv1.MachinePoolSpec{Replicas: ptr.To(int32(1))}},
+			controlPlane: defaultControlPlane(),
+			existingNodePool: &containerpb.NodePool{
+				InitialNodeCount: 3,
+				Locations:        []string{"us-central1-a"},
+			},
+			wantNeedUpdate: true,
+			wantNodeCount:  1,
+		},
+		{
+			name: "autoscaling enabled suppresses size update",
+			machinePool: &infrav1exp.GCPManagedMachinePool{
+				Spec: infrav1exp.GCPManagedMachinePoolSpec{
+					GCPManagedMachinePoolClassSpec: infrav1exp.GCPManagedMachinePoolClassSpec{
+						Scaling: &infrav1exp.NodePoolAutoScaling{
+							MinCount: ptr.To(int32(1)),
+							MaxCount: ptr.To(int32(10)),
+						},
+					},
+				},
+			},
+			mp:           &clusterv1.MachinePool{Spec: clusterv1.MachinePoolSpec{Replicas: ptr.To(int32(5))}},
+			controlPlane: defaultControlPlane(),
+			existingNodePool: &containerpb.NodePool{
+				InitialNodeCount: 3,
+				Locations:        []string{"us-central1-a"},
+			},
+			wantNeedUpdate: false,
+		},
+		{
+			name:         "nil Scaling spec does not suppress size update",
+			machinePool:  defaultGCPManagedMachinePool(),
+			mp:           &clusterv1.MachinePool{Spec: clusterv1.MachinePoolSpec{Replicas: ptr.To(int32(5))}},
+			controlPlane: defaultControlPlane(),
+			existingNodePool: &containerpb.NodePool{
+				InitialNodeCount: 3,
+				Locations:        []string{"us-central1-a"},
+			},
+			wantNeedUpdate: true,
+			wantNodeCount:  5,
+		},
+		{
+			name:        "regional cluster divides replicas by zone count",
+			machinePool: defaultGCPManagedMachinePool(),
+			mp:          &clusterv1.MachinePool{Spec: clusterv1.MachinePoolSpec{Replicas: ptr.To(int32(6))}},
+			controlPlane: &infrav1exp.GCPManagedControlPlane{
+				Spec: infrav1exp.GCPManagedControlPlaneSpec{
+					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
+						Project:     "test-project",
+						Location:    "us-central1",
+						ClusterName: "test-cluster",
+					},
+				},
+			},
+			existingNodePool: &containerpb.NodePool{
+				InitialNodeCount: 2,
+				Locations:        []string{"us-central1-a", "us-central1-b", "us-central1-c"},
+			},
+			wantNeedUpdate: false,
+		},
+		{
+			name:        "regional cluster detects diff after division",
+			machinePool: defaultGCPManagedMachinePool(),
+			mp:          &clusterv1.MachinePool{Spec: clusterv1.MachinePoolSpec{Replicas: ptr.To(int32(9))}},
+			controlPlane: &infrav1exp.GCPManagedControlPlane{
+				Spec: infrav1exp.GCPManagedControlPlaneSpec{
+					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
+						Project:     "test-project",
+						Location:    "us-central1",
+						ClusterName: "test-cluster",
+					},
+				},
+			},
+			existingNodePool: &containerpb.NodePool{
+				InitialNodeCount: 2,
+				Locations:        []string{"us-central1-a", "us-central1-b", "us-central1-c"},
+			},
+			wantNeedUpdate: true,
+			wantNodeCount:  3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newTestService(tt.machinePool, tt.mp, tt.controlPlane)
+			needUpdate, req := svc.checkDiffAndPrepareUpdateSize(tt.existingNodePool)
+			if needUpdate != tt.wantNeedUpdate {
+				t.Errorf("checkDiffAndPrepareUpdateSize() needUpdate = %v, want %v", needUpdate, tt.wantNeedUpdate)
+			}
+			if tt.wantNeedUpdate && req != nil && req.GetNodeCount() != tt.wantNodeCount {
+				t.Errorf("checkDiffAndPrepareUpdateSize() NodeCount = %v, want %v", req.GetNodeCount(), tt.wantNodeCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR tackles the 4 bugs that are listed out in #1656 which prevent manual `MachinePool` scaling from working with a `GCPManagedNodePool`. Namely:

1. Add a `nil` guard to the Autoscaling check - This means that nodepools that don't have an Autoscaling config won't return early, so manual scaling can occur
2. Add a `nil` guard to `LinuxNodeConfig` - This means that `LinuxNodeConfig` is only compared when it's set, rather than comparing a non-nil empty struct generated by `ConvertToSdkLinuxNodeConfig` to the `nil` that GKE returns
3. Sync `AdditionalLabels` via the InstanceTemplate not the NodePool - The NodePool object doesn't have a labels attribute on it, so instead of that we create an InstanceTemplate client, look up the template that's relevant and check the labels we're setting are correctly set there, and rely on GKE to propagate those into the nodes themselves. 
4. Run all three checks (`checkDiffAndPrepareUpdateSize`, `checkDiffAndPrepareUpdateAutoscaling`, `checkDiffAndPrepareUpdateConfig`) before any update is applied - This means the current behaviour where updates are run sequentially and there's an early exit (and in turn causes size updates to be starved because of (3)), doesn't happen anymore. Updates are all checked and then run in priority order (size -> autoscaling -> general).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1656

**Special notes for your reviewer**:
I've verified as much of this as I can on my own cluster, particularly the `additionalLabels` checks, but I also appreciate there's an alternative approach where you could fetch the Instances themselves and check, and I'm happy to pivot to that approach if we think that's demonstrably better.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
Ensure that GCPManagedNodePool scaling always works and improve how labels are synced to NodePools
```
