### PR TITLE
ci: dynamically compute Ginkgo parallel nodes based on available CPUs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,6 @@ test: $(SETUP_ENVTEST) ## Run unit and integration tests
 # Allow overriding the e2e configurations
 GINKGO_FOCUS ?= Workload cluster creation
 GINKGO_SKIP ?= API Version Upgrade
-GINKGO_NODES ?= 1
 GINKGO_NOCOLOR ?= false
 GINKGO_ARGS ?=
 GINKGO_TIMEOUT ?= 2h
@@ -195,7 +194,7 @@ SKIP_CREATE_MGMT_CLUSTER ?= false
 test-e2e-run: $(ENVSUBST) $(KUBECTL) $(GINKGO) e2e-image ## Run the end-to-end tests
 	$(ENVSUBST) < $(E2E_CONF_FILE) > $(E2E_CONF_FILE_ENVSUBST) && \
 	time $(GINKGO) -v --trace -poll-progress-after=$(GINKGO_POLL_PROGRESS_AFTER) -poll-progress-interval=$(GINKGO_POLL_PROGRESS_INTERVAL) \
-	--tags=e2e --focus="$(GINKGO_FOCUS)" -skip="$(GINKGO_SKIP)" --nodes=$(GINKGO_NODES) --no-color=$(GINKGO_NOCOLOR) \
+	--tags=e2e --focus="$(GINKGO_FOCUS)" -skip="$(GINKGO_SKIP)" --no-color=$(GINKGO_NOCOLOR) \
 	--timeout=$(GINKGO_TIMEOUT) --output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" $(GINKGO_ARGS) ./test/e2e -- \
 		-e2e.artifacts-folder="$(ARTIFACTS)" \
 		-e2e.config="$(E2E_CONF_FILE_ENVSUBST)" \

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -34,8 +34,8 @@ source "${REPO_ROOT}/hack/ensure-go.sh"
 source "${REPO_ROOT}/hack/ensure-kustomize.sh"
 
 # Configure e2e tests
-export GINKGO_NODES=3
-export GINKGO_ARGS="--fail-fast" # Other ginkgo args that need to be appended to the command.
+# Use -p to dynamically compute the number of Ginkgo nodes based on the available CPUs.
+export GINKGO_ARGS="-p --fail-fast"
 ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
 mkdir -p "${ARTIFACTS}/logs/"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Replace the hardcoded `GINKGO_NODES=3` in `ci-e2e.sh` with Ginkgo's `--parallel` flag, which dynamically sets the number of parallel test nodes based on available CPUs. Remove the now-unused `GINKGO_NODES` variable from the Makefile.

Local `make test-e2e` runs remain single-node (Ginkgo's default), CI runs auto-detect from CPU count.

**Note:** this PR pairs with [kubernetes/test-infra#37046](https://github.com/kubernetes/test-infra/pull/37046), which bumps CPU requests for CAPG e2e jobs from 2 to 4 cores. That PR should merge first to avoid a temporary regression from 3→2 nodes.

**Release note**:
```release-note
NONE
```