### PR TITLE
fix(gke): avoid nil pointer panic when network name is unset

### DIFF
--- a/cloud/services/container/clusters/reconcile.go
+++ b/cloud/services/container/clusters/reconcile.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
+	"k8s.io/utils/ptr"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-gcp/util/reconciler"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -251,7 +252,7 @@ func (s *Service) createCluster(ctx context.Context, log *logr.Logger) error {
 	cluster := &containerpb.Cluster{
 		Name:        s.scope.ClusterName(),
 		Description: s.scope.GCPManagedControlPlane.Spec.Description,
-		Network:     *s.scope.GCPManagedCluster.Spec.Network.Name,
+		Network:     s.networkName(),
 		Subnetwork:  s.getSubnetNameInClusterRegion(),
 		Autopilot: &containerpb.Autopilot{
 			Enabled: s.scope.GCPManagedControlPlane.Spec.EnableAutopilot,
@@ -378,6 +379,12 @@ func (s *Service) createCluster(ctx context.Context, log *logr.Logger) error {
 	}
 
 	return nil
+}
+
+// networkName returns the configured network name. If unset, it returns an empty string,
+// leaving the GKE API to connect the cluster to the project's "default" network.
+func (s *Service) networkName() string {
+	return ptr.Deref(s.scope.GCPManagedCluster.Spec.Network.Name, "")
 }
 
 // getSubnetNameInClusterRegion returns the subnet which is in the same region as cluster. If not found it returns empty string.

--- a/cloud/services/container/clusters/reconcile_test.go
+++ b/cloud/services/container/clusters/reconcile_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	infrav1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-gcp/cloud/scope"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-gcp/exp/api/v1beta1"
 )
@@ -31,6 +32,43 @@ func newTestService(controlPlane *infrav1exp.GCPManagedControlPlane) *Service {
 	s := new(scope.ManagedControlPlaneScope)
 	s.GCPManagedControlPlane = controlPlane
 	return &Service{scope: s}
+}
+
+// TestNetworkName guards against a regression of
+// https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/1187: createCluster used to
+// dereference Spec.Network.Name directly, which panicked whenever a GCPManagedCluster was created
+// without the network field set. Network is a non-pointer struct field, so omitting it from a
+// manifest leaves it as the zero-value NetworkSpec{} (Name == nil), which is what "network name
+// not set" below represents.
+func TestNetworkName(t *testing.T) {
+	tests := []struct {
+		name    string
+		network infrav1.NetworkSpec
+		want    string
+	}{
+		{
+			name:    "network name not set",
+			network: infrav1.NetworkSpec{},
+			want:    "",
+		},
+		{
+			name:    "network name set",
+			network: infrav1.NetworkSpec{Name: ptr.To("my-network")},
+			want:    "my-network",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newTestService(&infrav1exp.GCPManagedControlPlane{})
+			svc.scope.GCPManagedCluster = &infrav1exp.GCPManagedCluster{
+				Spec: infrav1exp.GCPManagedClusterSpec{Network: tt.network},
+			}
+			if got := svc.networkName(); got != tt.want {
+				t.Errorf("networkName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestCheckDiffAndPrepareUpdate(t *testing.T) {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`GCPManagedCluster.spec.network.name` is `+optional`, but `createCluster` dereferenced it unconditionally when building the GKE `CreateClusterRequest`, so creating a `GCPManagedCluster` without `network.name` set crashed the controller with a nil pointer dereference.

The GKE Container API already documents that an unset `network` field means "connect the cluster to the project's `default` network" (https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster), so the fix simply stops forcing the dereference and lets the configured value (or nothing) pass through, deferring to GKE's own default-network handling rather than CAPG inventing a stricter requirement of its own.

**Which issue(s) this PR fixes**:
Fixes #1187

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
fix(gke): avoid nil pointer panic when GCPManagedCluster.spec.network.name is unset
```