### PR TITLE
Remove reliance on controller-runtime from api packages

### DIFF
--- a/api/v1beta1/gcpcluster_types.go
+++ b/api/v1beta1/gcpcluster_types.go
@@ -114,5 +114,5 @@ type GCPClusterList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&GCPCluster{}, &GCPClusterList{})
+	objectTypes = append(objectTypes, &GCPCluster{}, &GCPClusterList{})
 }

--- a/api/v1beta1/gcpclustertemplate_types.go
+++ b/api/v1beta1/gcpclustertemplate_types.go
@@ -36,6 +36,10 @@ type GCPClusterTemplateResource struct {
 	Spec GCPClusterSpec `json:"spec"`
 }
 
+func init() {
+	objectTypes = append(objectTypes, &GCPClusterTemplate{}, &GCPClusterTemplateList{})
+}
+
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=gcpclustertemplates,scope=Namespaced,categories=cluster-api,shortName=gcpct
 // +kubebuilder:storageversion
@@ -55,8 +59,4 @@ type GCPClusterTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []GCPClusterTemplate `json:"items"`
-}
-
-func init() {
-	SchemeBuilder.Register(&GCPClusterTemplate{}, &GCPClusterTemplateList{})
 }

--- a/api/v1beta1/gcpmachine_types.go
+++ b/api/v1beta1/gcpmachine_types.go
@@ -483,5 +483,5 @@ type GCPMachineList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&GCPMachine{}, &GCPMachineList{})
+	objectTypes = append(objectTypes, &GCPMachine{}, &GCPMachineList{})
 }

--- a/api/v1beta1/gcpmachinetemplate_types.go
+++ b/api/v1beta1/gcpmachinetemplate_types.go
@@ -47,5 +47,5 @@ type GCPMachineTemplateList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&GCPMachineTemplate{}, &GCPMachineTemplateList{})
+	objectTypes = append(objectTypes, &GCPMachineTemplate{}, &GCPMachineTemplateList{})
 }

