### PR TITLE
fix(gke): Various small fixes around DiskSizeGb, Dead Code & Docs

### DIFF
--- a/cloud/scope/managedmachinepool.go
+++ b/cloud/scope/managedmachinepool.go
@@ -198,9 +198,6 @@ func ConvertToSdkNodePool(nodePool infrav1exp.GCPManagedMachinePool, machinePool
 	if nodePool.Spec.MachineType != nil {
 		sdkNodePool.Config.MachineType = *nodePool.Spec.MachineType
 	}
-	if nodePool.Spec.DiskSizeGb != nil {
-		sdkNodePool.Config.DiskSizeGb = *nodePool.Spec.DiskSizeGb
-	}
 	if nodePool.Spec.ImageType != nil {
 		sdkNodePool.Config.ImageType = *nodePool.Spec.ImageType
 	}
@@ -230,8 +227,13 @@ func ConvertToSdkNodePool(nodePool infrav1exp.GCPManagedMachinePool, machinePool
 	if nodePool.Spec.InstanceType != nil {
 		sdkNodePool.Config.MachineType = *nodePool.Spec.InstanceType
 	}
-	if nodePool.Spec.DiskSizeGB != nil {
-		sdkNodePool.Config.DiskSizeGb = int32(*nodePool.Spec.DiskSizeGB) //nolint:gosec
+	// DiskSizeGB is deprecated in favor of DiskSizeGb; apply it first so that
+	// DiskSizeGb - the canonical field - takes precedence when both are set.
+	if nodePool.Spec.DiskSizeGB != nil { //nolint:staticcheck // SA1019: deprecated field read intentionally for backward compatibility
+		sdkNodePool.Config.DiskSizeGb = int32(*nodePool.Spec.DiskSizeGB) //nolint:gosec,staticcheck // SA1019: deprecated field read intentionally for backward compatibility
+	}
+	if nodePool.Spec.DiskSizeGb != nil {
+		sdkNodePool.Config.DiskSizeGb = *nodePool.Spec.DiskSizeGb
 	}
 	if len(nodePool.Spec.NodeNetwork.Tags) != 0 {
 		sdkNodePool.Config.Tags = nodePool.Spec.NodeNetwork.Tags

--- a/cloud/scope/managedmachinepool.go
+++ b/cloud/scope/managedmachinepool.go
@@ -230,12 +230,6 @@ func ConvertToSdkNodePool(nodePool infrav1exp.GCPManagedMachinePool, machinePool
 	if nodePool.Spec.InstanceType != nil {
 		sdkNodePool.Config.MachineType = *nodePool.Spec.InstanceType
 	}
-	if nodePool.Spec.ImageType != nil {
-		sdkNodePool.Config.ImageType = *nodePool.Spec.ImageType
-	}
-	if nodePool.Spec.DiskType != nil {
-		sdkNodePool.Config.DiskType = string(*nodePool.Spec.DiskType)
-	}
 	if nodePool.Spec.DiskSizeGB != nil {
 		sdkNodePool.Config.DiskSizeGb = int32(*nodePool.Spec.DiskSizeGB) //nolint:gosec
 	}

--- a/cloud/scope/managedmachinepool_test.go
+++ b/cloud/scope/managedmachinepool_test.go
@@ -164,5 +164,25 @@ var _ = Describe("GCPManagedMachinePool Scope", func() {
 				},
 			}))
 		})
+
+		It("should let DiskSizeGb take precedence over DiskSizeGB when both are set", func() {
+			diskSizeGb := int32(64)
+			diskSizeGB := int64(128)
+			TestGCPMMP.Spec.DiskSizeGb = &diskSizeGb
+			TestGCPMMP.Spec.DiskSizeGB = &diskSizeGB //nolint:staticcheck // SA1019: exercising deprecated field for backward-compatibility test
+
+			sdkNodePool := ConvertToSdkNodePool(*TestGCPMMP, *TestMP, false, TestClusterName)
+
+			Expect(sdkNodePool.GetConfig().GetDiskSizeGb()).To(Equal(diskSizeGb))
+		})
+
+		It("should fall back to DiskSizeGB when DiskSizeGb is unset", func() {
+			diskSizeGB := int64(128)
+			TestGCPMMP.Spec.DiskSizeGB = &diskSizeGB //nolint:staticcheck // SA1019: exercising deprecated field for backward-compatibility test
+
+			sdkNodePool := ConvertToSdkNodePool(*TestGCPMMP, *TestMP, false, TestClusterName)
+
+			Expect(sdkNodePool.GetConfig().GetDiskSizeGb()).To(Equal(int32(diskSizeGB)))
+		})
 	})
 })

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedmachinepools.yaml
@@ -62,6 +62,12 @@ spec:
                 description: |-
                   DiskSizeGB is size of the disk attached to each node,
                   specified in GB.
