### PR TITLE
test: add SSH-based log collection for e2e tests

### DIFF
--- a/test/e2e/config/gcp-ci.yaml
+++ b/test/e2e/config/gcp-ci.yaml
@@ -114,6 +114,7 @@ variables:
   GKE_MACHINE_POOL_MIN_CRITICAL_ADDONS_ONLY: "0"
   GKE_MACHINE_POOL_MAX_CRITICAL_ADDONS_ONLY: "1"
   CAPG_LOGLEVEL: "4"
+  GCP_SSH_KEY: "${GCP_SSH_KEY:-}"
 
 intervals:
   default/wait-controllers: ["5m", "10s"]

--- a/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-creds.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-creds.yaml
@@ -83,6 +83,10 @@ spec:
     spec:
       instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -116,6 +120,10 @@ spec:
     spec:
       instanceType: "${GCP_NODE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-external-and-internal-lb.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-external-and-internal-lb.yaml
@@ -87,6 +87,10 @@ spec:
     spec:
       instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -120,6 +124,10 @@ spec:
     spec:
       instanceType: "${GCP_NODE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-firewall-rules.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-firewall-rules.yaml
@@ -100,6 +100,10 @@ spec:
     spec:
       instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -133,6 +137,10 @@ spec:
     spec:
       instanceType: "${GCP_NODE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-internal-lb.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-ci-with-internal-lb.yaml
@@ -90,6 +90,10 @@ spec:
     spec:
       instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -123,6 +127,10 @@ spec:
     spec:
       instanceType: "${GCP_NODE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-gcp/cluster-template-ci.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-ci.yaml
@@ -80,6 +80,10 @@ spec:
     spec:
       instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -113,6 +117,10 @@ spec:
     spec:
       instanceType: "${GCP_NODE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-gcp/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-kcp-remediation.yaml
@@ -79,6 +79,10 @@ spec:
     spec:
       instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -127,6 +131,10 @@ spec:
     spec:
       instanceType: "${GCP_NODE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-gcp/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-md-remediation.yaml
@@ -79,6 +79,10 @@ spec:
     spec:
       instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -129,6 +133,10 @@ spec:
     spec:
       instanceType: "${GCP_NODE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-gcp/cluster-template-prow-ci-version.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-prow-ci-version.yaml
@@ -149,6 +149,10 @@ spec:
     spec:
       instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -184,6 +188,10 @@ spec:
     spec:
       instanceType: "${GCP_NODE_MACHINE_TYPE}"
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-gcp/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-gcp/cluster-template-upgrades.yaml
@@ -69,6 +69,10 @@ spec:
     spec:
       instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
       image: "${KUBERNETES_IMAGE_UPGRADE_FROM}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -102,6 +106,10 @@ spec:
     spec:
       instanceType: "${GCP_NODE_MACHINE_TYPE}"
       image: "${KUBERNETES_IMAGE_UPGRADE_FROM}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -144,6 +152,10 @@ spec:
     spec:
       instanceType: "${GCP_CONTROL_PLANE_MACHINE_TYPE}"
       image: "${KUBERNETES_IMAGE_UPGRADE_TO}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: GCPMachineTemplate
@@ -154,6 +166,10 @@ spec:
     spec:
       instanceType: "${GCP_NODE_MACHINE_TYPE}"
       image: "${KUBERNETES_IMAGE_UPGRADE_TO}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/test/e2e/data/infrastructure-gcp/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-gcp/clusterclass-quick-start.yaml
@@ -149,6 +149,10 @@ spec:
     spec:
       instanceType: REPLACEME
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: GCPMachineTemplate
@@ -159,6 +163,10 @@ spec:
     spec:
       instanceType: REPLACEME
       image: "${IMAGE_ID}"
