### PR TITLE
fix: allow colons in KMS project IDs for sovereign cloud support

### DIFF
--- a/api/v1beta1/gcpmachine_types.go
+++ b/api/v1beta1/gcpmachine_types.go
@@ -167,7 +167,7 @@ type ManagedKey struct {
 	// KMSKeyName is the name of the encryption key that is stored in Google Cloud KMS. For example:
 	// "kmsKeyName": "projects/kms_project_id/locations/region/keyRings/key_region/cryptoKeys/key
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern=`projects\/[-_[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+`
+	// +kubebuilder:validation:Pattern=`projects\/[-_:[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+`
 	// +kubebuilder:validation:MaxLength=160
 	KMSKeyName string `json:"kmsKeyName,omitempty"`
 }
@@ -207,7 +207,7 @@ type CustomerEncryptionKey struct {
 	// The maximum length is based on the Service Account ID (max 30), Project (max 30), and a valid gcloud email
 	// suffix ("iam.gserviceaccount.com").
 	// +kubebuilder:validation:MaxLength=85
-	// +kubebuilder:validation:Pattern=`[-_[A-Za-z0-9]+@[-_[A-Za-z0-9]+.iam.gserviceaccount.com`
+	// +kubebuilder:validation:Pattern=`[-_.[A-Za-z0-9]+@[-_.[A-Za-z0-9]+.iam.gserviceaccount.com`
 	// +optional
 	KMSKeyServiceAccount *string `json:"kmsKeyServiceAccount,omitempty"`
 	// ManagedKey references keys managed by the Cloud Key Management Service. This should be set when KeyType is Managed.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinepools.yaml
@@ -88,7 +88,7 @@ spec:
                             The maximum length is based on the Service Account ID (max 30), Project (max 30), and a valid gcloud email
                             suffix ("iam.gserviceaccount.com").
                           maxLength: 85
-                          pattern: '[-_[A-Za-z0-9]+@[-_[A-Za-z0-9]+.iam.gserviceaccount.com'
+                          pattern: '[-_.[A-Za-z0-9]+@[-_.[A-Za-z0-9]+.iam.gserviceaccount.com'
                           type: string
                         managedKey:
                           description: ManagedKey references keys managed by the Cloud
@@ -100,7 +100,7 @@ spec:
                                 KMSKeyName is the name of the encryption key that is stored in Google Cloud KMS. For example:
                                 "kmsKeyName": "projects/kms_project_id/locations/region/keyRings/key_region/cryptoKeys/key
                               maxLength: 160
-                              pattern: projects\/[-_[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+
+                              pattern: projects\/[-_:[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+
                               type: string
                           required:
                           - kmsKeyName
@@ -360,7 +360,7 @@ spec:
                       The maximum length is based on the Service Account ID (max 30), Project (max 30), and a valid gcloud email
                       suffix ("iam.gserviceaccount.com").
                     maxLength: 85
-                    pattern: '[-_[A-Za-z0-9]+@[-_[A-Za-z0-9]+.iam.gserviceaccount.com'
+                    pattern: '[-_.[A-Za-z0-9]+@[-_.[A-Za-z0-9]+.iam.gserviceaccount.com'
                     type: string
                   managedKey:
                     description: ManagedKey references keys managed by the Cloud Key
@@ -371,7 +371,7 @@ spec:
                           KMSKeyName is the name of the encryption key that is stored in Google Cloud KMS. For example:
                           "kmsKeyName": "projects/kms_project_id/locations/region/keyRings/key_region/cryptoKeys/key
                         maxLength: 160
-                        pattern: projects\/[-_[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+
+                        pattern: projects\/[-_:[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+
                         type: string
                     required:
                     - kmsKeyName

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachines.yaml
@@ -98,7 +98,7 @@ spec:
                             The maximum length is based on the Service Account ID (max 30), Project (max 30), and a valid gcloud email
                             suffix ("iam.gserviceaccount.com").
                           maxLength: 85
-                          pattern: '[-_[A-Za-z0-9]+@[-_[A-Za-z0-9]+.iam.gserviceaccount.com'
+                          pattern: '[-_.[A-Za-z0-9]+@[-_.[A-Za-z0-9]+.iam.gserviceaccount.com'
                           type: string
                         managedKey:
                           description: ManagedKey references keys managed by the Cloud
@@ -110,7 +110,7 @@ spec:
                                 KMSKeyName is the name of the encryption key that is stored in Google Cloud KMS. For example:
                                 "kmsKeyName": "projects/kms_project_id/locations/region/keyRings/key_region/cryptoKeys/key
                               maxLength: 160
-                              pattern: projects\/[-_[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+
+                              pattern: projects\/[-_:[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+
                               type: string
                           required:
                           - kmsKeyName
@@ -393,7 +393,7 @@ spec:
                       The maximum length is based on the Service Account ID (max 30), Project (max 30), and a valid gcloud email
                       suffix ("iam.gserviceaccount.com").
                     maxLength: 85
-                    pattern: '[-_[A-Za-z0-9]+@[-_[A-Za-z0-9]+.iam.gserviceaccount.com'
+                    pattern: '[-_.[A-Za-z0-9]+@[-_.[A-Za-z0-9]+.iam.gserviceaccount.com'
                     type: string
                   managedKey:
                     description: ManagedKey references keys managed by the Cloud Key
@@ -404,7 +404,7 @@ spec:
                           KMSKeyName is the name of the encryption key that is stored in Google Cloud KMS. For example:
                           "kmsKeyName": "projects/kms_project_id/locations/region/keyRings/key_region/cryptoKeys/key
                         maxLength: 160
-                        pattern: projects\/[-_[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+
+                        pattern: projects\/[-_:[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+
                         type: string
                     required:
                     - kmsKeyName

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmachinetemplates.yaml
@@ -111,7 +111,7 @@ spec:
                                     The maximum length is based on the Service Account ID (max 30), Project (max 30), and a valid gcloud email
                                     suffix ("iam.gserviceaccount.com").
                                   maxLength: 85
-                                  pattern: '[-_[A-Za-z0-9]+@[-_[A-Za-z0-9]+.iam.gserviceaccount.com'
+                                  pattern: '[-_.[A-Za-z0-9]+@[-_.[A-Za-z0-9]+.iam.gserviceaccount.com'
                                   type: string
                                 managedKey:
                                   description: ManagedKey references keys managed
@@ -123,7 +123,7 @@ spec:
                                         KMSKeyName is the name of the encryption key that is stored in Google Cloud KMS. For example:
                                         "kmsKeyName": "projects/kms_project_id/locations/region/keyRings/key_region/cryptoKeys/key
                                       maxLength: 160
-                                      pattern: projects\/[-_[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+
+                                      pattern: projects\/[-_:[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+
                                       type: string
                                   required:
                                   - kmsKeyName
@@ -408,7 +408,7 @@ spec:
                               The maximum length is based on the Service Account ID (max 30), Project (max 30), and a valid gcloud email
                               suffix ("iam.gserviceaccount.com").
                             maxLength: 85
-                            pattern: '[-_[A-Za-z0-9]+@[-_[A-Za-z0-9]+.iam.gserviceaccount.com'
+                            pattern: '[-_.[A-Za-z0-9]+@[-_.[A-Za-z0-9]+.iam.gserviceaccount.com'
                             type: string
                           managedKey:
                             description: ManagedKey references keys managed by the
@@ -420,7 +420,7 @@ spec:
                                   KMSKeyName is the name of the encryption key that is stored in Google Cloud KMS. For example:
                                   "kmsKeyName": "projects/kms_project_id/locations/region/keyRings/key_region/cryptoKeys/key
                                 maxLength: 160
-                                pattern: projects\/[-_[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+
+                                pattern: projects\/[-_:[A-Za-z0-9]+\/locations\/[-_[A-Za-z0-9]+\/keyRings\/[-_[A-Za-z0-9]+\/cryptoKeys\/[-_[A-Za-z0-9]+
                                 type: string
                             required:
                             - kmsKeyName


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->
/kind bug

**What this PR does / why we need it**:

Allow full project format. for sovereign clouds. The project name includes the colon which was not a character that was previously allowed. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix(gcpmachine_types): allow colons in KMS project IDs for sovereign cloud support
```
