### PR TITLE
CORS-4421: Add universe domain support for sovereign clouds

### DIFF
--- a/cloud/scope/clients.go
+++ b/cloud/scope/clients.go
@@ -19,6 +19,7 @@ package scope
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/pkg/errors"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
 	"k8s.io/client-go/pkg/version"
@@ -96,16 +98,41 @@ func defaultClientOptions(ctx context.Context, credentialsRef *infrav1.ObjectRef
 			return nil, fmt.Errorf("parsing gcp credential type from reference %s: %w", credentialsRef, err)
 		}
 
+		var optCredType option.CredentialsType
+		var googleCredType google.CredentialsType
 		switch header.Type {
 		case "service_account":
-			opts = append(opts, option.WithAuthCredentialsJSON(option.ServiceAccount, rawData))
+			optCredType = option.ServiceAccount
+			googleCredType = google.ServiceAccount
 		case "external_account":
-			opts = append(opts, option.WithAuthCredentialsJSON(option.ExternalAccount, rawData))
+			optCredType = option.ExternalAccount
+			googleCredType = google.ExternalAccount
 		case "impersonated_service_account":
-			opts = append(opts, option.WithAuthCredentialsJSON(option.ImpersonatedServiceAccount, rawData))
+			optCredType = option.ImpersonatedServiceAccount
+			googleCredType = google.ImpersonatedServiceAccount
 		default:
-			opts = append(opts, option.WithAuthCredentialsJSON(option.ServiceAccount, rawData))
+			optCredType = option.ServiceAccount
+			googleCredType = google.ServiceAccount
 		}
+		opts = append(opts, option.WithAuthCredentialsJSON(optCredType, rawData))
+
+		// Extract credentials to get universe domain for sovereign clouds
+		// Use CredentialsFromJSONWithType to avoid deprecated CredentialsFromJSON
+		creds, err := google.CredentialsFromJSONWithType(ctx, rawData, googleCredType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract credentials from JSON: %w", err)
+		}
+
+		// CredentialsFromJSONWithType never returns (nil, nil), but guard defensively.
+		if creds == nil {
+			return nil, stderrors.New("credentials are nil after parsing JSON")
+		}
+
+		universeDomain, err := creds.GetUniverseDomain()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get universe domain from credentials: %w", err)
+		}
+		opts = append(opts, option.WithUniverseDomain(universeDomain))
 	}
 
 	return opts, nil

--- a/cloud/scope/universedomain.go
+++ b/cloud/scope/universedomain.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+const (
+	// DefaultUniverseDomain is the default universe domain for GCP.
+	DefaultUniverseDomain = "googleapis.com"
+)
+
+// IsNonDefaultUniverseDomain checks if the given universe domain differs from the default.
+func IsNonDefaultUniverseDomain(universeDomain string) bool {
+	return universeDomain != "" && universeDomain != DefaultUniverseDomain
+}

--- a/cloud/scope/universedomain_test.go
+++ b/cloud/scope/universedomain_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import "testing"
+
+func TestIsNonDefaultUniverseDomain(t *testing.T) {
+	tests := []struct {
+		name           string
+		universeDomain string
+		want           bool
+	}{
+		{
+			name:           "default googleapis.com",
+			universeDomain: "googleapis.com",
+			want:           false,
+		},
+		{
+			name:           "empty string",
+			universeDomain: "",
+			want:           false,
+		},
+		{
+			name:           "sovereign cloud domain",
+			universeDomain: "googleapis.example.com",
+			want:           true,
+		},
+		{
+			name:           "custom universe domain",
+			universeDomain: "custom.universe.domain",
+			want:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsNonDefaultUniverseDomain(tt.universeDomain)
+			if got != tt.want {
+				t.Errorf("IsNonDefaultUniverseDomain(%q) = %v, want %v", tt.universeDomain, got, tt.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect; indirect// indirect
 	golang.org/x/exp v0.0.0-20260727155853-b88d891fe743 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect


### PR DESCRIPTION
Add support for alternate universe domains in GCP client initialization to enable sovereign cloud environments like Google Cloud Distributed (GCD).

Changes:
- Extract universe domain from credentials using GetUniverseDomain()
- Set universe domain via option.WithUniverseDomain() for all GCP clients
- Add IsNonDefaultUniverseDomain() helper for validation
- Add unit tests for universe domain helper

This implementation uses option.WithAuthCredentialsJSON() which employs self-signed JWT authentication instead of OAuth2, avoiding issues with non-existent OAuth2 token endpoints in sovereign clouds.

The universe domain is now properly extracted from JSON credentials and applied to all GCP service clients (compute, container, IAM, etc.), ensuring API calls use the correct endpoints for non-default environments.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
/kind feature

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
CORS-4421

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for GCP sovereign clouds by detecting and configuring alternate universe domains from credential
```