--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -20,8 +20,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +31,16 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
+
+	objectTypes = []runtime.Object{}
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion, objectTypes...)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ package v1beta1
 
 import (
 	"k8s.io/api/core/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	corev1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 )
 

--- a/cloud/scope/machine_test.go
+++ b/cloud/scope/machine_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
 	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -15,8 +16,9 @@ import (
 func TestMachineLocalSSDDiskType(t *testing.T) {
 	ctx := context.Background()
 
-	// Register the GCPMachine and GCPMachineList in a schema.
-	schema, err := infrav1.SchemeBuilder.Register(&infrav1.GCPMachine{}, &infrav1.GCPMachineList{}).Build()
+	// Register the GCPMachine types in a scheme.
+	schema := runtime.NewScheme()
+	err := infrav1.AddToScheme(schema)
 
 	// Make sure no errors were triggered.
 	assert.Nil(t, err)

--- a/exp/api/v1beta1/gcpmachinepool_types.go
+++ b/exp/api/v1beta1/gcpmachinepool_types.go
@@ -199,10 +199,6 @@ type GCPMachinePoolList struct {
 	Items           []GCPMachinePool `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&GCPMachinePool{}, &GCPMachinePoolList{})
-}
-
 // GetObjectKind will return the ObjectKind of an GCPMachinePool.
 func (r *GCPMachinePool) GetObjectKind() schema.ObjectKind {
 	return &r.TypeMeta
@@ -224,4 +220,8 @@ func (r *GCPMachinePool) SetConditions(conditions []metav1.Condition) {
 // GetConditions gets conditions for a MachinePool.
 func (r *GCPMachinePool) GetConditions() []metav1.Condition {
 	return r.Status.Conditions
+}
+
+func init() {
+	objectTypes = append(objectTypes, &GCPMachinePool{}, &GCPMachinePoolList{})
 }

--- a/exp/api/v1beta1/gcpmanagedcluster_types.go
+++ b/exp/api/v1beta1/gcpmanagedcluster_types.go
@@ -107,5 +107,5 @@ type GCPManagedClusterList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&GCPManagedCluster{}, &GCPManagedClusterList{})
+	objectTypes = append(objectTypes, &GCPManagedCluster{}, &GCPManagedClusterList{})
 }

--- a/exp/api/v1beta1/gcpmanagedclustertemplate_types.go
+++ b/exp/api/v1beta1/gcpmanagedclustertemplate_types.go
@@ -46,11 +46,11 @@ type GCPManagedClusterTemplateList struct {
 	Items           []GCPManagedClusterTemplate `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&GCPManagedClusterTemplate{}, &GCPManagedClusterTemplateList{})
-}
-
 // GCPManagedClusterTemplateResource describes the data needed to create an GCPManagedCluster from a template.
 type GCPManagedClusterTemplateResource struct {
 	Spec GCPManagedClusterTemplateResourceSpec `json:"spec"`
+}
+
+func init() {
+	objectTypes = append(objectTypes, &GCPManagedClusterTemplate{}, &GCPManagedClusterTemplateList{})
 }

--- a/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
+++ b/exp/api/v1beta1/gcpmanagedcontrolplane_types.go
@@ -321,5 +321,5 @@ func (r *GCPManagedControlPlane) SetConditions(conditions clusterv1beta1.Conditi
 }
 
 func init() {
-	SchemeBuilder.Register(&GCPManagedControlPlane{}, &GCPManagedControlPlaneList{})
+	objectTypes = append(objectTypes, &GCPManagedControlPlane{}, &GCPManagedControlPlaneList{})
 }

--- a/exp/api/v1beta1/gcpmanagedcontrolplanetemplate_types.go
+++ b/exp/api/v1beta1/gcpmanagedcontrolplanetemplate_types.go
@@ -46,11 +46,11 @@ type GCPManagedControlPlaneTemplateList struct {
 	Items           []GCPManagedControlPlaneTemplate `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&GCPManagedControlPlaneTemplate{}, &GCPManagedControlPlaneTemplateList{})
-}
-
 // GCPManagedControlPlaneTemplateResource describes the data needed to create an GCPManagedCluster from a template.
 type GCPManagedControlPlaneTemplateResource struct {
 	Spec GCPManagedControlPlaneTemplateResourceSpec `json:"spec"`
+}
+
+func init() {
+	objectTypes = append(objectTypes, &GCPManagedControlPlaneTemplate{}, &GCPManagedControlPlaneTemplateList{})
 }

--- a/exp/api/v1beta1/gcpmanagedmachinepool_types.go
+++ b/exp/api/v1beta1/gcpmanagedmachinepool_types.go
@@ -224,5 +224,5 @@ func (r *GCPManagedMachinePool) SetConditions(conditions clusterv1beta1.Conditio
 }
 
 func init() {
-	SchemeBuilder.Register(&GCPManagedMachinePool{}, &GCPManagedMachinePoolList{})
+	objectTypes = append(objectTypes, &GCPManagedMachinePool{}, &GCPManagedMachinePoolList{})
 }

--- a/exp/api/v1beta1/gcpmanagedmachinepooltemplate_types.go
+++ b/exp/api/v1beta1/gcpmanagedmachinepooltemplate_types.go
@@ -46,11 +46,11 @@ type GCPManagedMachinePoolTemplateList struct {
 	Items           []GCPManagedMachinePoolTemplate `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&GCPManagedMachinePoolTemplate{}, &GCPManagedMachinePoolTemplateList{})
-}
-
 // GCPManagedMachinePoolTemplateResource describes the data needed to create an GCPManagedCluster from a template.
 type GCPManagedMachinePoolTemplateResource struct {
 	Spec GCPManagedMachinePoolTemplateResourceSpec `json:"spec"`
+}
+
+func init() {
+	objectTypes = append(objectTypes, &GCPManagedMachinePoolTemplate{}, &GCPManagedMachinePoolTemplateList{})
 }

--- a/exp/api/v1beta1/groupversion_info.go
+++ b/exp/api/v1beta1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +30,16 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
+
+	objectTypes = []runtime.Object{}
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion, objectTypes...)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/exp/api/v1beta1/zz_generated.deepcopy.go
+++ b/exp/api/v1beta1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	apiv1beta1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	corev1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 )

--- a/exp/bootstrap/gke/api/v1beta1/gkeconfig_types.go
+++ b/exp/bootstrap/gke/api/v1beta1/gkeconfig_types.go
@@ -77,5 +77,5 @@ type GKEConfigList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&GKEConfig{}, &GKEConfigList{})
+	objectTypes = append(objectTypes, &GKEConfig{}, &GKEConfigList{})
 }

--- a/exp/bootstrap/gke/api/v1beta1/gkeconfigtemplate_types.go
+++ b/exp/bootstrap/gke/api/v1beta1/gkeconfigtemplate_types.go
@@ -50,5 +50,5 @@ type GKEConfigTemplateList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&GKEConfigTemplate{}, &GKEConfigTemplateList{})
+	objectTypes = append(objectTypes, &GKEConfigTemplate{}, &GKEConfigTemplateList{})
 }

--- a/exp/bootstrap/gke/api/v1beta1/groupversion_info.go
+++ b/exp/bootstrap/gke/api/v1beta1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +30,16 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "bootstrap.cluster.x-k8s.io", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
+
+	objectTypes = []runtime.Object{}
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion, objectTypes...)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/exp/bootstrap/gke/api/v1beta1/zz_generated.deepcopy.go
+++ b/exp/bootstrap/gke/api/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	corev1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 )
 


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

With `controller-runtime:v0.24.0`, `scheme.Builder` is now deprecated. This presents a good opportunity to remove the dependency on `controller-runtime` from the API packages, similar to what other CAPI projects have already done, i.e. [core CAPI](https://github.com/kubernetes-sigs/cluster-api/pull/9266).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The plan is to bump `controller-runtime` [together with CAPI](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1748) on top of the changes in this PR.

The `apidiff` errors are expected because the `SchemeBuilder` type changed, but this should be safe to merge to `main` and published on `v1.14.0`.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove reliance on controller-runtime scheme builder
```
