### PR TITLE
Fix MonitoringService update writing to DesiredLoggingService

### DIFF
--- a/cloud/services/container/clusters/reconcile.go
+++ b/cloud/services/container/clusters/reconcile.go
@@ -512,7 +512,7 @@ func (s *Service) checkDiffAndPrepareUpdate(existingCluster *containerpb.Cluster
 	if specMonitoringService := s.scope.GCPManagedControlPlane.Spec.MonitoringService; specMonitoringService != nil {
 		if existingCluster.GetMonitoringService() != specMonitoringService.String() {
 			needUpdate = true
-			clusterUpdate.DesiredLoggingService = specMonitoringService.String()
+			clusterUpdate.DesiredMonitoringService = specMonitoringService.String()
 			log.V(2).Info("MonitoringService config update required", "current", existingCluster.GetMonitoringService(), "desired", specMonitoringService.String())
 		}
 	}

--- a/cloud/services/container/clusters/reconcile_test.go
+++ b/cloud/services/container/clusters/reconcile_test.go
@@ -119,6 +119,32 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "update needed when monitoring service differs",
+			controlPlane: &infrav1exp.GCPManagedControlPlane{
+				Spec: infrav1exp.GCPManagedControlPlaneSpec{
+					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
+						Project:           "test-project",
+						Location:          "us-central1",
+						MonitoringService: ptr.To(infrav1exp.MonitoringService("none")),
+					},
+					ClusterName: "test-cluster",
+				},
+			},
+			existingCluster: &containerpb.Cluster{
+				MonitoringService: "monitoring.googleapis.com/kubernetes",
+			},
+			wantNeedUpdate: true,
+			validateUpdateFunc: func(t *testing.T, req *containerpb.UpdateClusterRequest) {
+				t.Helper()
+				if req.GetUpdate().GetDesiredMonitoringService() != "none" {
+					t.Errorf("expected DesiredMonitoringService to be set to %q, got %q", "none", req.GetUpdate().GetDesiredMonitoringService())
+				}
+				if req.GetUpdate().GetDesiredLoggingService() != "" {
+					t.Errorf("expected DesiredLoggingService to be left unset, got %q", req.GetUpdate().GetDesiredLoggingService())
+				}
+			},
+		},
+		{
 			name: "no panic when existing cluster has nil ControlPlaneEndpointsConfig",
 			controlPlane: &infrav1exp.GCPManagedControlPlane{
 				Spec: infrav1exp.GCPManagedControlPlaneSpec{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`checkDiffAndPrepareUpdate`'s `MonitoringService` diff block was setting `clusterUpdate.DesiredLoggingService` instead of `clusterUpdate.DesiredMonitoringService`. This meant changing `spec.monitoringService` on an existing `GCPManagedControlPlane` silently overwrote `LoggingService` instead of updating monitoring.

**Which issue(s) this PR fixes**:
Fixes #1716

**Special notes for your reviewer**:

Added a regression test (`update needed when monitoring service differs`) that fails against the old code and passes with the fix.

**TODOs**:
- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
fix: updating `GCPManagedControlPlane.spec.monitoringService` incorrectly updated the GKE cluster's logging  service instead of monitoring
```