### PR TITLE
fix(gke): make ClusterNetwork IP allocation fields immutable

### DIFF
--- a/exp/webhooks/gcpmanagedcontrolplane_webhook.go
+++ b/exp/webhooks/gcpmanagedcontrolplane_webhook.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 
 	"github.com/pkg/errors"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
@@ -168,6 +169,33 @@ func (*GCPManagedControlPlane) ValidateUpdate(_ context.Context, old, r *expinfr
 	if old.Spec.EnableAutopilot && r.Spec.ClusterNetwork != nil && r.Spec.ClusterNetwork.GatewayAPIChannel != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "ClusterNetwork", "GatewayAPIChannel"),
 			r.Spec.ClusterNetwork.GatewayAPIChannel, "can't be set when autopilot is enabled"))
+	}
+
+	// UseIPAliases, Pod, and Service (the pod/service secondary IP ranges) can only be set at cluster
+	// creation time: GKE has no API to change a cluster's IP allocation mode or ranges afterward, so an
+	// update here would otherwise be silently accepted and silently ignored by the reconciler.
+	oldClusterNetwork := ptr.Deref(old.Spec.ClusterNetwork, expinfrav1.ClusterNetwork{})
+	newClusterNetwork := ptr.Deref(r.Spec.ClusterNetwork, expinfrav1.ClusterNetwork{})
+
+	if !cmp.Equal(oldClusterNetwork.UseIPAliases, newClusterNetwork.UseIPAliases) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "ClusterNetwork", "UseIPAliases"),
+				newClusterNetwork.UseIPAliases, "field is immutable"),
+		)
+	}
+
+	if !cmp.Equal(oldClusterNetwork.Pod, newClusterNetwork.Pod) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "ClusterNetwork", "Pod"),
+				newClusterNetwork.Pod, "field is immutable"),
+		)
+	}
+
+	if !cmp.Equal(oldClusterNetwork.Service, newClusterNetwork.Service) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "ClusterNetwork", "Service"),
+				newClusterNetwork.Service, "field is immutable"),
+		)
 	}
 
 	if old.Spec.Version != nil && r.Spec.ControlPlaneVersion != nil { //nolint:staticcheck

--- a/exp/webhooks/gcpmanagedcontrolplane_webhook_test.go
+++ b/exp/webhooks/gcpmanagedcontrolplane_webhook_test.go
@@ -330,6 +330,90 @@ func TestGCPManagedControlPlaneValidatingWebhookUpdate(t *testing.T) {
 			},
 		},
 		{
+			name:        "request to change UseIPAliases should cause an error",
+			expectError: true,
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
+					ClusterNetwork: &expinfrav1.ClusterNetwork{
+						UseIPAliases: true,
+					},
+				},
+			},
+			oldSpec: &expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
+					ClusterNetwork: &expinfrav1.ClusterNetwork{
+						UseIPAliases: false,
+					},
+				},
+			},
+		},
+		{
+			name:        "request to change Pod secondary range should cause an error",
+			expectError: true,
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
+					ClusterNetwork: &expinfrav1.ClusterNetwork{
+						Pod: &expinfrav1.ClusterNetworkPod{CidrBlock: "10.0.0.0/16"},
+					},
+				},
+			},
+			oldSpec: &expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
+					ClusterNetwork: &expinfrav1.ClusterNetwork{
+						Pod: &expinfrav1.ClusterNetworkPod{CidrBlock: "10.1.0.0/16"},
+					},
+				},
+			},
+		},
+		{
+			name:        "request to change Service secondary range should cause an error",
+			expectError: true,
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
+					ClusterNetwork: &expinfrav1.ClusterNetwork{
+						Service: &expinfrav1.ClusterNetworkService{CidrBlock: "10.2.0.0/20"},
+					},
+				},
+			},
+			oldSpec: &expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
+					ClusterNetwork: &expinfrav1.ClusterNetwork{
+						Service: &expinfrav1.ClusterNetworkService{CidrBlock: "10.3.0.0/20"},
+					},
+				},
+			},
+		},
+		{
+			name:        "keeping UseIPAliases, Pod, and Service unchanged should not cause an error",
+			expectError: false,
+			spec: expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
+					ClusterNetwork: &expinfrav1.ClusterNetwork{
+						UseIPAliases: true,
+						Pod:          &expinfrav1.ClusterNetworkPod{CidrBlock: "10.0.0.0/16"},
+						Service:      &expinfrav1.ClusterNetworkService{CidrBlock: "10.2.0.0/20"},
+					},
+				},
+			},
+			oldSpec: &expinfrav1.GCPManagedControlPlaneSpec{
+				GCPManagedControlPlaneClassSpec: expinfrav1.GCPManagedControlPlaneClassSpec{
+					ClusterName: "default_cluster1",
+					ClusterNetwork: &expinfrav1.ClusterNetwork{
+						UseIPAliases: true,
+						Pod:          &expinfrav1.ClusterNetworkPod{CidrBlock: "10.0.0.0/16"},
+						Service:      &expinfrav1.ClusterNetworkService{CidrBlock: "10.2.0.0/20"},
+					},
+				},
+			},
+		},
+		{
 			name:        "request to change gateway api channel should not cause an error",
 			expectError: false,
 			spec: expinfrav1.GCPManagedControlPlaneSpec{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`GCPManagedControlPlane.Spec.ClusterNetwork.UseIPAliases`, `.Pod`, and `.Service` (the pod/service secondary IP ranges) can only be set at GKE cluster creation time — GKE has no `UpdateCluster` field for changing a cluster's IP allocation mode or ranges afterward (confirmed against `containerpb.ClusterUpdate`), and `reconcile.go`'s `createCluster` is the only place these are read; the update path never touches them.

Previously, changing these fields on an existing `GCPManagedControlPlane` was accepted by the API server and then silently had no effect on the live cluster — the same failure class as #1576 (mutable network fields on the generic `GCPCluster` type). This adds the missing immutability checks to `ValidateUpdate`, following the same pattern already used for `GatewayAPIChannel`.

**Which issue(s) this PR fixes**:
None filed — found while investigating a related, still-open bug (#1576) on the generic `GCPCluster` type. Happy to file one if preferred; didn't think it necessary for a fix this small.

**Special notes for your reviewer**:
No new types or reconciler changes — these fields were already create-only in practice, so the fix is purely rejecting an update that was already a no-op, not changing any runtime behavior for anyone using the fields correctly.

**TODOs**:
- [x] squashed commits
- [x] adds unit tests

**Release note**:
```release-note
Fixes a bug whereby changes to `ClusterNetwork.UseIPAliases`, `ClusterNetwork.Pod` and `ClusterNetwork.Service` would silently no-op rather than being rejected as there is no GKE API to update these after the creation of the cluster.
```