### PR TITLE
release: add release-notes automation scripts and improve release docs

### DIFF
--- a/docs/book/src/developers/releasing.md
+++ b/docs/book/src/developers/releasing.md
@@ -31,13 +31,13 @@
 
  1. Add a git remote to the upstream project. git remote add upstream `git@github.com:kubernetes-sigs/cluster-api-provider-gcp.git`
 
- 1. If this is a major or minor release, create a new release branch and push to GitHub, otherwise switch to it, e.g. `git checkout release-1.7`.
+ 1. If this is a major or minor release, create a new release branch `git checkout -b release-1.7`. Otherwise if it is a patch release the branch should already exist to it, fetch the latest and sync up your local branch: e.g. `git fetch upstream release-1.7 && git checkout release-1.7 && git reset upstream/release-1.7 --hard`.
 
- 1. If this is a major or minor release, update metadata.yaml by adding a new section with the version, and make a commit.
+ 1. If this is a major or minor release, update `metadata.yaml` by adding a new section with the version, and make a commit.
 
- 1. Update the release branch on the repository, e.g. `git push origin HEAD:release-1.7`. origin refers to the remote git reference to your fork.
+ 1. Push new/existing release branch to your repository's fork, e.g. `git push origin HEAD:release-1.7`. origin refers to the remote git reference to your fork.
 
- 1. Update the release branch on the repository, e.g. git push upstream HEAD:release-1.7. upstream refers to the upstream git reference.
+ 1. Push new/existing release branch to the upstream repository, e.g. `git push upstream HEAD:release-1.7`. upstream refers to the upstream git reference.
 
  1. Make sure your repo is clean by git standards.
 
@@ -58,20 +58,33 @@
 
 1. Generate release-notes (requires exported `GITHUB_TOKEN` variable, ensure the TOKEN is not expired!):
 
-    Run the release-notes tool with the appropriate commits. Commits range from the first commit after the previous non-beta release to the newest commit of the release branch. Set branch to the release branch you are cutting this release from. For example if this is release `v1.11.z`, branch is going to be `release-1.11`. When this finishes it will log the path to the temporary file where the notes have been written.
+    Commits range from the first commit after the previous non-beta release to the newest commit of the release branch. Set branch to the release branch you are cutting this release from. For example if this is release `v1.11.z`, branch is going to be `release-1.11`.
+
+    First, compute the required variables. Review the output and verify the values are correct before proceeding:
+
+    ```bash
+    source ./hack/compute-release-notes-vars.sh
+    ```
+
+    Once the values look correct, run the release-notes tool. When this finishes it will log the path to the temporary file where the notes have been written:
 
     ```bash
     release-notes --org kubernetes-sigs --repo cluster-api-provider-gcp \
-    --start-sha 1cf1ec4a1effd9340fe7370ab45b173a4979dc8f  \
-    --end-sha e843409f896981185ca31d6b4a4c939f27d975de \
-    --branch <NEW_RELEASE_BRANCH_OR_MAIN_BRANCH>
+    --start-rev "${PREVIOUS_TAG}" \
+    --end-rev "${VERSION}" \
+    --branch "${RELEASE_BRANCH}" \
+    --required-author "" \
+    --go-template "go-template:hack/release-notes.tpl"
     ```
 
-1. Open the output temporary file logged by the tool and manually format and categorize the release notes
+    > **Note**: The `--required-author ""` flag is needed because the tool defaults to only processing commits authored by `k8s-ci-robot`, which would skip most PRs since CAPG uses squash merges that preserve the original author.
+
+1. Open the output temporary file logged by the tool and manually format and categorize the release notes.
 
 ## Prepare release in GitHub
 
-Create the GitHub release in the UI
+Create the GitHub release in the UI:
+
  - Go to: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases  
  - Create a draft release with the output from above in GitHub and associate it with the tag that was created
  - Copy paste the release notes