+      publicIP: true
+      additionalMetadata:
+      - key: "ssh-keys"
+        value: "${GCP_SSH_KEY}"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/log_collector.go
+++ b/test/e2e/log_collector.go
@@ -27,8 +27,10 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -36,7 +38,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GCPLogCollector collects serial port output from GCP VM instances using gcloud CLI.
+// GCPLogCollector collects logs from GCP VM instances using gcloud CLI.
+// It collects serial port output (always works via GCP API) and optionally
+// attempts SSH-based collection for richer logs (kubelet, containerd, cloud-init).
 type GCPLogCollector struct{}
 
 func (c GCPLogCollector) CollectMachineLog(ctx context.Context, managementClusterClient client.Client, m *clusterv1.Machine, outputPath string) error {
@@ -45,7 +49,14 @@ func (c GCPLogCollector) CollectMachineLog(ctx context.Context, managementCluste
 		return err
 	}
 
-	return collectSerialLog(ctx, project, zone, instanceName, outputPath)
+	serialErr := collectSerialLog(ctx, project, zone, instanceName, outputPath)
+
+	sshErr := collectSSHLogs(ctx, project, zone, instanceName, outputPath)
+	if sshErr != nil {
+		klog.Warningf("SSH-based log collection failed for %s (serial logs may still be available): %v", instanceName, sshErr)
+	}
+
+	return serialErr
 }
 
 func (c GCPLogCollector) CollectMachinePoolLog(_ context.Context, _ client.Client, _ *clusterv1.MachinePool, _ string) error {
@@ -138,4 +149,130 @@ func collectSerialLog(ctx context.Context, project, zone, instanceName, outputPa
 	cmd.Stderr = os.Stderr
 
 	return cmd.Run()
+}
+
+type sshLogSpec struct {
+	fileName string
+	command  string
+}
+
+func collectSSHLogs(ctx context.Context, project, zone, instanceName, outputPath string) error {
+	sshKeyFile, err := prepareSSHKeyPair()
+	if err != nil {
+		return err
+	}
+
+	specs := []sshLogSpec{
+		{"kubelet.log", "sudo journalctl --no-pager --output=short-precise -u kubelet.service"},
+		{"containerd.log", "sudo journalctl --no-pager --output=short-precise -u containerd.service"},
+		{"cloud-init.log", "sudo cat /var/log/cloud-init.log"},
+		{"cloud-init-output.log", "sudo cat /var/log/cloud-init-output.log"},
+	}
+
+	funcs := make([]func() error, 0, len(specs))
+	for _, s := range specs {
+		funcs = append(funcs, func() error {
+			return executeSSHCommand(ctx, project, zone, instanceName, outputPath, sshKeyFile, s.fileName, s.command)
+		})
+	}
+
+	return aggregateConcurrent(funcs...)
+}
+
+func executeSSHCommand(ctx context.Context, project, zone, instanceName, outputPath, sshKeyFile, fileName, command string) error {
+	if err := os.MkdirAll(outputPath, 0o750); err != nil {
+		return err
+	}
+
+	f, err := os.Create(filepath.Join(outputPath, fileName)) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	cmd := exec.CommandContext(ctx, //nolint:gosec
+		"gcloud", "compute", "ssh", "--quiet",
+		instanceName,
+		"--zone", zone,
+		"--project", project,
+		"--ssh-key-file", sshKeyFile,
+		"--command", command,
+		"--",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "ConnectTimeout=30",
+	)
+
+	output, runErr := cmd.CombinedOutput()
+	if len(output) > 0 {
+		if _, writeErr := f.Write(output); writeErr != nil {
+			return kerrors.NewAggregate([]error{runErr, writeErr})
+		}
+	}
+
+	return runErr
+}
+
+// prepareSSHKeyPair ensures gcloud compute ssh can find a matching key pair.
+// gcloud expects <key-file>.pub alongside the private key, but the test-infra
+// preset-k8s-ssh mounts them at separate paths in a read-only secret volume.
+// Copy both keys to a writable temp directory so gcloud finds the pair.
+func prepareSSHKeyPair() (string, error) {
+	privKeyFile := os.Getenv("GCE_SSH_PRIVATE_KEY_FILE")
+	if privKeyFile == "" {
+		return "", fmt.Errorf("GCE_SSH_PRIVATE_KEY_FILE not set, skipping SSH log collection")
+	}
+
+	pubKeyFile := os.Getenv("GCE_SSH_PUBLIC_KEY_FILE")
+	if pubKeyFile == "" {
+		return "", fmt.Errorf("GCE_SSH_PUBLIC_KEY_FILE not set, cannot create key pair for gcloud")
+	}
+
+	privKeyBytes, err := os.ReadFile(privKeyFile) //nolint:gosec
+	if err != nil {
+		return "", errors.Wrapf(err, "reading private key from %s", privKeyFile)
+	}
+
+	pubKeyBytes, err := os.ReadFile(pubKeyFile) //nolint:gosec
+	if err != nil {
+		return "", errors.Wrapf(err, "reading public key from %s", pubKeyFile)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "capg-ssh-*")
+	if err != nil {
+		return "", errors.Wrap(err, "creating temp directory for SSH keys")
+	}
+
+	dst := filepath.Join(tmpDir, "ssh-key")
+	if err := os.WriteFile(dst, privKeyBytes, 0o600); err != nil {
+		return "", errors.Wrapf(err, "writing private key to %s", dst)
+	}
+	if err := os.WriteFile(dst+".pub", pubKeyBytes, 0o600); err != nil {
+		return "", errors.Wrapf(err, "writing public key to %s", dst+".pub")
+	}
+
+	klog.Infof("Prepared SSH key pair at %s for gcloud compatibility", dst)
+	return dst, nil
+}
+
+func aggregateConcurrent(funcs ...func() error) error {
+	ch := make(chan error, len(funcs))
+	var wg sync.WaitGroup
+	for _, f := range funcs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ch <- f()
+		}()
+	}
+	wg.Wait()
+	close(ch)
+
+	var errs []error
+	for err := range ch {
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return kerrors.NewAggregate(errs)
 }

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -140,6 +140,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(configPath).To(BeAnExistingFile(), "Invalid test suite argument. e2e.config should be an existing file.")
 	Expect(os.MkdirAll(artifactFolder, 0o755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder)
 
+	setupSSHKeyEnv()
+
 	By("Initializing a runtime.Scheme with all the GVK relevant for this test")
 	scheme := initScheme()
 
@@ -270,4 +272,26 @@ func tearDown(bootstrapClusterProvider bootstrap.ClusterProvider, bootstrapClust
 	if bootstrapClusterProvider != nil {
 		bootstrapClusterProvider.Dispose(context.TODO())
 	}
+}
+
+// setupSSHKeyEnv reads the SSH public key injected by the test-infra preset-k8s-ssh
+// (https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/ssh-key-secret/)
+// and sets GCP_SSH_KEY for clusterctl template substitution. The preset mounts the
+// ssh-key-secret and exposes GCE_SSH_PUBLIC_KEY_FILE / GCE_SSH_PRIVATE_KEY_FILE env vars.
+func setupSSHKeyEnv() {
+	pubKeyPath, ok := os.LookupEnv("GCE_SSH_PUBLIC_KEY_FILE")
+	if !ok || pubKeyPath == "" {
+		klog.Warning("GCE_SSH_PUBLIC_KEY_FILE not set — SSH key will not be injected into VM metadata")
+		return
+	}
+
+	pubKeyBytes, err := os.ReadFile(pubKeyPath) //nolint:gosec
+	if err != nil {
+		klog.Warningf("Failed to read SSH public key from %s: %v", pubKeyPath, err)
+		return
+	}
+
+	sshKey := fmt.Sprintf("capi:%s", strings.TrimSpace(string(pubKeyBytes)))
+	os.Setenv("GCP_SSH_KEY", sshKey)
+	klog.Infof("Set GCP_SSH_KEY for VM metadata injection (key from %s)", pubKeyPath)
 }


### PR DESCRIPTION
## Summary
- Wire up the test-infra `preset-k8s-ssh` key (from [kubernetes/test-infra#36731](https://github.com/kubernetes/test-infra/pull/36731)) for SSH access to CAPG-managed VMs during e2e test failures
- Inject the SSH public key into GCP VM instance metadata via `additionalMetadata` on all non-GKE e2e cluster templates
- Pass `--ssh-key-file` with `GCE_SSH_PRIVATE_KEY_FILE` to `gcloud compute ssh` in the log collector
- Collect kubelet, containerd, and cloud-init logs via SSH alongside the existing serial port output
- Gracefully skip SSH log collection when the preset env vars are not set (e.g. local development runs)
- Enables publicIp for instances to allow for SSHing

## Test plan
- [x] Verify e2e tests still pass without `GCE_SSH_PUBLIC_KEY_FILE` / `GCE_SSH_PRIVATE_KEY_FILE` set (graceful skip)
- [x] Verify SSH log collection works in CI with `preset-k8s-ssh` enabled (kubelet.log, containerd.log, cloud-init logs collected)
  - Logs here: https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-gcp/1665/pull-cluster-api-provider-gcp-e2e-test/2055301524677988352/artifacts/clusters/capg-e2e-czqsgm-topology/machines/capg-e2e-czqsgm-topology-kqd2r-pjg7h/
- [x] Verify serial port log collection still works independently of SSH