### PR TITLE
fix: allow GCPMachineTemplate network tag updates

### DIFF
--- a/webhooks/gcpmachinetemplate_webhook.go
+++ b/webhooks/gcpmachinetemplate_webhook.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
@@ -70,17 +71,10 @@ func (*GCPMachineTemplate) ValidateUpdate(_ context.Context, oldObj, r *infrav1.
 	newGCPMachineTemplateSpec := newGCPMachineTemplate["spec"].(map[string]interface{})
 	oldGCPMachineTemplateSpec := oldGCPMachineTemplate["spec"].(map[string]interface{})
 
-	// allow changes to providerID
-	delete(oldGCPMachineTemplateSpec, "providerID")
-	delete(newGCPMachineTemplateSpec, "providerID")
-
-	// allow changes to additionalLabels
-	delete(oldGCPMachineTemplateSpec, "additionalLabels")
-	delete(newGCPMachineTemplateSpec, "additionalLabels")
-
-	// allow changes to additionalNetworkTags
-	delete(oldGCPMachineTemplateSpec, "additionalNetworkTags")
-	delete(newGCPMachineTemplateSpec, "additionalNetworkTags")
+	for _, fieldName := range []string{"providerID", "additionalLabels", "additionalNetworkTags"} {
+		unstructured.RemoveNestedField(oldGCPMachineTemplateSpec, "template", "spec", fieldName)
+		unstructured.RemoveNestedField(newGCPMachineTemplateSpec, "template", "spec", fieldName)
+	}
 
 	if !reflect.DeepEqual(oldGCPMachineTemplateSpec, newGCPMachineTemplateSpec) {
 		return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("GCPMachineTemplate").GroupKind(), r.Name, field.ErrorList{

--- a/webhooks/gcpmachinetemplate_webhook.go
+++ b/webhooks/gcpmachinetemplate_webhook.go
@@ -71,6 +71,7 @@ func (*GCPMachineTemplate) ValidateUpdate(_ context.Context, oldObj, r *infrav1.
 	newGCPMachineTemplateSpec := newGCPMachineTemplate["spec"].(map[string]interface{})
 	oldGCPMachineTemplateSpec := oldGCPMachineTemplate["spec"].(map[string]interface{})
 
+	// allow changes to providerID, additionalLabels and additionalNetworkTags
 	for _, fieldName := range []string{"providerID", "additionalLabels", "additionalNetworkTags"} {
 		unstructured.RemoveNestedField(oldGCPMachineTemplateSpec, "template", "spec", fieldName)
 		unstructured.RemoveNestedField(newGCPMachineTemplateSpec, "template", "spec", fieldName)

--- a/webhooks/gcpmachinetemplate_webhook_test.go
+++ b/webhooks/gcpmachinetemplate_webhook_test.go
@@ -243,3 +243,71 @@ func TestGCPMachineTemplate_ValidateCreate(t *testing.T) {
 		})
 	}
 }
+
+func TestGCPMachineTemplate_ValidateUpdate(t *testing.T) {
+	tests := []struct {
+		name        string
+		oldTemplate *infrav1.GCPMachineTemplate
+		newTemplate *infrav1.GCPMachineTemplate
+		wantErr     bool
+	}{
+		{
+			name: "allows changing only additionalNetworkTags",
+			oldTemplate: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
+							InstanceType: "n2d-standard-4",
+						},
+					},
+				},
+			},
+			newTemplate: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
+							InstanceType:          "n2d-standard-4",
+							AdditionalNetworkTags: []string{"new-tag"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "rejects changing instanceType",
+			oldTemplate: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
+							InstanceType: "n2d-standard-4",
+						},
+					},
+				},
+			},
+			newTemplate: &infrav1.GCPMachineTemplate{
+				Spec: infrav1.GCPMachineTemplateSpec{
+					Template: infrav1.GCPMachineTemplateResource{
+						Spec: infrav1.GCPMachineSpec{
+							InstanceType: "n2d-standard-8",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			warn, err := (&GCPMachineTemplate{}).ValidateUpdate(t.Context(), test.oldTemplate, test.newTemplate)
+			if test.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			g.Expect(warn).To(BeNil())
+		})
+	}
+}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`GCPMachineTemplate` update validation intended to allow changes to `providerID`, `additionalLabels`, and `additionalNetworkTags`, but it removed those keys from the top-level `spec` map before comparing objects.

Those fields live under `spec.template.spec` for machine templates, so changes to `additionalNetworkTags` still made the webhook reject the update as an immutable `spec` change. This removes the allowed mutable fields at the nested template-spec path before comparison and keeps unrelated template changes immutable.

**Which issue(s) this PR fixes**:
Fixes #1693

**Special notes for your reviewer**:

Added focused unit coverage for allowing `additionalNetworkTags` changes while still rejecting an `instanceType` change.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
fix(webhooks): allow updates to GCPMachineTemplate additionalNetworkTags
```
