### PR TITLE
Make GCPCluster network name and subnets immutable

### DIFF
--- a/webhooks/gcpcluster_webhook.go
+++ b/webhooks/gcpcluster_webhook.go
@@ -103,6 +103,20 @@ func (*GCPCluster) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Obje
 		)
 	}
 
+	if !reflect.DeepEqual(c.Spec.Network.Name, old.Spec.Network.Name) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "network", "name"),
+				c.Spec.Network.Name, "field is immutable"),
+		)
+	}
+
+	if !reflect.DeepEqual(c.Spec.Network.Subnets, old.Spec.Network.Subnets) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "network", "subnets"),
+				c.Spec.Network.Subnets, "field is immutable"),
+		)
+	}
+
 	if c.Spec.Network.Mtu < int64(1300) {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "Network", "Mtu"),

--- a/webhooks/gcpcluster_webhook_test.go
+++ b/webhooks/gcpcluster_webhook_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 )
 
@@ -211,6 +212,58 @@ func TestGCPCluster_ValidateUpdate(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "GCPCluster with immutable network name",
+			newCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
+						Name: ptr.To("new-network"),
+						Mtu:  int64(1500),
+					},
+				},
+			},
+			oldCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
+						Name: ptr.To("old-network"),
+						Mtu:  int64(1500),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "GCPCluster with immutable network subnets",
+			newCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
+						Mtu: int64(1500),
+						Subnets: infrav1.Subnets{
+							{
+								Name:      "new-subnet",
+								CidrBlock: "10.1.0.0/24",
+								Region:    "us-central1",
+							},
+						},
+					},
+				},
+			},
+			oldCluster: &infrav1.GCPCluster{
+				Spec: infrav1.GCPClusterSpec{
+					Network: infrav1.NetworkSpec{
+						Mtu: int64(1500),
+						Subnets: infrav1.Subnets{
+							{
+								Name:      "old-subnet",
+								CidrBlock: "10.0.0.0/24",
+								Region:    "us-central1",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #1576

This updates the GCPCluster validating webhook to reject updates to `spec.network.name` and `spec.network.subnets`. Changing those fields after infrastructure has been provisioned can leave existing machines on the old VPC/subnets while future reconciliation uses the new network configuration.

The PR also adds webhook unit coverage for both immutable fields.

Tests:
- `go test ./webhooks`
- `KUBEBUILDER_ASSETS="/Users/agentzero/Library/Application Support/io.kubebuilder.envtest/k8s/1.34.0-darwin-arm64" go test ./api/... ./webhooks/...`

```release-note
GCPCluster `spec.network.name` and `spec.network.subnets` are now immutable.
```