### PR TITLE
fix(gke): don't force a Gateway API channel when unset

### DIFF
--- a/cloud/services/container/clusters/reconcile.go
+++ b/cloud/services/container/clusters/reconcile.go
@@ -562,20 +562,22 @@ func (s *Service) checkDiffAndPrepareUpdate(existingCluster *containerpb.Cluster
 		log.V(4).Info("Master authorized networks config update check", "desired", desiredMasterAuthorizedNetworksConfig)
 	}
 
-	// Gateway API channel
-	var desiredGatewayAPIChannel *infrav1exp.GatewayAPIChannel
-	if cn := s.scope.GCPManagedControlPlane.Spec.ClusterNetwork; cn != nil {
-		desiredGatewayAPIChannel = cn.GatewayAPIChannel
-	}
-	desiredGatewayChannel := convertToSdkGatewayAPIChannel(desiredGatewayAPIChannel)
-	if desiredGatewayChannel != existingCluster.GetNetworkConfig().GetGatewayApiConfig().GetChannel() {
-		needUpdate = true
-		clusterUpdate.DesiredGatewayApiConfig = &containerpb.GatewayAPIConfig{
-			Channel: desiredGatewayChannel,
+	// Gateway API channel. Only compare/apply when the user has explicitly
+	// configured it: GKE decides its own default (e.g. Autopilot clusters
+	// mandate STANDARD and reject anything else), so treating an unset
+	// spec as "desired: UNSPECIFIED" would permanently fight whatever GKE
+	// actually has.
+	if cn := s.scope.GCPManagedControlPlane.Spec.ClusterNetwork; cn != nil && cn.GatewayAPIChannel != nil {
+		desiredGatewayChannel := convertToSdkGatewayAPIChannel(cn.GatewayAPIChannel)
+		if desiredGatewayChannel != existingCluster.GetNetworkConfig().GetGatewayApiConfig().GetChannel() {
+			needUpdate = true
+			clusterUpdate.DesiredGatewayApiConfig = &containerpb.GatewayAPIConfig{
+				Channel: desiredGatewayChannel,
+			}
+			log.V(2).Info("Gateway API channel update required",
+				"current", existingCluster.GetNetworkConfig().GetGatewayApiConfig().GetChannel(),
+				"desired", desiredGatewayChannel)
 		}
-		log.V(2).Info("Gateway API channel update required",
-			"current", existingCluster.GetNetworkConfig().GetGatewayApiConfig().GetChannel(),
-			"desired", desiredGatewayChannel)
 	}
 
 	updateClusterRequest := containerpb.UpdateClusterRequest{

--- a/cloud/services/container/clusters/reconcile_test.go
+++ b/cloud/services/container/clusters/reconcile_test.go
@@ -233,6 +233,42 @@ func TestCheckDiffAndPrepareUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "no diff when gateway api channel is unset, regardless of what GKE actually has",
+			controlPlane: &infrav1exp.GCPManagedControlPlane{
+				Spec: infrav1exp.GCPManagedControlPlaneSpec{
+					GCPManagedControlPlaneClassSpec: infrav1exp.GCPManagedControlPlaneClassSpec{
+						Project:        "test-project",
+						Location:       "us-central1",
+						ReleaseChannel: ptr.To(infrav1exp.Stable),
+						ClusterName:    "test-cluster",
+						// No ClusterNetwork/GatewayAPIChannel set - matches an
+						// Autopilot cluster, which GKE mandates onto the
+						// STANDARD channel regardless of what's requested.
+					},
+				},
+			},
+			existingCluster: &containerpb.Cluster{
+				ReleaseChannel: &containerpb.ReleaseChannel{
+					Channel: containerpb.ReleaseChannel_STABLE,
+				},
+				NetworkConfig: &containerpb.NetworkConfig{
+					GatewayApiConfig: &containerpb.GatewayAPIConfig{
+						Channel: containerpb.GatewayAPIConfig_CHANNEL_STANDARD,
+					},
+				},
+				ControlPlaneEndpointsConfig: &containerpb.ControlPlaneEndpointsConfig{
+					IpEndpointsConfig: &containerpb.ControlPlaneEndpointsConfig_IPEndpointsConfig{
+						AuthorizedNetworksConfig: &containerpb.MasterAuthorizedNetworksConfig{
+							Enabled:                     false,
+							CidrBlocks:                  []*containerpb.MasterAuthorizedNetworksConfig_CidrBlock{},
+							GcpPublicCidrsAccessEnabled: ptr.To(false),
+						},
+					},
+				},
+			},
+			wantNeedUpdate: false,
+		},
+		{
 			name: "no diff when gateway api channel matches",
 			controlPlane: &infrav1exp.GCPManagedControlPlane{
 				Spec: infrav1exp.GCPManagedControlPlaneSpec{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`checkDiffAndPrepareUpdate` always compares GKE's actual Gateway API channel against `Spec.ClusterNetwork.GatewayAPIChannel`, even when that field is left unset on the `GCPManagedControlPlane`. An unset field computes a desired channel of `CHANNEL_UNSPECIFIED`, but GKE never actually reports that back - it always has some real channel (e.g. Autopilot clusters mandate `STANDARD` and reject any other value). The result is a permanent mismatch: every reconcile issues an update GKE immediately rejects, in a tight retry loop that never resolves.

This change only compares/applies the Gateway API channel when the user has explicitly configured `GatewayAPIChannel`, matching how GKE itself treats it: GKE decides its own default when the field is omitted, so an unset spec should never fight whatever GKE actually has.

**Special notes for your reviewer**:
This is one of three related PRs from the same diagnosis. It's independent of the other two and can be reviewed/merged on its own. For proof this composes with the other fixes to get a fully green GKE e2e run, see this Prow run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-gcp/1750/pull-cluster-api-provider-gcp-e2e-test/2095209473210585088

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
fix(gke): GCPManagedControlPlane was getting stuck in a permanent update loop when Gateway API channel is left unset (e.g. on GKE Autopilot clusters)
```