+
+                  Deprecated: DiskSizeGB duplicates DiskSizeGb (both configure the same
+                  underlying GKE node pool disk size) and is retained only for backward
+                  compatibility with existing resources that already set it. This field
+                  remains immutable and will not gain new functionality; use DiskSizeGb
+                  for new manifests. If both fields are set, DiskSizeGb takes precedence.
                 format: int64
                 minimum: 10
                 type: integer
@@ -69,6 +75,7 @@ spec:
                 description: |-
                   DiskSizeGb is the size of the disk attached to each node, specified in GB.
                   The smallest allowed disk size is 10GB. If unspecified, the default disk size is 100GB.
+                  If DiskSizeGB is also set, DiskSizeGb takes precedence.
                 format: int32
                 type: integer
               diskType:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedmachinepooltemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedmachinepooltemplates.yaml
@@ -64,6 +64,12 @@ spec:
                         description: |-
                           DiskSizeGB is size of the disk attached to each node,
                           specified in GB.
+
+                          Deprecated: DiskSizeGB duplicates DiskSizeGb (both configure the same
+                          underlying GKE node pool disk size) and is retained only for backward
+                          compatibility with existing resources that already set it. This field
+                          remains immutable and will not gain new functionality; use DiskSizeGb
+                          for new manifests. If both fields are set, DiskSizeGb takes precedence.
                         format: int64
                         minimum: 10
                         type: integer
@@ -71,6 +77,7 @@ spec:
                         description: |-
                           DiskSizeGb is the size of the disk attached to each node, specified in GB.
                           The smallest allowed disk size is 10GB. If unspecified, the default disk size is 100GB.
+                          If DiskSizeGB is also set, DiskSizeGb takes precedence.
                         format: int32
                         type: integer
                       diskType:

--- a/docs/book/src/topics/preemptible-vms.md
+++ b/docs/book/src/topics/preemptible-vms.md
@@ -18,15 +18,12 @@ kind: GCPMachineTemplate
 metadata:
   name: capg-md-0
 spec:
-  region: us-west-1
   template:
-    osDisk:
-      diskSizeGB: 30
-      managedDisk:
-        storageAccountType: STANDARD
-      osType: Linux
-    vmSize: E2
-    preemptible: true
+    spec:
+      instanceType: n1-standard-2
+      rootDeviceSize: 30
+      rootDeviceType: pd-standard
+      preemptible: true
 ```
 
 ## Spot VMs
@@ -40,15 +37,12 @@ kind: GCPMachineTemplate
 metadata:
   name: capg-md-0
 spec:
-  region: us-west-1
   template:
-    osDisk:
-      diskSizeGB: 30
-      managedDisk:
-        storageAccountType: STANDARD
-      osType: Linux
-    vmSize: E2
-    provisioningModel: Spot
+    spec:
+      instanceType: n1-standard-2
+      rootDeviceSize: 30
+      rootDeviceType: pd-standard
+      provisioningModel: Spot
 ```
 
 NOTE: specifying `preemptible: true` and `provisioningModel: Spot` is equivalent to only `provisioningModel: Spot`. Spot takes priority. 