@@ -93,6 +106,7 @@ To promote images from the staging repository to the production registry (`regis
 
       ```bash
       # Export the tag of the release to be cut, e.g.:
+      export USER_FORK=<personal GitHub handle> # if needed (see notes below)
       export VERSION=v1.11.0-beta.0
       export GITHUB_TOKEN=<your GH token>
       make promote-images

--- a/hack/compute-release-notes-vars.sh
+++ b/hack/compute-release-notes-vars.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script computes and exports environment variables needed to run the
+# release-notes tool. It is meant to be sourced, not executed directly.
+# Required input: VERSION and GITHUB_TOKEN must be set in the caller's env.
+# If you edit this script, run hack/test-compute-release-notes-vars.sh to
+# verify it still works correctly.
+
+echo "Computing release-notes env vars..."
+echo ""
+
+# Validate required input variables.
+if [ -z "${VERSION:-}" ]; then echo "ERROR: VERSION is not set" >&2; return 1; fi
+if [ -z "${GITHUB_TOKEN:-}" ]; then echo "ERROR: GITHUB_TOKEN is not set" >&2; return 1; fi
+
+# Clear any stale values from a previous run.
+unset RELEASE_BRANCH PREVIOUS_TAG
+
+# Derive the release branch from VERSION (e.g. v1.12.1 -> release-1.12).
+# Fall back to main if the branch doesn't exist yet (common for early betas).
+RELEASE_BRANCH="release-$(echo "${VERSION}" | sed -E 's/^v([0-9]+\.[0-9]+)\..*/\1/')"
+if ! git ls-remote --exit-code --heads upstream "${RELEASE_BRANCH}" > /dev/null 2>&1; then
+  RELEASE_BRANCH="main"
+fi
+
+# Fetch the release branch and all tags from upstream.
+git fetch upstream "${RELEASE_BRANCH}" --tags > /dev/null 2>&1
+
+# Find the most recent stable release tag before VERSION using git ancestry.
+# Lists all tags merged into VERSION (i.e. ancestors), then strips any
+# prerelease suffix (e.g. v1.11.0-beta.0 -> v1.11.0) to resolve to the
+# stable release for that series. Skips tags that resolve to VERSION itself.
+#
+# Note: the release-notes tool does not use git ancestry to determine which
+# commits to include. Instead, it queries the GitHub API with Since/Until
+# parameters based on the commit dates of PREVIOUS_TAG and VERSION. This is
+# equivalent to:
+#   git rev-list HEAD \
+#     --after="$(git log -1 --format='%cI' "${PREVIOUS_TAG}")" \
+#     --before="$(git log -1 --format='%cI' "${VERSION}")"
+# So PREVIOUS_TAG determines the start of the date window, making it important
+# that it points to the right release even if it's not a direct git ancestor.
+# Examples:
+#   v1.12.0       -> v1.11.0
+#   v1.11.2       -> v1.11.1
+#   v1.11.1       -> v1.11.0
+#   v1.11.0       -> v1.10.0
+#   v1.11.0-beta.0 -> v1.10.0
+PREVIOUS_TAG=$(git tag --merged "${VERSION}" --sort=-v:refname | while read -r tag; do
+  if [ "${tag}" = "${VERSION}" ]; then continue; fi
+  resolved=$(echo "${tag}" | sed -E 's/-.*//')
+  if [ "${resolved}" = "${VERSION}" ]; then continue; fi
+  echo "${resolved}"; break
+done)
+
+export RELEASE_BRANCH PREVIOUS_TAG
+
+echo "VERSION=${VERSION}"
+echo "RELEASE_BRANCH=${RELEASE_BRANCH}"
+echo "PREVIOUS_TAG=${PREVIOUS_TAG}"
+echo ""
+echo "These variables have been exported in your current shell."
+echo "If the values look correct, proceed to run the release-notes tool."

--- a/hack/release-notes.tpl
+++ b/hack/release-notes.tpl
@@ -1,0 +1,20 @@
+{{- $CurrentRevision := .CurrentRevision -}}
+{{- $PreviousRevision := .PreviousRevision -}}
+## Changelog since {{$PreviousRevision}}
+
+{{with .NotesWithActionRequired -}}
+## Urgent Upgrade Notes
+
+### (No, really, you MUST read this before you upgrade)
+
+{{range .}}{{println "-" .}} {{end}}
+{{end}}
+
+{{- if .Notes -}}
+## Changes by Kind
+{{ range .Notes}}
+### {{.Kind | prettyKind}}
+
+{{range $note := .NoteEntries }}{{println "-" $note}}{{end}}
+{{- end -}}
+{{- end -}}

--- a/hack/test-compute-release-notes-vars.sh
+++ b/hack/test-compute-release-notes-vars.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test for hack/compute-release-notes-vars.sh
+# Verifies PREVIOUS_TAG resolution against the real git history.
+# Requires the upstream remote to be configured.
+
+SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+PASS=0
+FAIL=0
+
+assert_previous_tag() {
+  local version="${1}"
+  local expected="${2}"
+
+  # shellcheck source=hack/compute-release-notes-vars.sh
+  VERSION="${version}" GITHUB_TOKEN="test" source "${SCRIPT_DIR}/compute-release-notes-vars.sh" > /dev/null 2>&1
+
+  if [ "${PREVIOUS_TAG}" = "${expected}" ]; then
+    echo "PASS: VERSION=${version} -> PREVIOUS_TAG=${PREVIOUS_TAG}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: VERSION=${version} -> PREVIOUS_TAG=${PREVIOUS_TAG} (expected ${expected})"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "Running compute-release-notes-vars tests..."
+echo ""
+
+assert_previous_tag "v1.12.0"        "v1.11.0"
+assert_previous_tag "v1.11.2"        "v1.11.1"
+assert_previous_tag "v1.11.1"        "v1.11.0"
+assert_previous_tag "v1.11.0"        "v1.10.0"
+assert_previous_tag "v1.11.0-beta.0" "v1.10.0"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [ "${FAIL}" -gt 0 ]; then
+  return 1 2>/dev/null || exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `hack/compute-release-notes-vars.sh` to automatically compute `RELEASE_BRANCH` and `PREVIOUS_TAG` from the `VERSION` env var, supporting both stable and prerelease versions
- Add `hack/release-notes.tpl` as a custom Go template for the release-notes tool that includes a "Changelog since" header
- Update `releasing.md` to reference the new scripts and use `--start-rev`/`--end-rev` with tag names instead of hardcoded SHAs

## Test plan
- [x] Tested `source ./hack/compute-release-notes-vars.sh` with stable version (v1.11.0)
- [x] Tested with prerelease version (v1.11.0-beta.0)
- [x] Verified release-notes tool runs successfully with computed variables