### PR TITLE
fix: e2e: upgrades cluster template: ccm: add missing cloud.config/label, pin to v34.2.0

### DIFF
--- a/test/e2e/data/ccm/gce-cloud-controller-manager.yaml
+++ b/test/e2e/data/ccm/gce-cloud-controller-manager.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
       - name: cloud-controller-manager
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v34.2.0
         imagePullPolicy: IfNotPresent
         command:
         - /cloud-controller-manager

--- a/test/e2e/data/infrastructure-gcp/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-upgrades.yaml
@@ -5,6 +5,7 @@ metadata:
   name: "${CLUSTER_NAME}"
   labels:
     cni: "${CLUSTER_NAME}-crs-cni"
+    ccm: "${CLUSTER_NAME}-crs-ccm"
 spec:
   clusterNetwork:
     pods:

--- a/test/e2e/data/infrastructure-gcp/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-upgrades.yaml
@@ -54,6 +54,16 @@ spec:
           cloud-provider: external
           allocate-node-cidrs: "false"
       kubernetesVersion: "${KUBERNETES_VERSION}"
+    files:
+    - content: |
+        [Global]
+
+        project-id = "${GCP_PROJECT}"
+        network-name = "${GCP_NETWORK_NAME}"
+        multizone = true
+      owner: root:root
+      path: /etc/kubernetes/cloud.config
+      permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         name: '{{ ds.meta_data.local_hostname.split(".")[0] }}'


### PR DESCRIPTION
Surfaced when I ran the upgrade job on another PR: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-gcp/1663/pull-cluster-api-provider-gcp-e2e-workload-upgrade/2054931806385344512

- [fix: add missing ccm label to upgrades cluster template](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1664/changes/c90374b3289630da4b08b8dfcf6c10d6c4a00fcf)
In the e2e template, add missing `ccm` label to the Cluster object in `cluster-template-upgrades.yaml`
The CCM `ClusterResourceSet` selects clusters by `matchLabels: {ccm: ...}`, but the Cluster object in the upgrades template only had the `cni` label. This meant the CCM was never deployed to workload clusters created by the upgrade test, so Nodes never got their `providerID` set, and CAPI timed out waiting for control plane machines.
The label was missed when the CCM resources were added to this template in #1554.

- [e2e: pin cloud-controller-manager image to v34.2.0](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1664/changes/cafca0a2368061d34478fb0fda5dcd51eb9b0a0f)
The floating :master tag is non-deterministic and can pick up
regressions at any time. Pin to v34.2.0 (cloud-provider-gcp for
Kubernetes 1.34) for stable e2e results.

- [fix: add missing cloud.config to upgrades cluster template](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1664/changes/f67bdb50a9eb6bd5069607ce1be4ca0e448894b1)
The upgrades template was missing the cloud.config file with
multizone = true that all other templates have. Without it, the
CCM only manages the single zone where it runs and deletes nodes
in other zones because it can't find their GCE instances.