--- a/exp/api/v1beta1/types_class.go
+++ b/exp/api/v1beta1/types_class.go
@@ -98,6 +98,7 @@ type GCPManagedMachinePoolClassSpec struct {
 	MachineType *string `json:"machineType,omitempty"`
 	// DiskSizeGb is the size of the disk attached to each node, specified in GB.
 	// The smallest allowed disk size is 10GB. If unspecified, the default disk size is 100GB.
+	// If DiskSizeGB is also set, DiskSizeGb takes precedence.
 	// +optional
 	DiskSizeGb *int32 `json:"diskSizeGb,omitempty"`
 	// LocalSsdCount is the number of local SSD disks to be attached to the node.
@@ -121,6 +122,12 @@ type GCPManagedMachinePoolClassSpec struct {
 	DiskType *DiskType `json:"diskType,omitempty"`
 	// DiskSizeGB is size of the disk attached to each node,
 	// specified in GB.
+	//
+	// Deprecated: DiskSizeGB duplicates DiskSizeGb (both configure the same
+	// underlying GKE node pool disk size) and is retained only for backward
+	// compatibility with existing resources that already set it. This field
+	// remains immutable and will not gain new functionality; use DiskSizeGb
+	// for new manifests. If both fields are set, DiskSizeGb takes precedence.
 	// +kubebuilder:validation:Minimum:=10
 	// +optional
 	DiskSizeGB *int64 `json:"diskSizeGB,omitempty"`

--- a/exp/webhooks/gcpmanagedmachinepool_webhook.go
+++ b/exp/webhooks/gcpmanagedmachinepool_webhook.go
@@ -108,6 +108,11 @@ func (*GCPManagedMachinePool) ValidateCreate(_ context.Context, r *expinfrav1.GC
 	gcpmanagedmachinepoollog.Info("Validating GCPManagedMachinePool create", "name", r.Name)
 
 	var allErrs field.ErrorList
+	var allWarns admission.Warnings
+
+	if r.Spec.DiskSizeGB != nil { //nolint:staticcheck // SA1019: checked to emit a deprecation warning
+		allWarns = append(allWarns, "spec.diskSizeGB is deprecated and will soon be removed: please use spec.diskSizeGb")
+	}
 
 	if err := validateNodePoolName(
 		r.Spec.NodePoolName,
@@ -148,10 +153,10 @@ func (*GCPManagedMachinePool) ValidateCreate(_ context.Context, r *expinfrav1.GC
 	}
 
 	if len(allErrs) == 0 {
-		return nil, nil
+		return allWarns, nil
 	}
 
-	return nil, apierrors.NewInvalid(
+	return allWarns, apierrors.NewInvalid(
 		r.GroupVersionKind().GroupKind(),
 		r.Name,
 		allErrs,
@@ -199,6 +204,13 @@ func (*GCPManagedMachinePool) ValidateUpdate(_ context.Context, old, r *expinfra
 		field.NewPath("spec", "diskSizeGb"),
 		old.Spec.DiskSizeGb,
 		r.Spec.DiskSizeGb); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("spec", "diskSizeGB"),
+		old.Spec.DiskSizeGB,             //nolint:staticcheck // SA1019: deprecated field still validated for backward compatibility
+		r.Spec.DiskSizeGB); err != nil { //nolint:staticcheck // SA1019: deprecated field still validated for backward compatibility
 		allErrs = append(allErrs, err)
 	}
 

--- a/exp/webhooks/gcpmanagedmachinepool_webhook_test.go
+++ b/exp/webhooks/gcpmanagedmachinepool_webhook_test.go
@@ -32,6 +32,7 @@ var (
 	invalidMinCount   = int32(-1)
 	enableAutoscaling = false
 	diskSizeGb        = int32(200)
+	diskSizeGB        = int64(200)
 	maxPods           = int64(10)
 	localSsds         = int32(0)
 	invalidDiskSizeGb = int32(-200)
@@ -44,6 +45,7 @@ func TestGCPManagedMachinePoolValidatingWebhookCreate(t *testing.T) {
 		name        string
 		spec        expinfrav1.GCPManagedMachinePoolSpec
 		expectError bool
+		expectWarn  bool
 	}{
 		{
 			name: "valid node pool name",
@@ -140,6 +142,17 @@ func TestGCPManagedMachinePoolValidatingWebhookCreate(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "diskSizeGB (deprecated) set should cause a warning",
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+					NodePoolName: "nodepool1",
+					DiskSizeGB:   &diskSizeGB,
+				},
+			},
+			expectError: false,
+			expectWarn:  true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -156,8 +169,11 @@ func TestGCPManagedMachinePoolValidatingWebhookCreate(t *testing.T) {
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 			}
-			// Nothing emits warnings yet
-			g.Expect(warn).To(BeEmpty())
+			if tc.expectWarn {
+				g.Expect(warn).ToNot(BeEmpty())
+			} else {
+				g.Expect(warn).To(BeEmpty())
+			}
 		})
 	}
 }
@@ -190,11 +206,138 @@ func TestGCPManagedMachinePoolValidatingWebhookUpdate(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "immutable field node pool name is mutated",
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+					NodePoolName: "nodepool2",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "immutable field instanceType set after creation",
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+					NodePoolName: "nodepool1",
+					InstanceType: ptr.To("n1-standard-4"),
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "immutable field machineType set after creation",
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+					NodePoolName: "nodepool1",
+					MachineType:  ptr.To("n2-standard-4"),
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "immutable field diskType set after creation",
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+					NodePoolName: "nodepool1",
+					DiskType:     ptr.To(expinfrav1.SSD),
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "immutable field localSsdCount set after creation",
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+					NodePoolName:  "nodepool1",
+					LocalSsdCount: ptr.To(int32(2)),
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "immutable field management set after creation",
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+					NodePoolName: "nodepool1",
+					Management:   &expinfrav1.NodePoolManagement{AutoUpgrade: true},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "immutable field maxPodsPerNode set after creation",
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+					NodePoolName:   "nodepool1",
+					MaxPodsPerNode: ptr.To(int64(20)),
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "immutable field nodeNetwork podRangeName set after creation",
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+					NodePoolName: "nodepool1",
+					NodeNetwork: expinfrav1.NodeNetworkConfig{
+						PodRangeName: ptr.To("pods-range"),
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "immutable field nodeNetwork createPodRange set after creation",
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+					NodePoolName: "nodepool1",
+					NodeNetwork: expinfrav1.NodeNetworkConfig{
+						CreatePodRange: ptr.To(true),
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "immutable field nodeNetwork podRangeCidrBlock set after creation",
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+					NodePoolName: "nodepool1",
+					NodeNetwork: expinfrav1.NodeNetworkConfig{
+						PodRangeCidrBlock: ptr.To("10.0.0.0/16"),
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "immutable field nodeSecurity set after creation",
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+					NodePoolName: "nodepool1",
+					NodeSecurity: expinfrav1.NodeSecurityConfig{
+						SandboxType: ptr.To("gvisor"),
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
 			name: "immutable field disk size is mutated",
 			spec: expinfrav1.GCPManagedMachinePoolSpec{
 				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
 					NodePoolName: "nodepool1",
 					DiskSizeGb:   &diskSizeGb,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "immutable field diskSizeGB (deprecated) is mutated",
+			spec: expinfrav1.GCPManagedMachinePoolSpec{
+				GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+					NodePoolName: "nodepool1",
+					DiskSizeGB:   &diskSizeGB,
 				},
 			},
 			expectError: true,

--- a/exp/webhooks/gcpmanagedmachinepooltemplate_webhook.go
+++ b/exp/webhooks/gcpmanagedmachinepooltemplate_webhook.go
@@ -58,6 +58,11 @@ func (*GCPManagedMachinePoolTemplate) ValidateCreate(_ context.Context, r *expin
 	gmmplog.Info("Validating GCPManagedMachinePoolTemplate create", "name", r.Name)
 
 	var allErrs field.ErrorList
+	var allWarns admission.Warnings
+
+	if r.Spec.Template.Spec.DiskSizeGB != nil { //nolint:staticcheck // SA1019: checked to emit a deprecation warning
+		allWarns = append(allWarns, "spec.template.spec.diskSizeGB is deprecated and will soon be removed: please use spec.template.spec.diskSizeGb")
+	}
 
 	if err := validateNodePoolName(
 		r.Spec.Template.Spec.NodePoolName,
@@ -98,10 +103,10 @@ func (*GCPManagedMachinePoolTemplate) ValidateCreate(_ context.Context, r *expin
 	}
 
 	if len(allErrs) == 0 {
-		return nil, nil
+		return allWarns, nil
 	}
 
-	return nil, apierrors.NewInvalid(
+	return allWarns, apierrors.NewInvalid(
 		r.GroupVersionKind().GroupKind(),
 		r.Name,
 		allErrs,
@@ -149,6 +154,13 @@ func (*GCPManagedMachinePoolTemplate) ValidateUpdate(_ context.Context, old, r *
 		field.NewPath("spec", "template", "spec", "diskSizeGb"),
 		old.Spec.Template.Spec.DiskSizeGb,
 		r.Spec.Template.Spec.DiskSizeGb); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("spec", "template", "spec", "diskSizeGB"),
+		old.Spec.Template.Spec.DiskSizeGB,             //nolint:staticcheck // SA1019: deprecated field still validated for backward compatibility
+		r.Spec.Template.Spec.DiskSizeGB); err != nil { //nolint:staticcheck // SA1019: deprecated field still validated for backward compatibility
 		allErrs = append(allErrs, err)
 	}
 

--- a/exp/webhooks/gcpmanagedmachinepooltemplate_webhook_test.go
+++ b/exp/webhooks/gcpmanagedmachinepooltemplate_webhook_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
+)
+
+func TestGCPManagedMachinePoolTemplateValidatingWebhookCreate(t *testing.T) {
+	tests := []struct {
+		name       string
+		classSpec  expinfrav1.GCPManagedMachinePoolClassSpec
+		expectWarn bool
+	}{
+		{
+			name: "valid node pool template",
+			classSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+				NodePoolName: "nodepool1",
+			},
+			expectWarn: false,
+		},
+		{
+			name: "diskSizeGB (deprecated) set should cause a warning",
+			classSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+				NodePoolName: "nodepool1",
+				DiskSizeGB:   &diskSizeGB,
+			},
+			expectWarn: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			mmpt := &expinfrav1.GCPManagedMachinePoolTemplate{
+				Spec: expinfrav1.GCPManagedMachinePoolTemplateSpec{
+					Template: expinfrav1.GCPManagedMachinePoolTemplateResource{
+						Spec: expinfrav1.GCPManagedMachinePoolTemplateResourceSpec{
+							GCPManagedMachinePoolClassSpec: tc.classSpec,
+						},
+					},
+				},
+			}
+
+			warn, err := (&GCPManagedMachinePoolTemplate{}).ValidateCreate(t.Context(), mmpt)
+
+			g.Expect(err).ToNot(HaveOccurred())
+			if tc.expectWarn {
+				g.Expect(warn).ToNot(BeEmpty())
+			} else {
+				g.Expect(warn).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestGCPManagedMachinePoolTemplateValidatingWebhookUpdate(t *testing.T) {
+	tests := []struct {
+		name        string
+		classSpec   expinfrav1.GCPManagedMachinePoolClassSpec
+		expectError bool
+	}{
+		{
+			name: "node pool template is not mutated",
+			classSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+				NodePoolName: "nodepool1",
+			},
+			expectError: false,
+		},
+		{
+			name: "immutable field diskSizeGB (deprecated) is mutated",
+			classSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+				NodePoolName: "nodepool1",
+				DiskSizeGB:   &diskSizeGB,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			newMMPT := &expinfrav1.GCPManagedMachinePoolTemplate{
+				Spec: expinfrav1.GCPManagedMachinePoolTemplateSpec{
+					Template: expinfrav1.GCPManagedMachinePoolTemplateResource{
+						Spec: expinfrav1.GCPManagedMachinePoolTemplateResourceSpec{
+							GCPManagedMachinePoolClassSpec: tc.classSpec,
+						},
+					},
+				},
+			}
+			oldMMPT := &expinfrav1.GCPManagedMachinePoolTemplate{
+				Spec: expinfrav1.GCPManagedMachinePoolTemplateSpec{
+					Template: expinfrav1.GCPManagedMachinePoolTemplateResource{
+						Spec: expinfrav1.GCPManagedMachinePoolTemplateResourceSpec{
+							GCPManagedMachinePoolClassSpec: expinfrav1.GCPManagedMachinePoolClassSpec{
+								NodePoolName: "nodepool1",
+							},
+						},
+					},
+				},
+			}
+
+			warn, err := (&GCPManagedMachinePoolTemplate{}).ValidateUpdate(t.Context(), oldMMPT, newMMPT)
+
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(warn).To(BeEmpty())
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup
/kind documentation

**What this PR does / why we need it**: While I was doing some work in another area for another PR I discovered that `GCPManagedMachinePoolClassSpec` has two fields that both configure a GKE node pool's disk size: `DiskSizeGb` (`int32`) and `DiskSizeGB` (`int64`, added earlier). `ConvertToSdkNodePool` let `DiskSizeGB` silently win when both were set, via a lossy `int64`->`int32` cast, and the update webhooks only enforced immutability on `DiskSizeGb` - `DiskSizeGB` meanwhile could be freely changed on a running node pool with no rejection, bypassing the intended immutability.

This PR:
- Makes `DiskSizeGb` canonical (it matches GKE's own `int32` field with no lossy cast) and ensures it takes precedence when both fields are set. `DiskSizeGB` is marked deprecated but kept for backward compatibility - it's a released CRD field. If we wanted to remove it completely we could, but that would be a breaking change and I don't know how best to handle that here.
- Adds the missing `ValidateImmutable` check for `diskSizeGB` in both the `GCPManagedMachinePool` and `GCPManagedMachinePoolTemplate` webhooks, closing the bypass.
- Removes two harmless-but-confusing dead code blocks in `ConvertToSdkNodePool` that re-checked `Spec.ImageType`/`Spec.DiskType` against themselves a second time.
- Fixes the `GCPMachineTemplate` example manifests in `docs/book/src/topics/preemptible-vms.md`, which used fields that don't exist on this provider's API (`osDisk`, `managedDisk.storageAccountType`, `vmSize`, top-level `region`).

**Special notes for your reviewer**:

The three commits are intentionally separated: dead code removal, doc fixes, and the actual duplication/immutability fix (with its tests and CRD regen).

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
fix(gke): close a webhook gap that allowed `diskSizeGB` to bypass disk-size immutability on GCPManagedMachinePool/GCPManagedMachinePoolTemplate; DiskSizeGb is now the canonical field and DiskSizeGB is deprecated.
```