### PR TITLE
fix: fetch GCPManagedMachinePools in order

### DIFF
--- a/cloud/scope/managedcontrolplane.go
+++ b/cloud/scope/managedcontrolplane.go
@@ -28,6 +28,7 @@ import (
 	credentials "cloud.google.com/go/iam/credentials/apiv1"
 	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -190,15 +191,21 @@ func (s *ManagedControlPlaneScope) GetAllNodePools(ctx context.Context) ([]infra
 		if err := s.client.List(ctx, machinePoolList, listOptions...); err != nil {
 			return nil, nil, err
 		}
-		managedMachinePoolList := &infrav1exp.GCPManagedMachinePoolList{}
-		if err := s.client.List(ctx, managedMachinePoolList, listOptions...); err != nil {
-			return nil, nil, err
-		}
-		if len(machinePoolList.Items) != len(managedMachinePoolList.Items) {
-			return nil, nil, fmt.Errorf("machinePoolList length (%d) != managedMachinePoolList length (%d)", len(machinePoolList.Items), len(managedMachinePoolList.Items))
-		}
+
 		s.AllMachinePools = machinePoolList.Items
-		s.AllManagedMachinePools = managedMachinePoolList.Items
+		s.AllManagedMachinePools = []infrav1exp.GCPManagedMachinePool{}
+		for _, machinePool := range s.AllMachinePools {
+			managedMachinePool := infrav1exp.GCPManagedMachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      machinePool.Spec.Template.Spec.InfrastructureRef.Name,
+					Namespace: machinePool.GetNamespace(),
+				},
+			}
+			if err := s.client.Get(ctx, client.ObjectKeyFromObject(&managedMachinePool), &managedMachinePool); err != nil {
+				return nil, nil, fmt.Errorf("getting GCPManagedMachinePool %s for MachinePool %s: %w", managedMachinePool.GetName(), machinePool.GetName(), err)
+			}
+			s.AllManagedMachinePools = append(s.AllManagedMachinePools, managedMachinePool)
+		}
 	}
 
 	return s.AllManagedMachinePools, s.AllMachinePools, nil


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

This PR fixes a bug where GCPManagedMachinePools and MachinePools are sorted in the wrong order.
This creates wrong comparisons that result in `GCPManagedControlPlane` reconciliation errors like:
```
status:
  conditions:
  - lastTransitionTime: 2026-06-30T01:47:56Z
    message: "creating cluster: preflight checks on machine pools before cluster create: expect machinepool infraref (cluster-gke-9tzw7a-system-pool-dlcjd) to match managed machine pool name (cluster-gke-9tzw7a-worker-pool-94j8l)"
    reason: GKEControlPlaneReconciliationFailed
    severity: Error
    status: "False"
    type: Ready
```

The code is now ensuring the GCPManagedMachinePool list is in the same order as the MachinePool list.

Also note that there was a check to ensure that the number of GCPManagedMachinePools and MachinePools are the same. I couldn't find a reason for this check to exist, given that GCPManagedMachinePools are owned by MachinePools, so the number should always be implicitly the same. Ownership should also guarantee GCPManagedMachinePool deletion once the owner MachinePool is deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: GCPManagedControlPlane reconciliation error when multiple GCPManagedMachinePools are in use
```
